### PR TITLE
doc/man: ready tasks sorted with started tasks 1st

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -294,9 +294,9 @@ value.
 
 .TP
 .B task <filter> ready
-Shows a page of the most urgent ready tasks, sorted by urgency.  A ready task is
-one that is either unscheduled, or has a scheduled date that is past and has no
-wait date.
+Shows a page of the most urgent ready tasks, sorted by urgency with started
+tasks first. A ready task is one that is either unscheduled, or has a scheduled
+date that is past and has no wait date.
 
 .TP
 .B task <filter> oldest


### PR DESCRIPTION
Documentation of the default sort method for `task ready` being *started-then-urgent*.