### PR TITLE
Fix TestBug1436's failure due to task number vs. hash

### DIFF
--- a/test/quotes.t
+++ b/test/quotes.t
@@ -108,10 +108,8 @@ class TestBug1436(TestCase):
         #   Python turns \\ --> \, therefore \\\\\\\\ --> \\\\
         #   Some process launch thing does the same, therefore \\\\ --> \\
         #   Taskwarrior sees \\, which means \
-        code, out, err = self.t("add Use this backslash \\\\\\\\")
-        self.assertIn("Created task 1", out)
-
-        code, out, err = self.t("list")
+        self.t("add Use this backslash \\\\\\\\")
+        code, out, err = self.t("_get 1.description")
         self.assertIn("Use this backslash \\", out)
 
     def test_backslashes(self):


### PR DESCRIPTION
#### Description

The test was failing because it expected "Created task 1"
but it saw "Created task 0a436fd8-7f06-4168-a66d-bbc940498af9".

Instead, the new code looks at the description of task 1.
Replace this text with a description of the PR.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

Before this PR:
> quotes.t                            2

After this PR:
> quotes.t                            1
