### PR TITLE
Fix report colors in calendar - Issue #1997

### DIFF
--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -348,6 +348,8 @@ int CmdCalendar::execute (std::string& output)
       args.push_back ("rc:" + Context::getContext ().rc_file._data);
       args.push_back ("rc.due:0");
       args.push_back ("rc.verbose:label,affected,blank");
+      if (Context::getContext ().color ())
+          args.push_back ("rc._forcecolor:on");
       args.push_back ("due.after:" + after);
       args.push_back ("due.before:" + before);
       args.push_back ("-nocal");


### PR DESCRIPTION
#### Description

As far as I can see, this should be everything that is necessary to fix the bug described in #1997 

#### Additional information...

- [x] Have you run the test suite?

```
Failed:                        
add.t                               1
bash_completion.t                   4
dateformat.t                        1
dependencies.t                      1
filter.t                            5
project.t                           1
quotes.t                            1
search.t                            1
version.t                           1

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:             
dependencies.t                      2
hyphenate.t                         1
project.t                           1
```

With:

`$ diff timbuntu/taskwarrior/problems GothenburgBitFactory/taskwarrior/problems`
```diff
8c8
< quotes.t                            1
---
> quotes.t                            2
10d9
< version.t                           1
```