### PR TITLE
Use nullptr instead lf C-styled NULL

### DIFF
--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -1734,8 +1734,8 @@ void CLI2::insertIDExpr ()
           else
           {
             bool ascending = true;
-            int low  = strtol (r->first.c_str (),  NULL, 10);
-            int high = strtol (r->second.c_str (), NULL, 10);
+            int low  = strtol (r->first.c_str (),  nullptr, 10);
+            int high = strtol (r->second.c_str (), nullptr, 10);
             if (low <= high)
               ascending = true;
             else

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1027,7 +1027,7 @@ void Context::getLimits (int& rows, int& lines)
     }
     else
     {
-      rows = (int) strtol (limit.c_str (), NULL, 10);
+      rows = (int) strtol (limit.c_str (), nullptr, 10);
       lines = 0;
     }
   }

--- a/src/DOM.cpp
+++ b/src/DOM.cpp
@@ -279,7 +279,7 @@ bool getDOM (const std::string& name, const Task& task, Variant& value)
     else if (type == Lexer::Type::number &&
              token.find ('.') == std::string::npos)
     {
-      auto id = strtol (token.c_str (), NULL, 10);
+      auto id = strtol (token.c_str (), nullptr, 10);
       if (id && id != ref.id)
         Context::getContext ().tdb2.get (id, ref);
 
@@ -375,7 +375,7 @@ bool getDOM (const std::string& name, const Task& task, Variant& value)
   {
     auto annos = ref.getAnnotations ();
 
-    int a = strtol (elements[1].c_str (), NULL, 10);
+    int a = strtol (elements[1].c_str (), nullptr, 10);
     int count = 0;
 
     // Count off the 'a'th annotation.
@@ -403,7 +403,7 @@ bool getDOM (const std::string& name, const Task& task, Variant& value)
   {
     auto annos = ref.getAnnotations ();
 
-    int a = strtol (elements[1].c_str (), NULL, 10);
+    int a = strtol (elements[1].c_str (), nullptr, 10);
     int count = 0;
 
     // Count off the 'a'th annotation.

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -1026,7 +1026,7 @@ void TDB2::show_diff (
   const std::string& prior,
   const std::string& when)
 {
-  Datetime lastChange (strtol (when.c_str (), NULL, 10));
+  Datetime lastChange (strtol (when.c_str (), nullptr, 10));
 
   // Set the colors.
   Color color_red   (Context::getContext ().color () ? Context::getContext ().config.get ("color.undo.before") : "");

--- a/src/TLSClient.cpp
+++ b/src/TLSClient.cpp
@@ -218,7 +218,7 @@ void TLSClient::connect (const std::string& host, const std::string& port)
 #if GNUTLS_VERSION_NUMBER >= 0x030406
   // For _trust == TLSClient::allow_all we perform no action
   if (_trust == TLSClient::ignore_hostname)
-    gnutls_session_set_verify_cert (_session, NULL, 0); // 3.4.6
+    gnutls_session_set_verify_cert (_session, nullptr, 0); // 3.4.6
   else if (_trust == TLSClient::strict)
     gnutls_session_set_verify_cert (_session, _host.c_str (), 0); // 3.4.6
 #endif
@@ -251,7 +251,7 @@ void TLSClient::connect (const std::string& host, const std::string& port)
 
   // Try them all, stop on success.
   struct addrinfo* p;
-  for (p = res; p != NULL; p = p->ai_next)
+  for (p = res; p != nullptr; p = p->ai_next)
   {
     if ((_socket = ::socket (p->ai_family, p->ai_socktype, p->ai_protocol)) == -1)
       continue;
@@ -275,7 +275,7 @@ void TLSClient::connect (const std::string& host, const std::string& port)
 
   free (res);
 
-  if (p == NULL)
+  if (p == nullptr)
     throw format ("Could not connect to {1} {2}", host, port);
 
 #if GNUTLS_VERSION_NUMBER >= 0x030100
@@ -362,7 +362,7 @@ int TLSClient::verify_certificate () const
   const char* hostname = _host.c_str();
 #if GNUTLS_VERSION_NUMBER >= 0x030104
   if (_trust == TLSClient::ignore_hostname)
-    hostname = NULL;
+    hostname = nullptr;
 
   int ret = gnutls_certificate_verify_peers3 (_session, hostname, &status); // 3.1.4
   if (ret < 0)

--- a/src/TLSClient.h
+++ b/src/TLSClient.h
@@ -58,7 +58,7 @@ private:
   std::string                      _host        {""};
   std::string                      _port        {""};
   gnutls_certificate_credentials_t _credentials {};
-  gnutls_session_t                 _session     {0};
+  gnutls_session_t                 _session     {nullptr};
   int                              _socket      {0};
   int                              _limit       {0};
   bool                             _debug       {false};

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -181,7 +181,7 @@ const std::string Task::identifier (bool shortened /* = false */) const
 void Task::setAsNow (const std::string& att)
 {
   char now[16];
-  snprintf (now, 16, "%u", (unsigned int) time (NULL));
+  snprintf (now, 16, "%u", (unsigned int) time (nullptr));
   set (att, now);
 
   recalc_urgency = true;
@@ -231,7 +231,7 @@ int Task::get_int (const std::string& name) const
 {
   auto i = data.find (name);
   if (i != data.end ())
-    return strtol (i->second.c_str (), NULL, 10);
+    return strtol (i->second.c_str (), nullptr, 10);
 
   return 0;
 }
@@ -241,7 +241,7 @@ unsigned long Task::get_ulong (const std::string& name) const
 {
   auto i = data.find (name);
   if (i != data.end ())
-    return strtoul (i->second.c_str (), NULL, 10);
+    return strtoul (i->second.c_str (), nullptr, 10);
 
   return 0;
 }
@@ -251,7 +251,7 @@ float Task::get_float (const std::string& name) const
 {
   auto i = data.find (name);
   if (i != data.end ())
-    return strtof (i->second.c_str (), NULL);
+    return strtof (i->second.c_str (), nullptr);
 
   return 0.0;
 }
@@ -261,7 +261,7 @@ time_t Task::get_date (const std::string& name) const
 {
   auto i = data.find (name);
   if (i != data.end ())
-    return (time_t) strtoul (i->second.c_str (), NULL, 10);
+    return (time_t) strtoul (i->second.c_str (), nullptr, 10);
 
   return 0;
 }
@@ -1060,7 +1060,7 @@ bool Task::hasAnnotations () const
 // timestamp.
 void Task::addAnnotation (const std::string& description)
 {
-  time_t now = time (NULL);
+  time_t now = time (nullptr);
   std::string key;
 
   do
@@ -1953,7 +1953,7 @@ float Task::urgency_active () const
 float Task::urgency_scheduled () const
 {
   if (has ("scheduled") &&
-      get_date ("scheduled") < time (NULL))
+      get_date ("scheduled") < time (nullptr))
     return 1.0;
 
   return 0.0;

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1864,9 +1864,9 @@ void Variant::cast (const enum type new_type)
                _string == "0.0") ? false : true;
       break;
     case type_integer:
-      _integer = (int) strtol (_string.c_str (), NULL, (_string.substr (0, 2) == "0x" ? 16 : 10));
+      _integer = (int) strtol (_string.c_str (), nullptr, (_string.substr (0, 2) == "0x" ? 16 : 10));
       break;
-    case type_real:     _real = strtod (_string.c_str (), NULL);              break;
+    case type_real:     _real = strtod (_string.c_str (), nullptr);              break;
     case type_string:                                                         break;
     case type_date:
       {

--- a/src/columns/ColDepends.cpp
+++ b/src/columns/ColDepends.cpp
@@ -154,14 +154,14 @@ void ColumnDepends::modify (Task& task, const std::string& value)
       if (dep.length () == 37)
         task.removeDependency (dep.substr (1));
       else
-        task.removeDependency (strtol (dep.substr (1).c_str (), NULL, 10));
+        task.removeDependency (strtol (dep.substr (1).c_str (), nullptr, 10));
     }
     else
     {
       if (dep.length () == 36)
         task.addDependency (dep);
       else
-        task.addDependency (strtol (dep.c_str (), NULL, 10));
+        task.addDependency (strtol (dep.c_str (), nullptr, 10));
     }
   }
 }

--- a/src/columns/ColDescription.cpp
+++ b/src/columns/ColDescription.cpp
@@ -171,7 +171,7 @@ void ColumnDescription::render (
     {
       for (const auto& i : task.getAnnotations ())
       {
-        Datetime dt (strtol (i.first.substr (11).c_str (), NULL, 10));
+        Datetime dt (strtol (i.first.substr (11).c_str (), nullptr, 10));
         description += '\n' + std::string (_indent, ' ') + dt.toString (_dateformat) + ' ' + i.second;
       }
     }
@@ -200,7 +200,7 @@ void ColumnDescription::render (
     {
       for (const auto& i : task.getAnnotations ())
       {
-        Datetime dt (strtol (i.first.substr (11).c_str (), NULL, 10));
+        Datetime dt (strtol (i.first.substr (11).c_str (), nullptr, 10));
         description += ' ' + dt.toString (_dateformat) + ' ' + i.second;
       }
     }

--- a/src/columns/ColUDA.cpp
+++ b/src/columns/ColUDA.cpp
@@ -241,7 +241,7 @@ void ColumnUDADate::measure (Task& task, unsigned int& minimum, unsigned int& ma
         //   rc.report.<report>.dateformat
         //   rc.dateformat.report
         //   rc.dateformat
-        Datetime date ((time_t) strtol (value.c_str (), NULL, 10));
+        Datetime date ((time_t) strtol (value.c_str (), nullptr, 10));
         auto format = Context::getContext ().config.get ("report." + _report + ".dateformat");
         if (format == "")
           format = Context::getContext ().config.get ("dateformat.report");
@@ -287,7 +287,7 @@ void ColumnUDADate::render (
           format = Context::getContext ().config.get ("dateformat");
       }
 
-      renderStringLeft (lines, width, color, Datetime ((time_t) strtol (value.c_str (), NULL, 10)).toString (format));
+      renderStringLeft (lines, width, color, Datetime ((time_t) strtol (value.c_str (), nullptr, 10)).toString (format));
     }
     else if (_style == "indicator")
     {

--- a/src/columns/Column.cpp
+++ b/src/columns/Column.cpp
@@ -222,7 +222,7 @@ Column* Column::uda (const std::string& name)
   else if (type != "")
     throw std::string ("User defined attributes may only be of type 'string', 'date', 'duration' or 'numeric'.");
 
-  return NULL;
+  return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -122,12 +122,12 @@ int CmdCalendar::execute (std::string& output)
 
     // YYYY.
     else if (Lexer::isAllDigits (arg) && arg.length () == 4)
-      argYear = strtol (arg.c_str (), NULL, 10);
+      argYear = strtol (arg.c_str (), nullptr, 10);
 
     // MM.
     else if (Lexer::isAllDigits (arg) && arg.length () <= 2)
     {
-      argMonth = strtol (arg.c_str (), NULL, 10);
+      argMonth = strtol (arg.c_str (), nullptr, 10);
       if (argMonth < 1 || argMonth > 12)
         throw format ("Argument '{1}' is not a valid month.", arg);
     }
@@ -565,7 +565,7 @@ std::string CmdCalendar::renderMonths (
                 task.has ("due"))
             {
               std::string due = task.get ("due");
-              Datetime duedmy (strtol (due.c_str(), NULL, 10));
+              Datetime duedmy (strtol (due.c_str(), nullptr, 10));
 
               if (duedmy.day   () == d           &&
                   duedmy.month () == months[mpl] &&

--- a/src/commands/CmdDiagnostics.cpp
+++ b/src/commands/CmdDiagnostics.cpp
@@ -211,9 +211,9 @@ int CmdDiagnostics::execute (std::string& output)
   char* peditor;
   if (Context::getContext ().config.get ("editor") != "")
     out << "  rc.editor: " << Context::getContext ().config.get ("editor") << '\n';
-  else if ((peditor = getenv ("VISUAL")) != NULL)
+  else if ((peditor = getenv ("VISUAL")) != nullptr)
     out << "    $VISUAL: " << peditor << '\n';
-  else if ((peditor = getenv ("EDITOR")) != NULL)
+  else if ((peditor = getenv ("EDITOR")) != nullptr)
     out << "    $EDITOR: " << peditor << '\n';
 
   out << "     Server: "

--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -250,7 +250,7 @@ std::string CmdEdit::formatTask (Task task, const std::string& dateformat)
 
   for (auto& anno : task.getAnnotations ())
   {
-    Datetime dt (strtol (anno.first.substr (11).c_str (), NULL, 10));
+    Datetime dt (strtol (anno.first.substr (11).c_str (), nullptr, 10));
     before << "  Annotation:        " << dt.toString (dateformat)
            << " -- "                  << json::encode (anno.second) << '\n';
   }
@@ -653,7 +653,7 @@ void CmdEdit::parseTask (Task& task, const std::string& after, const std::string
     if (dep.length () >= 7)
       task.addDependency (dep);
     else
-      task.addDependency ((int) strtol (dep.c_str (), NULL, 10));
+      task.addDependency ((int) strtol (dep.c_str (), nullptr, 10));
   }
 
   // UDAs

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -244,7 +244,7 @@ int CmdInfo::execute (std::string& output)
     auto created = task.get ("entry");
     if (created.length ())
     {
-      Datetime dt (strtol (created.c_str (), NULL, 10));
+      Datetime dt (strtol (created.c_str (), nullptr, 10));
       age = Duration (now - dt).formatVague ();
     }
 
@@ -560,7 +560,7 @@ int CmdInfo::execute (std::string& output)
           {
             int row = journal.addRow ();
 
-            Datetime timestamp (strtol (undo[when].substr (5).c_str (), NULL, 10));
+            Datetime timestamp (strtol (undo[when].substr (5).c_str (), nullptr, 10));
             journal.set (row, 0, timestamp.toString (dateformat));
 
             Task before (undo[previous].substr (4));

--- a/src/commands/CmdModify.h
+++ b/src/commands/CmdModify.h
@@ -37,11 +37,11 @@ public:
   int execute (std::string&);
   void checkConsistency (Task &before, Task &after);
   int modifyAndUpdate (Task &before, Task &after,
-    std::map <std::string, std::string> *projectChanges = NULL);
+    std::map <std::string, std::string> *projectChanges = nullptr);
   int modifyRecurrenceSiblings (Task &task,
-    std::map <std::string, std::string> *projectChanges = NULL);
+    std::map <std::string, std::string> *projectChanges = nullptr);
   int modifyRecurrenceParent (Task &task,
-    std::map <std::string, std::string> *projectChanges = NULL);
+    std::map <std::string, std::string> *projectChanges = nullptr);
 };
 
 #endif

--- a/src/commands/CmdStats.cpp
+++ b/src/commands/CmdStats.cpp
@@ -89,7 +89,7 @@ int CmdStats::execute (std::string& output)
   filter.subset (all, filtered);
 
   Datetime now;
-  time_t earliest   = time (NULL);
+  time_t earliest   = time (nullptr);
   time_t latest     = 1;
   int totalT        = 0;
   int deletedT      = 0;
@@ -123,13 +123,13 @@ int CmdStats::execute (std::string& output)
     if (task.is_blocked)  ++blockedT;
     if (task.is_blocking) ++blockingT;
 
-    time_t entry = strtol (task.get ("entry").c_str (), NULL, 10);
+    time_t entry = strtol (task.get ("entry").c_str (), nullptr, 10);
     if (entry < earliest) earliest = entry;
     if (entry > latest)   latest   = entry;
 
     if (status == Task::completed)
     {
-      time_t end = strtol (task.get ("end").c_str (), NULL, 10);
+      time_t end = strtol (task.get ("end").c_str (), nullptr, 10);
       daysPending += (end - entry) / 86400.0;
     }
 

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -80,7 +80,7 @@ int CmdSummary::execute (std::string& output)
   std::map <std::string, int> countCompleted;
   std::map <std::string, double> sumEntry;
   std::map <std::string, int> counter;
-  time_t now = time (NULL);
+  time_t now = time (nullptr);
 
   // Initialize counters.
   for (auto& project : allProjects)
@@ -108,7 +108,7 @@ int CmdSummary::execute (std::string& output)
       {
         ++countPending[parent];
 
-        time_t entry = strtol (task.get ("entry").c_str (), NULL, 10);
+        time_t entry = strtol (task.get ("entry").c_str (), nullptr, 10);
         if (entry)
           sumEntry[parent] = sumEntry[parent] + (double) (now - entry);
       }
@@ -120,8 +120,8 @@ int CmdSummary::execute (std::string& output)
       {
         ++countCompleted[parent];
 
-        time_t entry = strtol (task.get ("entry").c_str (), NULL, 10);
-        time_t end   = strtol (task.get ("end").c_str (), NULL, 10);
+        time_t entry = strtol (task.get ("entry").c_str (), nullptr, 10);
+        time_t end   = strtol (task.get ("end").c_str (), nullptr, 10);
         if (entry && end)
           sumEntry[parent] = sumEntry[parent] + (double) (end - entry);
       }

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -247,7 +247,7 @@ std::string renderAttribute (const std::string& name, const std::string& value, 
         col->type () == "date" &&
         value != "")
     {
-      Datetime d ((time_t)strtol (value.c_str (), NULL, 10));
+      Datetime d ((time_t)strtol (value.c_str (), nullptr, 10));
       if (format == "")
         return d.toString (Context::getContext ().config.get ("dateformat"));
 

--- a/src/recur.cpp
+++ b/src/recur.cpp
@@ -232,7 +232,7 @@ Datetime getNextRecurrence (Datetime& current, std::string& period)
   else if (unicodeLatinDigit (period[0]) &&
            period[period.length () - 1] == 'm')
   {
-    int increment = strtol (period.substr (0, period.length () - 1).c_str (), NULL, 10);
+    int increment = strtol (period.substr (0, period.length () - 1).c_str (), nullptr, 10);
 
     m += increment;
     while (m > 12)
@@ -251,7 +251,7 @@ Datetime getNextRecurrence (Datetime& current, std::string& period)
            Lexer::isAllDigits (period.substr (1, period.length () - 2)) &&
            period[period.length () - 1] == 'M')
   {
-    int increment = strtol (period.substr (0, period.length () - 1).c_str (), NULL, 10);
+    int increment = strtol (period.substr (0, period.length () - 1).c_str (), nullptr, 10);
 
     m += increment;
     while (m > 12)
@@ -284,7 +284,7 @@ Datetime getNextRecurrence (Datetime& current, std::string& period)
 
   else if (unicodeLatinDigit (period[0]) && period[period.length () - 1] == 'q')
   {
-    int increment = strtol (period.substr (0, period.length () - 1).c_str (), NULL, 10);
+    int increment = strtol (period.substr (0, period.length () - 1).c_str (), nullptr, 10);
 
     m += 3 * increment;
     while (m > 12)
@@ -374,7 +374,7 @@ void updateRecurrenceMask (Task& task)
   if (uuid != "" &&
       Context::getContext ().tdb2.get (uuid, parent))
   {
-    unsigned int index = strtol (task.get ("imask").c_str (), NULL, 10);
+    unsigned int index = strtol (task.get ("imask").c_str (), nullptr, 10);
     auto mask = parent.get ("mask");
     if (mask.length () > index)
     {

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -35,7 +35,7 @@
 #include <shared.h>
 #include <format.h>
 
-static std::vector <Task>* global_data = NULL;
+static std::vector <Task>* global_data = nullptr;
 static std::vector <std::string> global_keys;
 static bool sort_compare (int, int);
 
@@ -194,13 +194,13 @@ static bool sort_compare (int left, int right)
     }
 
     // UDAs.
-    else if ((column = Context::getContext ().columns[field]) != NULL)
+    else if ((column = Context::getContext ().columns[field]) != nullptr)
     {
       std::string type = column->type ();
       if (type == "numeric")
       {
-        auto left_real  = strtof (((*global_data)[left].get_ref  (field)).c_str (), NULL);
-        auto right_real = strtof (((*global_data)[right].get_ref (field)).c_str (), NULL);
+        auto left_real  = strtof (((*global_data)[left].get_ref  (field)).c_str (), nullptr);
+        auto right_real = strtof (((*global_data)[right].get_ref (field)).c_str (), nullptr);
 
         if (left_real == right_real)
           continue;


### PR DESCRIPTION
Replace C-styled `NULL` with `nullptr`, which should be used in modern C++ projects.

This patch was generated by running clang-tidy [modernize-use-nullptr](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html) check.