### PR TITLE
JSON encode/decode string UDAs

### DIFF
--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -299,7 +299,12 @@ std::string CmdEdit::formatTask (Task task, const std::string& dateformat)
 
       std::string type = Context::getContext ().config.get ("uda." + uda + ".type");
       if (type == "string" || type == "numeric")
-        before << "  UDA " << uda << ": " << padding << task.get (uda) << '\n';
+      {
+        auto value = task.get (uda);
+        if (type == "string")
+          value = json::encode (value);
+        before << "  UDA " << uda << ": " << padding << value << '\n';
+      }
       else if (type == "date")
         before << "  UDA " << uda << ": " << padding << formatDate (task, uda, dateformat) << '\n';
       else if (type == "duration")
@@ -663,6 +668,8 @@ void CmdEdit::parseTask (Task& task, const std::string& after, const std::string
     if (type != "")
     {
       auto value = findValue (after, "\n  UDA " + col.first + ":");
+      if (type == "string")
+        value = json::decode (value);
       if ((task.get (col.first) != value) && (type != "date" ||
            (task.get (col.first) != Datetime (value, dateformat).toEpochString ())) &&
            (type != "duration" ||


### PR DESCRIPTION
#### Description

Previously, multiline string UDAs were not preserved when editing
a task via 'task X edit'. String UDAs are now JSON encoded/decoded
during the edit cycle to allow preservation of multiline.

#### Additional information...

- [X ] Have you run the test suite?

Failed:                        
add.t                               1
bash_completion.t                   5
calendar.t                          2
dateformat.t                        1
dependencies.t                      1
filter.t                            5
project.t                           1
quotes.t                            2
search.t                            1

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:             
dependencies.t                      2
hyphenate.t                         1
project.t                           1
