### PR TITLE
Correctly parse projects with spaces in zsh completion

### DIFF
--- a/scripts/zsh/_task
+++ b/scripts/zsh/_task
@@ -24,7 +24,7 @@
 # https://www.opensource.org/licenses/mit-license.php
 #
 typeset -g _task_cmds _task_projects _task_tags _task_config _task_modifiers
-_task_projects=($(task _projects))
+_task_projects=(${(f)"$(task _projects)"})
 _task_tags=($(task _tags))
 _task_zshids=( ${(f)"$(task _zshids)"} )
 _task_config=($(task _config))


### PR DESCRIPTION
#### Description

This is the same as how the `_task_zshids` array is created.
See https://github.com/ohmyzsh/ohmyzsh/issues/8249

#### Additional information...

This PR doesn't need to run the test suite. I have tested it manually with the following steps:

1. Use zsh with the completion file loaded
2. Create the task projects: `task add TEST project:"Test Project"`
3. Try to complete: `task project:[TAB]`