### PR TITLE
[feat] count newlines in PS1 for burndown max height

### DIFF
--- a/src/commands/CmdBurndown.cpp
+++ b/src/commands/CmdBurndown.cpp
@@ -171,7 +171,17 @@ Chart::Chart (char type)
   // How much space is there to render in?  This chart will occupy the
   // maximum space, and the width drives various other parameters.
   _width = Context::getContext ().getWidth ();
-  _height = Context::getContext ().getHeight () - 1;  // Allow for new line with prompt.
+
+  // check the PS1 to determine how many newlines to leave for the prompt
+  char* _ps1 = getenv("PS1");
+  int _ps1_lines = 1;
+  char* _substr = _ps1;
+  while ((_substr = strstr(_substr, "\\n")) != NULL) {
+    _ps1_lines++;
+    ++_substr;
+  }
+
+  _height = Context::getContext ().getHeight () - _ps1_lines;
   _graph_height = _height - 7;
   _graph_width = _width - _max_label - 14;
 


### PR DESCRIPTION
#### Description

The burndown charts blindly assume a single line PS1. This patch accounts for multi-line PS1's.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
$ ./problems
Failed:
burndown.t                          4
diag.t                              1
filter.t                            5
project.t                           4
search.t                            1
version.t                           1

Unexpected successes:

Skipped:
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
wait.t                              1

Expected failures:
dependencies.t                      2
hyphenate.t                         1
```