### PR TITLE
Fix rc.verbose default value in taskrc(5)

### DIFF
--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -255,8 +255,8 @@ prompt. This is only referenced when 'limit:page' is used.
 
 .TP
 .B verbose=1|0|nothing|list...
-When set to "1", helpful explanatory comments are added to all output from
-Taskwarrior. Setting this to "0" (the default) means that you would see regular
+When set to "1" (the default), helpful explanatory comments are added to all
+output from Taskwarrior. Setting this to "0" means that you would see regular
 output.
 
 The special value "nothing" can be used to eliminate all optional output, which


### PR DESCRIPTION
As promised in #2116, this reverts one of the changes I made in f6b2a6541c462eab1e89c3bbcb4610eca84ec295.

It looks like `verbose=1` was actually the correct default; I had been using an older version. Sorry!