### PR TITLE
Display task ID when unwaiting task

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -367,7 +367,7 @@ void TF2::load_gc (Task& task)
       Context::getContext ().tdb2.pending._dirty = true;
 
       if (Context::getContext ().verbose ("unwait"))
-        Context::getContext ().footnote (format ("Un-waiting task '{1}'", task.get ("description")));
+        Context::getContext ().footnote (format ("Un-waiting task {1} '{2}'", task.id, task.get ("description")));
     }
 
     Context::getContext ().tdb2.pending._tasks.push_back (task);


### PR DESCRIPTION
#### Description

Implements #2012. The task ID is displayed just before the description when unwaiting. I am happy to work on a more flexible implementation if it's required.

#### Additional information...

The test suite problems seem to be the same as before the change.

- [x] Have you run the test suite?
```$ ./problems
Failed:                        
diag.t                              1
filter.t                            5
project.t                           4
search.t                            1

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
wait.t                              1

Expected failures:             
dependencies.t                      2
hyphenate.t                         1```
