### PR TITLE
Update notes regarding C++14 support

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,7 +2,7 @@
 
 ## Satisfy the Requirements:
  * CMake 3.0 or later
- * gcc 5.0 or later, clang 3.4 or later, or a compiler with full C++11 support
+ * gcc 5.0 or later, clang 3.4 or later, or a compiler with full C++14 support
  * libuuid (if not on macOS)
  * gnutls (optional)
  * python 2.7 or 3 (optional, for running the test suite)

--- a/INSTALL
+++ b/INSTALL
@@ -14,7 +14,7 @@ from source. More information on CMake can be obtained at https://cmake.org
 You will also need:
   - make
 
-You will need a C++ compiler that supports full C++11, which includes:
+You will need a C++ compiler that supports full C++14, which includes:
   - gcc 5.0   (released 2013-12-23)
   - clang 3.4 (released 2014-01-02)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are many binary packages available, but to install from source requires:
 * git
 * cmake
 * make
-* C++ compiler, currently gcc 5.0+ or clang 3.4+ for full C++11 support
+* C++ compiler, currently gcc 5.0+ or clang 3.4+ for full C++14 support
 
 Download the tarball, and expand it:
 


### PR DESCRIPTION
4a929197ae8c32d62a109e1ab063217d0c57c01b introduced C++14 support. After these changes, the build will now terminate unless the compiler supports C++14 dialect. The documentation does not reflect that: this commit updates few reference files to actually say that the building process requires a C++14-compliant compiler.