### PR TITLE
hook onModify into task undo (Closes: #2213)

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -839,6 +839,9 @@ void TDB2::revert ()
     //   - erase from completed
     //   - if in backlog, erase, else cannot undo
 
+    Task old = Task (prior);
+    Context::getContext ().hooks.onModify (Task (current), old);
+
     // Modify other data files accordingly.
     std::vector <std::string> p = pending.get_lines ();
     revert_pending (p, uuid, prior);


### PR DESCRIPTION
#### Description

Call onModify hook when running task undo. Changes from the hook are ignored.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.