### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Taskwarrior - a command line task list manager.
+The MIT License
 
-Copyright 2006 - 2019, Paul Beckingham, Federico Hernandez.
+Copyright 2006 - 2020, Paul Beckingham, Federico Hernandez.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
By changing the first line to `The MIT License`, users can see the license on the Github Taskwarrior main page.

