### PR TITLE
task UI: prevent ID/UID being followed by period.

### DIFF
--- a/src/commands/CmdAdd.cpp
+++ b/src/commands/CmdAdd.cpp
@@ -64,20 +64,20 @@ int CmdAdd::execute (std::string& output)
 
   if (Context::getContext ().verbose ("new-uuid") &&
            status != Task::recurring)
-    output += format ("Created task {1}.\n", task.get ("uuid"));
+    output += format ("Created task UID \"{1}\".\n", task.get ("uuid"));
 
   else if (Context::getContext ().verbose ("new-uuid") &&
            status == Task::recurring)
-    output += format ("Created task {1} (recurrence template).\n", task.get ("uuid"));
+    output += format ("Created task UID \"{1}\" (recurrence template).\n", task.get ("uuid"));
 
   else if (Context::getContext ().verbose ("new-id") &&
       (status == Task::pending ||
        status == Task::waiting))
-    output += format ("Created task {1}.\n", task.id);
+    output += format ("Created task ID \"{1}\".\n", task.id);
 
   else if (Context::getContext ().verbose ("new-id") &&
            status == Task::recurring)
-    output += format ("Created task {1} (recurrence template).\n", task.id);
+    output += format ("Created task ID \"{1}\" (recurrence template).\n", task.id);
 
   if (Context::getContext ().verbose ("project"))
     Context::getContext ().footnote (onProjectChange (task));

--- a/src/commands/CmdAnnotate.cpp
+++ b/src/commands/CmdAnnotate.cpp
@@ -75,7 +75,7 @@ int CmdAnnotate::execute (std::string&)
     Task before (task);
 
     // Annotate the specified task.
-    std::string question = format ("Annotate task {1} '{2}'?",
+    std::string question = format ("Annotate task ID \"{1}\" '{2}'?",
                                    task.identifier (true),
                                    task.get ("description"));
 
@@ -85,7 +85,7 @@ int CmdAnnotate::execute (std::string&)
     {
       Context::getContext ().tdb2.modify (task);
       ++count;
-      feedback_affected ("Annotating task {1} '{2}'.", task);
+      feedback_affected ("Annotating task ID \"{1}\" '{2}'.", task);
       if (Context::getContext ().verbose ("project"))
         projectChanges[task.get ("project")] = onProjectChange (task, false);
 
@@ -102,7 +102,7 @@ int CmdAnnotate::execute (std::string&)
             sibling.modify (Task::modAnnotate, true);
             Context::getContext ().tdb2.modify (sibling);
             ++count;
-            feedback_affected ("Annotating recurring task {1} '{2}'.", sibling);
+            feedback_affected ("Annotating recurring task ID \"{1}\" '{2}'.", sibling);
           }
 
           // Annotate the parent

--- a/src/commands/CmdAppend.cpp
+++ b/src/commands/CmdAppend.cpp
@@ -75,7 +75,7 @@ int CmdAppend::execute (std::string&)
     Task before (task);
 
     // Append to the specified task.
-    auto question = format ("Append to task {1} '{2}'?",
+    auto question = format ("Append to task ID \"{1}\" '{2}'?",
                             task.identifier (true),
                             task.get ("description"));
 
@@ -85,7 +85,7 @@ int CmdAppend::execute (std::string&)
     {
       Context::getContext ().tdb2.modify (task);
       ++count;
-      feedback_affected ("Appending to task {1} '{2}'.", task);
+      feedback_affected ("Appending to task ID \"{1}}\" '{2}'.", task);
       if (Context::getContext ().verbose ("project"))
         projectChanges[task.get ("project")] = onProjectChange (task, false);
 
@@ -102,7 +102,7 @@ int CmdAppend::execute (std::string&)
             sibling.modify (Task::modAppend, true);
             Context::getContext ().tdb2.modify (sibling);
             ++count;
-            feedback_affected ("Appending to recurring task {1} '{2}'.", sibling);
+            feedback_affected ("Appending to recurring task ID \"{1}\" '{2}'.", sibling);
           }
 
           // Append to the parent

--- a/src/commands/CmdDelete.cpp
+++ b/src/commands/CmdDelete.cpp
@@ -33,7 +33,7 @@
 #include <format.h>
 #include <main.h>
 
-#define STRING_CMD_DELETE_TASK_R     "Deleting recurring task {1} '{2}'."
+#define STRING_CMD_DELETE_TASK_R     "Deleting recurring task ID \"{1}\" '{2}'."
 #define STRING_CMD_DELETE_CONFIRM_R  "This is a recurring task.  Do you want to delete all pending recurrences of this same task?"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,7 +80,7 @@ int CmdDelete::execute (std::string&)
     {
       // Delete the specified task.
       std::string question;
-      question = format ("Delete task {1} '{2}'?",
+      question = format ("Delete task ID \"{1}\" '{2}'?",
                          task.identifier (true),
                          task.get ("description"));
 
@@ -94,7 +94,7 @@ int CmdDelete::execute (std::string&)
         updateRecurrenceMask (task);
         ++count;
         Context::getContext ().tdb2.modify (task);
-        feedback_affected ("Deleting task {1} '{2}'.", task);
+        feedback_affected ("Deleting task ID \"{1}\" '{2}'.", task);
         feedback_unblocked (task);
         dependencyChainOnComplete (task);
         if (Context::getContext ().verbose ("project"))
@@ -167,7 +167,7 @@ int CmdDelete::execute (std::string&)
     }
     else
     {
-      std::cout << format ("Task {1} '{2}' is not deletable.",
+      std::cout << format ("Task ID \"{1}\" '{2}' is not deletable.",
                            task.identifier (true),
                            task.get ("description"))
           << '\n';

--- a/src/commands/CmdDenotate.cpp
+++ b/src/commands/CmdDenotate.cpp
@@ -127,7 +127,7 @@ int CmdDenotate::execute (std::string&)
 
     if (before.data != task.data)
     {
-      auto question = format ("Denotate task {1} '{2}'?",
+      auto question = format ("Denotate task ID \"{1}\" '{2}'?",
                               task.identifier (true),
                               task.get ("description"));
 

--- a/src/commands/CmdDone.cpp
+++ b/src/commands/CmdDone.cpp
@@ -77,7 +77,7 @@ int CmdDone::execute (std::string&)
         task.getStatus () == Task::waiting)
     {
       // Complete the specified task.
-      std::string question = format ("Complete task {1} '{2}'?",
+      std::string question = format ("Complete task ID \"{1}\" '{2}'?",
                                      task.identifier (true),
                                      task.get ("description"));
 
@@ -99,7 +99,7 @@ int CmdDone::execute (std::string&)
         updateRecurrenceMask (task);
         Context::getContext ().tdb2.modify (task);
         ++count;
-        feedback_affected ("Completed task {1} '{2}'.", task);
+        feedback_affected ("Completed task ID \"{1}\" '{2}'.", task);
         feedback_unblocked (task);
         if (!nagged)
           nagged = nag (task);
@@ -117,7 +117,7 @@ int CmdDone::execute (std::string&)
     }
     else
     {
-      std::cout << format ("Task {1} '{2}' is neither pending nor waiting.",
+      std::cout << format ("Task ID \"{1}\" '{2}' is neither pending nor waiting.",
                            task.identifier (true),
                            task.get ("description"))
                 << '\n';

--- a/src/commands/CmdDuplicate.cpp
+++ b/src/commands/CmdDuplicate.cpp
@@ -112,9 +112,7 @@ int CmdDuplicate::execute (std::string&)
       feedback_affected ("Duplicated task ID \"{1}\" '{2}'.", task);
 
       auto status = dup.getStatus ();
-      if (Context::getContext ().verbose ("new-id") &&
-          (status == Task::pending ||
-           status == Task::waiting))
+      if ((status == Task::pending || status == Task::waiting))
         std::cout << format ("Created task ID \"{1}\".\n", dup.id);
 
       else if (Context::getContext ().verbose ("new-uuid") &&

--- a/src/commands/CmdDuplicate.cpp
+++ b/src/commands/CmdDuplicate.cpp
@@ -85,7 +85,7 @@ int CmdDuplicate::execute (std::string&)
       dup.remove ("recur");
       dup.remove ("until");
       dup.remove ("imask");
-      std::cout << format ("Note: task {1} was a recurring task.  The duplicated task is not.", task.identifier ())
+      std::cout << format ("Note: task ID \"{1}\" was a recurring task.  The duplicated task is not.", task.identifier ())
           << '\n';
     }
 
@@ -93,7 +93,7 @@ int CmdDuplicate::execute (std::string&)
     else if (dup.getStatus () == Task::recurring)
     {
       dup.remove ("mask");
-      std::cout << format ("Note: task {1} was a parent recurring task.  The duplicated task is too.", task.identifier ())
+      std::cout << format ("Note: task ID \"{1}\" was a parent recurring task.  The duplicated task is too.", task.identifier ())
           << '\n';
     }
 
@@ -102,24 +102,24 @@ int CmdDuplicate::execute (std::string&)
 
     dup.modify (Task::modAnnotate);
 
-    if (permission (format ("Duplicate task {1} '{2}'?",
+    if (permission (format ("Duplicate task ID \"{1}\" '{2}'?",
                             task.identifier (true),
                             task.get ("description")),
                     filtered.size ()))
     {
       Context::getContext ().tdb2.add (dup);
       ++count;
-      feedback_affected ("Duplicated task {1} '{2}'.", task);
+      feedback_affected ("Duplicated task ID \"{1}\" '{2}'.", task);
 
       auto status = dup.getStatus ();
       if (Context::getContext ().verbose ("new-id") &&
           (status == Task::pending ||
            status == Task::waiting))
-        std::cout << format ("Created task {1}.\n", dup.id);
+        std::cout << format ("Created task ID \"{1}\".\n", dup.id);
 
       else if (Context::getContext ().verbose ("new-uuid") &&
                status != Task::recurring)
-        std::cout << format ("Created task {1}.\n", dup.get ("uuid"));
+        std::cout << format ("Created task UID \"{1}\".\n", dup.get ("uuid"));
 
       if (Context::getContext ().verbose ("project"))
         projectChanges[task.get ("project")] = onProjectChange (task);

--- a/src/commands/CmdLog.cpp
+++ b/src/commands/CmdLog.cpp
@@ -68,7 +68,7 @@ int CmdLog::execute (std::string& output)
     Context::getContext ().footnote (onProjectChange (task));
 
   if (Context::getContext ().verbose ("new-uuid"))
-    output = format ("Logged task {1}.\n", task.get ("uuid"));
+    output = format ("Logged task UID \"{1}\".\n", task.get ("uuid"));
 
   return 0;
 }

--- a/src/commands/CmdModify.cpp
+++ b/src/commands/CmdModify.cpp
@@ -33,7 +33,7 @@
 #include <format.h>
 #include <shared.h>
 
-#define STRING_CMD_MODIFY_TASK_R     "Modifying recurring task {1} '{2}'."
+#define STRING_CMD_MODIFY_TASK_R     "Modifying recurring task ID \"{1}\" '{2}'."
 #define STRING_CMD_MODIFY_RECUR      "This is a recurring task.  Do you want to modify all pending recurrences of this same task?"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -81,7 +81,7 @@ int CmdModify::execute (std::string&)
       // Abort if change introduces inconsistencies.
       checkConsistency(before, task);
 
-      auto question = format ("Modify task {1} '{2}'?",
+      auto question = format ("Modify task ID \"{1}\" '{2}'?",
                               task.identifier (true),
                               task.get ("description"));
 
@@ -139,7 +139,7 @@ int CmdModify::modifyAndUpdate (
   auto count = 1;
 
   updateRecurrenceMask (after);
-  feedback_affected ("Modifying task {1} '{2}'.", after);
+  feedback_affected ("Modifying task ID \"{1}\" '{2}'.", after);
   feedback_unblocked (after);
   Context::getContext ().tdb2.modify (after);
   if (Context::getContext ().verbose ("project") && projectChanges)

--- a/src/commands/CmdPrepend.cpp
+++ b/src/commands/CmdPrepend.cpp
@@ -75,7 +75,7 @@ int CmdPrepend::execute (std::string&)
     Task before (task);
 
     // Prepend to the specified task.
-    std::string question = format ("Prepend to task {1} '{2}'?",
+    std::string question = format ("Prepend to task ID \"{1}\" '{2}'?",
                                    task.identifier (true),
                                    task.get ("description"));
 
@@ -85,7 +85,7 @@ int CmdPrepend::execute (std::string&)
     {
       Context::getContext ().tdb2.modify (task);
       ++count;
-      feedback_affected ("Prepending to task {1} '{2}'.", task);
+      feedback_affected ("Prepending to task ID \"{1}\" '{2}'.", task);
       if (Context::getContext ().verbose ("project"))
         projectChanges[task.get ("project")] = onProjectChange (task, false);
 
@@ -102,7 +102,7 @@ int CmdPrepend::execute (std::string&)
             sibling.modify (Task::modPrepend, true);
             Context::getContext ().tdb2.modify (sibling);
             ++count;
-            feedback_affected ("Prepending to recurring task {1} '{2}'.", sibling);
+            feedback_affected ("Prepending to recurring task ID \"{1}\" '{2}'.", sibling);
           }
 
           // Prepend to the parent

--- a/src/commands/CmdPurge.cpp
+++ b/src/commands/CmdPurge.cpp
@@ -101,7 +101,7 @@ void CmdPurge::handleChildren (Task& task, int& count)
     {
       if (child.getStatus () != Task::deleted)
         // In case any child task is not deleted, bail out
-        throw format ("Task '{1}' is a recurrence template. Its child task {2} must be deleted before it can be purged.",
+        throw format ("Task '{1}' is a recurrence template. Its child task ID \"{2}\" must be deleted before it can be purged.",
                       task.get ("description"),
                       child.identifier (true));
       else
@@ -157,7 +157,7 @@ int CmdPurge::execute (std::string&)
     if (task.getStatus () == Task::deleted)
     {
       std::string question;
-      question = format ("Permanently remove task {1} '{2}'?",
+      question = format ("Permanently remove task ID \"{1}\" '{2}'?",
                          task.identifier (true),
                          task.get ("description"));
 

--- a/src/commands/CmdStart.cpp
+++ b/src/commands/CmdStart.cpp
@@ -76,7 +76,7 @@ int CmdStart::execute (std::string&)
       Task before (task);
 
       // Start the specified task.
-      std::string question = format ("Start task {1} '{2}'?",
+      std::string question = format ("Start task ID \"{1}\" '{2}'?",
                                      task.identifier (true),
                                      task.get ("description"));
       task.modify (Task::modAnnotate);
@@ -97,7 +97,7 @@ int CmdStart::execute (std::string&)
         updateRecurrenceMask (task);
         Context::getContext ().tdb2.modify (task);
         ++count;
-        feedback_affected ("Starting task {1} '{2}'.", task);
+        feedback_affected ("Starting task ID \"{1}\" '{2}'.", task);
         if (!nagged)
           nagged = nag (task);
         dependencyChainOnStart (task);
@@ -114,7 +114,7 @@ int CmdStart::execute (std::string&)
     }
     else
     {
-      std::cout << format ("Task {1} '{2}' already started.",
+      std::cout << format ("Task ID \"{1}\" '{2}' already started.",
                            task.id,
                            task.get ("description"))
                 << '\n';

--- a/src/commands/CmdStop.cpp
+++ b/src/commands/CmdStop.cpp
@@ -74,7 +74,7 @@ int CmdStop::execute (std::string&)
       Task before (task);
 
       // Stop the specified task.
-      std::string question = format ("Stop task {1} '{2}'?",
+      std::string question = format ("Stop task ID \"{1}\" '{2}'?",
                                      task.identifier (true),
                                      task.get ("description"));
 
@@ -89,7 +89,7 @@ int CmdStop::execute (std::string&)
         updateRecurrenceMask (task);
         Context::getContext ().tdb2.modify (task);
         ++count;
-        feedback_affected ("Stopping task {1} '{2}'.", task);
+        feedback_affected ("Stopping task ID \"{1}\" '{2}'.", task);
         dependencyChainOnStart (task);
         if (Context::getContext ().verbose ("project"))
           projectChanges[task.get ("project")] = onProjectChange (task, false);
@@ -104,7 +104,7 @@ int CmdStop::execute (std::string&)
     }
     else
     {
-      std::cout << format ("Task {1} '{2}' not started.",
+      std::cout << format ("Task ID \"{1}\" '{2}' not started.",
                            task.identifier (true),
                            task.get ("description"))
                 << '\n';

--- a/src/commands/CmdUrgency.cpp
+++ b/src/commands/CmdUrgency.cpp
@@ -68,7 +68,7 @@ int CmdUrgency::execute (std::string& output)
   std::stringstream out;
   for (auto& task : filtered)
   {
-    out << format ("task {1} urgency {2}",
+    out << format ("task ID \"{1}\" urgency {2}",
                    task.identifier (),
                    Lexer::trim (format (task.urgency (), 6, 3)))
         << '\n';


### PR DESCRIPTION
This enables copy and paste in case phrase collation class contains the dot character.

Signed-off-by: <corbolais@gmail.com>

#### Description

When working with tw I usually cnp the task ID or UID.

Task commands print the ID often followed by a period ".". Usually the dot is part of the collation char class for mouse selection by double-clicking, however. This means, not only the ID/UID is being marked and copied but the following "." is also. This regularly yields unecessary clutter requiring explicit clean up by hand.

