### PR TITLE
Fix issue #1917 [TW-1904] wrong order under projects command

### DIFF
--- a/src/commands/CmdProjects.cpp
+++ b/src/commands/CmdProjects.cpp
@@ -115,7 +115,8 @@ int CmdProjects::execute (std::string& output)
     sort_projects (sorted_view, unique);
 
     // construct view from sorted list
-    for (auto& item: sorted_view) {
+    for (auto& item: sorted_view)
+    {
       int row = view.addRow ();
       view.set (row, 0, (item.first == ""
                           ? "(none)"

--- a/src/commands/CmdProjects.cpp
+++ b/src/commands/CmdProjects.cpp
@@ -112,29 +112,7 @@ int CmdProjects::execute (std::string& output)
 
     // create sorted list of table entries
     std::list <std::pair<std::string, int>> sorted_view;
-    for (auto& project : unique)
-    {
-      const std::vector <std::string> parents = extractParents (project.first);
-      if (parents.size ()) {
-        // if parents exist: store iterator position of last parent
-        std::list<std::pair<std::string, int>>::iterator parent_pos;
-        for (auto& parent : parents)
-        {
-          parent_pos = std::find_if (sorted_view.begin (), sorted_view.end (),
-              [&parent](const std::pair<std::string, int>& element) { return element.first == parent; }
-          );
-          // if parent does not exist yet: insert into sorted view
-          if (parent_pos == sorted_view.end()) {
-            sorted_view.insert (parent_pos, std::make_pair(parent, 1));
-          }
-        }
-        // insert new element below latest parent
-        sorted_view.insert (++parent_pos, project);
-      } else {
-        // if has no parents: simply push to end of list
-        sorted_view.push_back (project);
-      }
-    }
+    sort_projects (sorted_view, unique);
 
     // construct view from sorted list
     for (auto& item: sorted_view) {

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -148,53 +148,24 @@ int CmdSummary::execute (std::string& output)
   }
 
   // sort projects into sorted list
-  std::list<std::string> sortedProjects;
-  for (auto& i : allProjects)
-  {
-    if (showAllProjects || countPending[i.first] > 0)
-    {
-      const std::vector <std::string> parents = extractParents (i.first);
-      if (parents.size ())
-      {
-        // if parents exist: store iterator position of last parent
-        std::list<std::string>::iterator parent_pos;
-        for (auto& parent : parents)
-        {
-          parent_pos = std::find (sortedProjects.begin (), sortedProjects.end (), parent);
-          // if parent does not exist yet: insert into sorted view
-          if (parent_pos == sortedProjects.end ())
-          {
-            sortedProjects.push_back (parent);
-          }
-        }
-        // insert new element below latest parent
-        if (parent_pos == sortedProjects.end ()) {
-          sortedProjects.push_back (i.first);
-        } else {
-          sortedProjects.insert (++parent_pos, i.first);
-        }
-      } else {
-        // if has no parents: simply push to end of list
-        sortedProjects.push_back (i.first);
-      }
-    }
-  }
+  std::list<std::pair<std::string, int>> sortedProjects;
+  sort_projects (sortedProjects, allProjects);
 
   int barWidth = 30;
   // construct view from sorted list
   for (auto& i : sortedProjects)
   {
       int row = view.addRow ();
-      view.set (row, 0, (i == ""
+      view.set (row, 0, (i.first == ""
                           ? "(none)"
-                          : indentProject (i, "  ", '.')));
+                          : indentProject (i.first, "  ", '.')));
 
-      view.set (row, 1, countPending[i]);
-      if (counter[i])
-        view.set (row, 2, Duration ((int) (sumEntry[i] / (double)counter[i])).formatVague ());
+      view.set (row, 1, countPending[i.first]);
+      if (counter[i.first])
+        view.set (row, 2, Duration ((int) (sumEntry[i.first] / (double)counter[i.first])).formatVague ());
 
-      int c = countCompleted[i];
-      int p = countPending[i];
+      int c = countCompleted[i.first];
+      int p = countPending[i.first];
       int completedBar = 0;
       if (c + p)
         completedBar = (c * barWidth) / (c + p);

--- a/src/main.h
+++ b/src/main.h
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <list>
 #include <map>
 #include <sys/types.h>
 #include <Context.h>
@@ -81,6 +82,8 @@ std::string onExpiration (Task&);
 
 // sort.cpp
 void sort_tasks (std::vector <Task>&, std::vector <int>&, const std::string&);
+void sort_projects (std::list <std::pair <std::string, int>>& sorted, std::map <std::string, int>& allProjects);
+void sort_projects (std::list <std::pair <std::string, int>>& sorted, std::map <std::string, bool>& allProjects);
 
 // legacy.cpp
 void legacyColumnMap (std::string&);

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -49,7 +49,6 @@ void sort_tasks (
   const std::string& keys)
 {
   Timer timer;
-
   global_data = &data;
 
   // Split the key defs.
@@ -76,16 +75,18 @@ void sort_projects (
       for (auto& parent : parents)
       {
         parent_pos = std::find_if (sorted.begin (), sorted.end (),
-            [&parent](const std::pair <std::string, int>& item) { return item.first == parent; }
-        );
+            [&parent](const std::pair <std::string, int>& item) { return item.first == parent; });
+        
         // if parent does not exist yet: insert into sorted view
-        if (parent_pos == sorted.end ()) {
+        if (parent_pos == sorted.end ())
           sorted.push_back (std::make_pair (parent, 1));
-        }
       }
+      
       // insert new element below latest parent
       sorted.insert ((parent_pos == sorted.end ()) ? parent_pos : ++parent_pos, project);
-    } else {
+    }
+    else
+    {
       // if has no parents: simply push to end of list
       sorted.push_back (project);
     }

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -99,9 +99,8 @@ void sort_projects (
 {
   std::map <std::string, int> allProjectsInt;
   for (auto& p : allProjects)
-  {
     allProjectsInt[p.first] = (int) p.second;
-  }
+  
   sort_projects (sorted, allProjectsInt);
 }
 

--- a/test/project.t
+++ b/test/project.t
@@ -481,6 +481,45 @@ class TestBug1627(TestCase):
         self.assertEqual("mon\n", out)
 
 
+class TestBug1904(TestCase):
+    def setUp(self):
+        """Executed before each test in the class"""
+        self.t = Task()
+
+    def add_tasks(self):
+        self.t("add pro:a-b test1")
+        self.t("add pro:a.b test2")
+
+    def validate_order(self, out):
+        order = (
+                "a",
+                "  b",
+                "a-b",
+        )
+
+        lines = out.splitlines(True)
+        # position where project names start on the lines list
+        position = 3
+
+        for i, proj in enumerate(order):
+            pos = position + i
+
+            self.assertTrue(
+                lines[pos].startswith(proj),
+                msg=("Project '{0}' is not in line #{1} or has an unexpected "
+                     "indentation.{2}".format(proj, pos, out))
+            )
+
+    def test_project_eval(self):
+        """1904: verify correct order under projects command"""
+        self.add_tasks()
+
+        code, out, err = self.t("projects")
+
+        self.validate_order(out)
+
+
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
     unittest.main(testRunner=TAPTestRunner())

--- a/test/project.t
+++ b/test/project.t
@@ -491,11 +491,9 @@ class TestBug1904(TestCase):
         self.t("add pro:a.b test2")
 
     def validate_order(self, out):
-        order = (
-                "a",
-                "  b",
-                "a-b",
-        )
+        order = ("a",
+                 "  b",
+                 "a-b")
 
         lines = out.splitlines(True)
         # position where project names start on the lines list
@@ -513,11 +511,8 @@ class TestBug1904(TestCase):
     def test_project_eval(self):
         """1904: verify correct order under projects command"""
         self.add_tasks()
-
         code, out, err = self.t("projects")
-
         self.validate_order(out)
-
 
 
 if __name__ == "__main__":

--- a/test/summary.t
+++ b/test/summary.t
@@ -73,11 +73,9 @@ class TestBug1904(TestCase):
         self.t("add pro:a.b test2")
 
     def validate_order(self, out):
-        order = (
-                "a-b",
-                "a",
-                "  b",
-        )
+        order = ("a-b",
+                 "a",
+                 "  b")
 
         lines = out.splitlines(True)
         # position where project names start on the lines list
@@ -95,9 +93,7 @@ class TestBug1904(TestCase):
     def test_project_eval(self):
         """1904: verify correct order under summary command"""
         self.add_tasks()
-
         code, out, err = self.t("summary")
-
         self.validate_order(out)
 
 

--- a/test/summary.t
+++ b/test/summary.t
@@ -63,6 +63,44 @@ class TestSummaryPercentage(TestCase):
         self.assertIn("No projects.", out)
 
 
+class TestBug1904(TestCase):
+    def setUp(self):
+        """Executed before each test in the class"""
+        self.t = Task()
+
+    def add_tasks(self):
+        self.t("add pro:a-b test1")
+        self.t("add pro:a.b test2")
+
+    def validate_order(self, out):
+        order = (
+                "a",
+                "  b",
+                "a-b",
+        )
+
+        lines = out.splitlines(True)
+        # position where project names start on the lines list
+        position = 3
+
+        for i, proj in enumerate(order):
+            pos = position + i
+
+            self.assertTrue(
+                lines[pos].startswith(proj),
+                msg=("Project '{0}' is not in line #{1} or has an unexpected "
+                     "indentation.{2}".format(proj, pos, out))
+            )
+
+    def test_project_eval(self):
+        """1904: verify correct order under summary command"""
+        self.add_tasks()
+
+        code, out, err = self.t("summary")
+
+        self.validate_order(out)
+
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
     unittest.main(testRunner=TAPTestRunner())

--- a/test/summary.t
+++ b/test/summary.t
@@ -74,9 +74,9 @@ class TestBug1904(TestCase):
 
     def validate_order(self, out):
         order = (
+                "a-b",
                 "a",
                 "  b",
-                "a-b",
         )
 
         lines = out.splitlines(True)


### PR DESCRIPTION
#### Description

This pull request fixes the issue _[TW-1904] wrong order under projects command_ #1917.
The issue arises due to the fact that the ASCII code of the '.' (dot) is bigger than that of the '-' (hyphen). Thus, the latter will be processed first when traversing a map of strings.
If this is to be fixed without major changes to the underlying Table class (of libshared), the (in my opinion, safe) assumption that nobody will use the '=' (equal) sign within project names comes in handy and can be used to replace all '-' occurrences by '=', pushing these project names behind those including '.' due to the higher ASCII code. Once such a name is encountered the substitution is reverted.
This pull request also extends the same functionality to the summary command.

Unit-tests for the working bug fix have also been added to the corresponding files.

#### Additional information...

- [x] Have you run the test suite?
  I am currently trying to clean up the results of the unit tests. Thus, the output of ./problems might vary for you. Simply note the added tests in ./project.t and ./summary.t:
```
> ./problems
Failed:                        
filter.t                            5

Unexpected successes:          

Skipped:                       
dependencies.t                      3
feature.default.project.t           1

Expected failures:             
dependencies.t                      2
hyphenate.t                         1
project.t                           3
search.t                            1
```
```
> ./project.t | grep 1904
ok 9 - project.t: 1904: verify correct order under projects command
```
```
> ./summary.t | grep 1904
ok 1 - summary.t: 1904: verify correct order under summary command
```