### PR TITLE
Fix parsing of "PnM" recurrence periods

### DIFF
--- a/src/recur.cpp
+++ b/src/recur.cpp
@@ -251,7 +251,7 @@ Datetime getNextRecurrence (Datetime& current, std::string& period)
            Lexer::isAllDigits (period.substr (1, period.length () - 2)) &&
            period[period.length () - 1] == 'M')
   {
-    int increment = strtol (period.substr (0, period.length () - 1).c_str (), nullptr, 10);
+    int increment = strtol (period.substr (1, period.length () - 2).c_str (), nullptr, 10);
 
     m += increment;
     while (m > 12)


### PR DESCRIPTION
#### Description

Due to not accounting for the leading "P", getNextRecurrence would always return the same datetime, breaking all generic "PnM" periods and leading to an infinite loop in generateDueDates.

All credit for the discovery of this bug goes to Michał Mirosław, who reported this and provided a patch in [this Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=951776); this is also why I backdated the author date to that bug report. I opted not to include the `if (increment <= 0)` part of the patch because that is a different and unrelated issue (#2262): an infinite loop in `generateDueDates` and caused only by (this bug and) weird, nonsensical periods of length zero, e.g. `P0M` .

Given that this bug was not caught earlier, it would also be good to add tests for this recurrence parsing, but I have not done so.

#### Additional information...

- [x] Have you run the test suite?

```
> ./run_all                                                   
Passed:                          3858
Failed:                            19
Unexpected successes:               0
Skipped:                           14
Expected failures:                  4
Runtime:                        10.46 seconds
> ./problems 
Failed:                        
bash_completion.t                   4
dateformat.t                        1
dependencies.t                      1
diag.t                              1
filter.t                            5
project.t                           1
quotes.t                            2
search.t                            1
undo.t                              2
version.t                           1

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:             
dependencies.t                      2
hyphenate.t                         1
project.t                           1
```

I get similar failures with a clean checkout of 2.6.0. To be precise, I get one *more* failure in bash_completion.t with that branch than this code.
Some of the failures may be because I disabled syncing (`-DENABLE_SYNC=OFF`) due to a lack of GnuTLS on the test machine.