### PR TITLE
Fix add.t Test1549 test failure.

### DIFF
--- a/test/add.t
+++ b/test/add.t
@@ -191,7 +191,7 @@ class Test1549(TestCase):
         """
 
         # This command will hang and therefore timeout in 2.4.1.
-        code, out, err = self.t('add 1e x')
+        code, out, err = self.t('rc.verbose:new-id add 1e x')
         self.assertIn("Created task 1.", out)
 
 


### PR DESCRIPTION
The test was failing on my machine on fresh checkout. It failed because
somehow both new-id and new-uuid verbosity were set during the test, so
TW defaulted to printing out uuid, which did not match the assertion.

Test fixed by explicitly setting verbosity to new-id.

#### Description

Replace this text with a description of the PR.

#### Additional information...

- [ ] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.
