### PR TITLE
Poor implementation of linewrap restored to task

### DIFF
--- a/src/ViewTask.cpp
+++ b/src/ViewTask.cpp
@@ -208,7 +208,6 @@ std::string ViewTask::render (std::vector <Task>& data, std::vector <int>& seque
   // Not enough for minimum.
   else if (overage < 0)
   {
-    context.error (format (STRING_VIEW_TOO_SMALL, sum_minimal + all_extra, _width));
     widths = minimal;
   }
 
@@ -313,10 +312,11 @@ std::string ViewTask::render (std::vector <Task>& data, std::vector <int>& seque
       row_color.blend (rule_color);
     }
 
+    const int off = overage < 0 ? overage : 0;
     for (unsigned int c = 0; c < _columns.size (); ++c)
     {
       cells.push_back (std::vector <std::string> ());
-      _columns[c]->render (cells[c], data[sequence[s]], widths[c], row_color);
+      _columns[c]->render (cells[c], data[sequence[s]], widths[c]+off, row_color);
 
       if (cells[c].size () > max_lines)
         max_lines = cells[c].size ();

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -54,7 +54,8 @@ void wrapText (
 {
   std::string line;
   unsigned int offset = 0;
-  while (extractLine (line, text, width, hyphenate, offset))
+  const int dw = width < 12 ? 12 : width;
+  while (extractLine (line, text, dw, hyphenate, offset))
     lines.push_back (line);
 }
 


### PR DESCRIPTION
This addresses #2023

For many years linewrap has been broken in taskwarrior, rendering the
application basically useless in terminals with short widths and tasks
containing URLs in them... This janky line wrap patch sort of works but
introduces other minor graphical glitches.

But seeing as no one took the time to fix it over the years, here some a
small salvation to those who suffer as much as me.

One problem of this patch is, when a line is wrapped, it may be 1 column
smaller than the terminal width, resulting in each line not fully
utilizing the terminal width.

This patch is not polished and could probably need to be tended by
someone who cares more.

This patch has been tested on v2.5.2
