### PR TITLE
[WIP] Fix rc.verbose documentation in taskrc(5)

### DIFF
--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -255,8 +255,8 @@ prompt. This is only referenced when 'limit:page' is used.
 
 .TP
 .B verbose=1|0|nothing|list...
-When set to "1" (the default), helpful explanatory comments are added to all
-output from Taskwarrior. Setting this to "0" means that you would see regular
+When set to "1", helpful explanatory comments are added to all output from
+Taskwarrior. Setting this to "0" (the default) means that you would see regular
 output.
 
 The special value "nothing" can be used to eliminate all optional output, which
@@ -292,7 +292,7 @@ and the "nothing" setting is equivalent to none of the tokens being specified.
 Here are the shortcut equivalents:
 
     verbose=on
-    verbose=blank,header,footnote,label,new-id,affected,edit,special,project,sync,filter,unwait,override
+    verbose=blank,header,footnote,label,new-id,new-uuid,affected,edit,special,project,sync,filter,unwait,override,recur
 
     verbose=0
     verbose=blank,label,new-id,edit

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -87,7 +87,7 @@ std::string configurationDefaults =
   "\n"
   "# Miscellaneous\n"
   "#                                              # Comma-separated list.  May contain any subset of:\n"
-  "verbose=blank,header,footnote,label,new-id,affected,edit,special,project,sync,unwait,override,recur\n"
+  "verbose=blank,header,footnote,label,new-id,new-uuid,affected,edit,special,project,sync,filter,unwait,override,recur\n"
   "confirmation=1                                 # Confirmation on delete, big changes\n"
   "recurrence=1                                   # Enable recurrence\n"
   "recurrence.confirmation=prompt                 # Confirmation for propagating changes among recurring tasks (yes/no/prompt)\n"


### PR DESCRIPTION
This commit fixes what I believe to be two mistakes in `taskrc(5)`, specifically, the documentation of the `verbose` setting.

I would appreciate if someone more familiar with this setting could review these changes.