### PR TITLE
Fix #2002

### DIFF
--- a/src/commands/CmdContext.cpp
+++ b/src/commands/CmdContext.cpp
@@ -73,7 +73,7 @@ int CmdContext::execute (std::string& output)
   else
   {
     listContexts (out);
-    out << "Use 'task context none' to unset the current context.";
+    out << "Use 'task context none' to unset the current context.\n";
   }
 
   output = out.str ();

--- a/src/commands/CmdContext.cpp
+++ b/src/commands/CmdContext.cpp
@@ -71,7 +71,10 @@ int CmdContext::execute (std::string& output)
     else if (words.size ())          setContext (words, out);
   }
   else
+  {
     listContexts (out);
+    out << "Use 'task context none' to unset the current context.";
+  }
 
   output = out.str ();
   return 0;


### PR DESCRIPTION
#### Description

Simply add the suggestion from #2002 

I did not implement another 'task context help' subcommand since no taskwarrior command has this. Simply calling 'task context' will give the hint on how to unset the context.
