### PR TITLE
Docs: mention "urgency" as possible attribute for filters

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -830,6 +830,13 @@ Attribute modifiers improve filters.  Supported modifiers are:
 .B  noword
 .RE
 
+They can be applied to all regular attributes (see above) and the following
+calculated attributes:
+
+.RS
+\fBurgency\fR (or short \fBurg\fR)
+.RE
+
 For example:
 
 .RS


### PR DESCRIPTION
Hello,

I noticed that the urgency attribute is not defined in the man page, this patch adds it.

However I don't know if there are additional unlisted attributes which can be used in filters. If so, please tell me and I'll update the patch.

Regards
Simon