### PR TITLE
Workaround for alias grep=rg in fish

### DIFF
--- a/scripts/fish/task.fish
+++ b/scripts/fish/task.fish
@@ -186,7 +186,7 @@ end
 
 function __fish.task.list.command
   # ignore special commands
-  __fish.task.list._command $argv | grep -Ev '^_'
+  __fish.task.list._command $argv | command grep -Ev '^_'
 end
 
 function __fish.task.list.command_mods


### PR DESCRIPTION
This is a cherry-pick of https://github.com/GothenburgBitFactory/taskwarrior/pull/2117 onto `2.6.0`.