### PR TITLE
Make completed projects appear in autocompletion

### DIFF
--- a/scripts/bash/task.sh
+++ b/scripts/bash/task.sh
@@ -65,7 +65,7 @@ _task_offer_priorities() {
 }
 
 _task_offer_projects() {
-    COMPREPLY=( $(compgen -W "$($taskcommand _projects)" -- ${cur/*:/}) )
+    COMPREPLY=( $(compgen -W "$($taskcommand _unique project)" -- ${cur/*:/}) )
 }
 
 _task_offer_contexts() {


### PR DESCRIPTION
#### Description

The aim of this pull request is to make completed projects appear in the bash auto completion.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
Failed:                        
dates.t                             1
version.t                           1

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
rx.t                                1
wait.t                              1

Expected failures:             
color.rules.t                       2
dependencies.t                      2
hyphenate.t                         1

```