### PR TITLE
fix stale reference to empty priority color config

### DIFF
--- a/doc/man/task-color.5.in
+++ b/doc/man/task-color.5.in
@@ -227,8 +227,8 @@ rule 'color.deleted' has the highest precedence, and 'color.uda.' the lowest.
 The keyword rule shown here as 'keyword.' corresponds to a wildcard pattern,
 meaning 'color.keyword.*', or in other words all the keyword rules.
 
-There is also 'color.project.none', 'color.tag.none' and 'color.pri.none' to
-specifically represent missing data.
+There is also 'color.project.none', 'color.tag.none' and
+'color.uda.priority.none' to specifically represent missing data.
 
 .SH THEMES
 Taskwarrior supports themes.  What this really means is that with the ability to


### PR DESCRIPTION
#### Description

color.pri.none is now color.uda.priority.none

I have tested the above change with TaskWarrior 2.5.1, and it works correctly. The old 'color.pri.none' option does not work.

#### Additional information...

- [ ] Have you run the test suite?

Not applicable.
