### PR TITLE
CmdHistory: repeat unit if a larger unit changes

### DIFF
--- a/src/commands/CmdHistory.cpp
+++ b/src/commands/CmdHistory.cpp
@@ -539,10 +539,13 @@ public:
     int last_m, last_d, last_y;
     last_dt.toYMD (last_y, last_m, last_d);
 
-    if ((y != last_y) || (lastTime == 0))
+    bool y_changed = (y != last_y) || (lastTime == 0);
+    bool m_changed = (m != last_m) || (lastTime == 0);
+
+    if (y_changed)
       view.set (row, 0, y);
 
-    if ((m != last_m) || (lastTime == 0))
+    if (y_changed || m_changed)
       view.set (row, 1, Datetime::monthName (m));
 
     view.set (row, 2, d);
@@ -586,10 +589,13 @@ public:
     int last_m, last_d, last_y;
     last_dt.toYMD (last_y, last_m, last_d);
 
-    if ((y != last_y) || (lastTime == 0))
+    bool y_changed = (y != last_y) || (lastTime == 0);
+    bool m_changed = (m != last_m) || (lastTime == 0);
+
+    if (y_changed)
       view.set (row, 0, y);
 
-    if ((m != last_m) || (lastTime == 0))
+    if (y_changed || m_changed)
       view.set (row, 1, Datetime::monthName (m));
 
     view.set (row, 2, d);
@@ -633,10 +639,13 @@ public:
     int last_m, last_d, last_y;
     last_dt.toYMD (last_y, last_m, last_d);
 
-    if ((y != last_y) || (lastTime == 0))
+    bool y_changed = (y != last_y) || (lastTime == 0);
+    bool m_changed = (m != last_m) || (lastTime == 0);
+
+    if (y_changed)
       view.set (row, 0, y);
 
-    if ((m != last_m) || (lastTime == 0))
+    if (y_changed || m_changed)
       view.set (row, 1, Datetime::monthName (m));
 
     view.set (row, 2, d);
@@ -680,10 +689,13 @@ public:
     int last_m, last_d, last_y;
     last_dt.toYMD (last_y, last_m, last_d);
 
-    if ((y != last_y) || (lastTime == 0))
+    bool y_changed = (y != last_y) || (lastTime == 0);
+    bool m_changed = (m != last_m) || (lastTime == 0);
+
+    if (y_changed)
       view.set (row, 0, y);
 
-    if ((m != last_m) || (lastTime == 0))
+    if (y_changed || m_changed)
       view.set (row, 1, Datetime::monthName (m));
 
     view.set (row, 2, d);


### PR DESCRIPTION
#### Description

In `history` and `ghistory` commands, repeat the smaller units when a larger unit changes.  For example, if January 2019 is displayed immediately after January 2018, re-show the "January" label instead of only showing the year change.

#### Example

Assume the `history.d` command shows January 1, 2019 immediately after January 1, 2018. This is the case if there was no activity between those dates.

Before this change:

```
Year Month         Day Added Completed Deleted Net
2018 January         1     2         1       0   1
2019                 1     2         1       0   1
```

After this change:

```
Year Month         Day Added Completed Deleted Net
2018 January         1     2         1       0   1
2019 January         1     2         1       0   1
```

#### Additional information

- [X] Have you run the test suite?
  There are unrelated failing tests.