### PR TITLE
Workaround for alias grep=rg in fish

### DIFF
--- a/scripts/fish/task.fish
+++ b/scripts/fish/task.fish
@@ -186,7 +186,7 @@ end
 
 function __fish.task.list.command
   # ignore special commands
-  __fish.task.list._command $argv | grep -Ev '^_'
+  __fish.task.list._command $argv | command grep -Ev '^_'
 end
 
 function __fish.task.list.command_mods


### PR DESCRIPTION
#### Description

If the user has `alias grep rg` in Fish, completions are going to fail as the meaning of `-E` option is different in `grep` and `rg`. This ensures that completions bypass aliasing.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
$ cd test && ./problems
Traceback (most recent call last):
  File "./problems", line 60, in <module>
    with open(cmd_args.tapfile) as fh:
FileNotFoundError: [Errno 2] No such file or directory: 'all.log'
```

Sorry, the tests seem to be broken.