### PR TITLE
New feature: urgency accumulation

### DIFF
--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -1159,6 +1159,17 @@ urgency.blocked.coefficient to 0.0 in order for this setting to
 be the most useful.
 .RE
 
+.B urgency.accumulate=off
+.RS
+Not actually a coefficient. When enabled, and if urgency.inherit is also
+enabled, blocking tasks inherit all of the urgency values of all of the tasks
+they block (calculated recursively), in addition to their own existing urgency
+value. I.e. the resulting urgency value is the sum of: the urgency the task
+would have if urgency inheritence were disabled, plus the urgency values of all
+the tasks blocked by the current task, and the tasks blocked by those tasks,
+etc.
+.RE
+
 .SS DEFAULTS
 
 .TP

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1845,8 +1845,12 @@ float Task::urgency_inherit () const
   float v = FLT_MIN;
   for (auto& task : blocked)
   {
-    // Find highest urgency in all blocked tasks.
-    v = std::max (v, task.urgency ());
+    if (context.config.getBoolean ("urgency.accumulate"))
+      // Find sum of urgency of current task + all blocked tasks.
+      v = v + task.urgency ();
+    else
+      // Find highest urgency in all blocked tasks.
+      v = std::max (v, task.urgency ());
   }
 
   return v;


### PR DESCRIPTION
#### Description

Allow blocking tasks' urgency values to reflect the total urgency of the blocked tasks, rather than just the urgency of the most urgent among the blocked tasks.

N.B. There seems to be a bug (maybe a race condition of some sort) in the way TaskWarrior attempts to recursively identify blocking tasks and to get their urgency values. As a result of that bug, some "leaf" tasks (in graph-theoretic terminology) end up being assigned the same urgency as "branch" tasks. Until the bug is resolved, the functionality added in this commit will not work *optimally* (nor exactly as people are likely to expect); though it is still *useful*.

Fixes [#2081](https://github.com/GothenburgBitFactory/taskwarrior/issues/2081).

needsTest.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
Failed:                        
calendar.t                          2
diag.t                              1
version.t                           1

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
rx.t                                1
wait.t                              1

Expected failures:             
color.rules.t                       2
dependencies.t                      2
hyphenate.t                         1
```