### PR TITLE
Do not set CMP0037 on CMake 3.11.0 and above

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required (VERSION 3.0)
 
-# See this CMake issue before complaining about the following.
-# https://cmake.org/Bug/view.php?id=16062
-if(POLICY CMP0037)
+# This is a work-around for the following CMake issue:
+# https://gitlab.kitware.com/cmake/cmake/issues/16062
+# The issue has been fixed in CMake 3.11.0; the policy is set
+# to OLD for compatibility with older versions of CMake only.
+if(POLICY CMP0037 AND ${CMAKE_VERSION} VERSION_LESS "3.11.0")
   cmake_policy(SET CMP0037 OLD)
 endif()
 


### PR DESCRIPTION
This policy is no longer necessary because CMake issue #16062, which caused incorrect warnings to be shown, has been resolved in 3.11.0.