### PR TITLE
Tests: Don't hardcode errno constants

### DIFF
--- a/test/basetest/hooks.py
+++ b/test/basetest/hooks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
+import errno
 import os
 from sys import stderr
 import shutil
@@ -144,7 +145,7 @@ class Hooks(object):
             shutil.rmtree(self.hookdir)
         except OSError as e:
             # If the hookdir folder doesn't exist, no harm done and keep going
-            if e.errno != 2:
+            if e.errno != errno.ENOENT:
                 raise
 
         os.mkdir(self.hookdir)
@@ -258,7 +259,7 @@ class Hook(object):
         try:
             os.remove(file)
         except OSError as e:
-            if e.errno == 2:
+            if e.errno == errno.ENOENT:
                 raise HookError("Hook with name {0} was not found on "
                                 "hooks/ folder".format(file))
             else:

--- a/test/basetest/task.py
+++ b/test/basetest/task.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import atexit
+import errno
 import json
 import os
 import shlex
@@ -274,7 +275,7 @@ class Task(object):
         try:
             shutil.rmtree(self.datadir)
         except OSError as e:
-            if e.errno == 2:
+            if e.errno == errno.ENOENT:
                 # Directory no longer exists
                 pass
             else:

--- a/test/basetest/taskd.py
+++ b/test/basetest/taskd.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division, print_function
+import errno
 import os
 import tempfile
 import shutil
@@ -310,7 +311,7 @@ class Taskd(object):
         try:
             shutil.rmtree(self.datadir)
         except OSError as e:
-            if e.errno == 2:
+            if e.errno == errno.ENOENT:
                 # Directory no longer exists
                 pass
             else:

--- a/test/basetest/utils.py
+++ b/test/basetest/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
+import errno
 import os
 import sys
 import socket
@@ -212,8 +213,8 @@ def _get_output(arguments, timeout=None):
         try:
             os.kill(pid, signal.SIGABRT)
         except OSError as e:
-            # 3 means the process finished/died between last check and now
-            if e.errno != 3:
+            # ESRCH means the process finished/died between last check and now
+            if e.errno != errno.ESRCH:
                 raise
 
         # Wait for process to finish (should die/exit after signal)


### PR DESCRIPTION
The values of `ENOENT` and `ESRCH` are architecture-dependent, so don't assume they're always 2 and 3.

Found using [pydiatra](https://github.com/jwilk/pydiatra).