### PR TITLE
Change taskrc override priority, respect verbose override, refactor.

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -1280,12 +1280,11 @@ Taskwarrior stores its configuration in a file in the user's home directory:
 
 .TP
 .B task rc:<path-to-alternate-file> ...
-Specifies an alternate configuration file.
+Specifies an alternate configuration file with highest priority.
 
 .TP
-.B TASKRC=/tmp/.taskrc task ..
-The environment variable overrides the default and the command line
-specification of the .taskrc file.
+.B TASKRC=<path-to-alternate-file> task ..
+The environment variable specifies an alternate configuration file to use.
 
 .TP
 .B task rc.<name>:<value> ...
@@ -1294,8 +1293,8 @@ Specifies individual configuration file overrides.
 
 .TP
 .B TASKDATA=/tmp/.task task ...
-The environment variable overrides the default, the command line, and
-the 'data.location' configuration setting of the task data directory.
+The environment variable overrides the default, and the 'data.location'
+configuration setting of the task data directory.
 
 .SH MORE EXAMPLES
 

--- a/src/CLI2.h
+++ b/src/CLI2.h
@@ -60,8 +60,8 @@ class CLI2
 public:
   static int minimumMatchLength;
 
-  static void getOverride (int, const char**, std::string&, File&);
-  static void getDataLocation (int, const char**, Path&);
+  static bool getOverride (int, const char**, std::string&, File&);
+  static bool getDataLocation (int, const char**, Path&);
   static void applyOverrides (int, const char**);
 
 public:

--- a/test/verbose.t
+++ b/test/verbose.t
@@ -105,11 +105,11 @@ class TestVerbosity(TestCase):
     def test_verbosity_header(self):
         """Verbosity header"""
 
-        code, out, err = self.t("rc.verbose:nothing ls")
+        code, out, err = self.t("rc.verbose:override ls")
         self.assertNotIn("TASKRC override:", err)
         self.assertNotIn("TASKDATA override:", err)
 
-        code, out, err = self.t("rc.verbose:header ls")
+        code, out, err = self.t("rc.verbose:header,override ls")
         self.assertIn("TASKRC override:", err)
         self.assertIn("TASKDATA override:", err)
 


### PR DESCRIPTION
My primary motivation was to stop task from printing environment variable overrides every time, but ended up fixing a few things around it as well.

#### Changes

* Original Priorities for taskrc/data overrides were

  Priority | taskrc file | taskdata directory
  -- | -- | --
  1(high) | environment variable | environment variable 
  2 | command line override | command line override
  3 | N/A | taskrc override
  4(low) | default | default

  This pr changes it so command line has higher priority then environment variable.
  command line having higher priority is pretty much standard in most programs.
  original behavior also caused two of the tests to fail due to not unsetting the environment variable

* The original behavior was to print `Using Alternate TASKRC/DATA` in the header for each command line override.
  This pr removes this behavior.
  the overridden TASKRC/DATA is printed out afterwards anyway,
  and is unnecessarily repetitive if using multiple for whatever reason

* The original behavior was to print `TASKRC/DATA Overide: $file` in the header, regardless of override setting.
  This pr makes it respect verbose settings for overrides.

* The original behavior for checking override verbosity in applyOverrides was a bit broken when setting verbosity via the command line.
  for example `task rc.verbose:footnote` would still show overrides despite not have `override` set
  This pr makes it respect verbose("override") by delayign the first call of verbose until after all overrides have been set, not a very good solution at all however.
  the function has also been simplified.


* The original behavior only allowed rc: unlike other the other override handling functions.
  This pr now allows rc= by having the `CLI2::get*` functions to use a common function, reducing code duplication and simplifying it.

#### Tests
The tests are kinda broken, col.t wont link properly,
anyway here are the before and after results for failures

Test | Before | After | Reason
--- | --- | --- | ---
diag.t | 1 | 1 |
filter.t |  5 | 5 |
project.t | 4 | 4 |
search.t | 1 | 1 |
tw-1643.t | 1 |  0 | originally failed due to not unsetting environment variable in bash test
tw-1718.t  |  1 | 0 | pr fixes it by having cli be higher priority
verbose.t | 0 | 0 | had to change test to match new results

#### Verbosity issues
verbosity is pretty poorly done right now, and caused an issue when i called it too early.
using `rc.verbose.header=1/0` would give greater control over the settings.
and instead of doing 
```cpp
if (Context::getContext ().verbose("override"))
  Context::getContext ().header ("msg");
```
we instead do
```cpp
Context::getContext ().header (Override, "msg");
```
by attching an enum, std::bitflag or whatever to it, that way verbosity checking is done only when we finally print the output. and can give greater control as well.