### PR TITLE
Fix typo in man page example

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -562,7 +562,7 @@ by third-party applications.
 Reports a unique set of attribute values. For example, to see all the active
 projects:
 
-  task +PENDING _unique projects
+  task +PENDING _unique project
 
 .TP
 .B task <filter> _uuids


### PR DESCRIPTION
#### Description

The example for _unique has typo, should be using attribute for project.
Fixes #2277

#### Additional information...

- [ ] ~~Have you run the test suite?~~
I opted to skip tests, given the scope of the change.