### PR TITLE
Follow XDG standard

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -482,7 +482,7 @@ void Config::parse (const std::string& input, int nest /* = 1 */)
 void Config::createDefaultRC (const std::string& rc, const std::string& data)
 {
   // Override data.location in the defaults.
-  auto loc = _defaults.find ("data.location=~/.task");
+  auto loc = _defaults.find ("data.location=~/.local/share/task");
   //                                      loc+0^          +14^   +21^
 
   ISO8601d now;

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -67,8 +67,8 @@ static const char* modifierNames[] =
 
 ////////////////////////////////////////////////////////////////////////////////
 Context::Context ()
-: rc_file ("~/.taskrc")
-, data_dir ("~/.task")
+: rc_file ("~/.config/taskrc")
+, data_dir ("~/.local/share/task")
 , config ()
 , tdb2 ()
 , determine_color_use (true)

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -685,7 +685,7 @@ void Context::createDefaultConfig ()
   if (rc_file._data != "" && ! rc_file.exists ())
   {
     if (config.getBoolean ("confirmation") &&
-        !confirm (format (STRING_CONTEXT_CREATE_RC, home_dir, rc_file._data)))
+        !confirm (format (STRING_CONTEXT_CREATE_RC, rc_file.parent().data(), rc_file._data)))
       throw std::string (STRING_CONTEXT_NEED_RC);
 
     config.createDefaultRC (rc_file, data_dir._original);


### PR DESCRIPTION
#### Description

Following popular request in #438, #1105 and #2203, this PR changes the default locations to the default XDG locations. This is obviously only a first step, as it should check for custom XDG locations and fall back on the previous defaults if these already exist, but I currently do not know how to implement that.