### PR TITLE
Fix issue #1917 [TW-1904] wrong order under projects command

### DIFF
--- a/src/commands/CmdProjects.cpp
+++ b/src/commands/CmdProjects.cpp
@@ -36,6 +36,21 @@
 #include <main.h>
 
 ////////////////////////////////////////////////////////////////////////////////
+template <char delimiter>
+struct ProjectCompare
+{
+  bool operator() (std::string a, std::string b)
+  {
+    // Replace project delimiter character to give it the highest sorting
+    // precedence
+    replace (a.begin (), a.end (), delimiter, '\0');
+    replace (b.begin (), b.end (), delimiter, '\0');
+
+    return a < b;
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
 CmdProjects::CmdProjects ()
 {
   _keyword               = "projects";
@@ -75,7 +90,7 @@ int CmdProjects::execute (std::string& output)
 
   // Scan all the tasks for their project name, building a map using project
   // names as keys.
-  std::map <std::string, int> unique;
+  std::map <std::string, int, ProjectCompare<'.'>> unique;
   bool no_project = false;
   std::string project;
   for (auto& task : filtered)


### PR DESCRIPTION
#### Description

Fixes incorrect ordering of projects as reported in TW-1904.  Default
string comparison was not respecting the higher sorting precedence
needed for the project delimiter character.

#### Additional information...

Failed:

Unexpected successes:

Skipped:

Expected failures:
