### PR TITLE
Test: Add UUID test demonstrating a "Cannot subtract strings" bug

### DIFF
--- a/test/lexer.t.cpp
+++ b/test/lexer.t.cpp
@@ -421,6 +421,7 @@ int main (int, char**)
 
     // UUID
     { "ffffffff-ffff-ffff-ffff-ffffffffffff",         { { "ffffffff-ffff-ffff-ffff-ffffffffffff",         Lexer::Type::uuid         }, NO, NO, NO, NO }, },
+    { "0000000d-0000-0000-0000-000000000000",         { { "0000000d-0000-0000-0000-000000000000",         Lexer::Type::uuid         }, NO, NO, NO, NO }, },
     { "00000000-0000-0000-0000-0000000",              { { "00000000-0000-0000-0000-0000000",              Lexer::Type::uuid         }, NO, NO, NO, NO }, },
     { "00000000-0000-0000-0000",                      { { "00000000-0000-0000-0000",                      Lexer::Type::uuid         }, NO, NO, NO, NO }, },
     { "00000000-0000-0000",                           { { "00000000-0000-0000",                           Lexer::Type::uuid         }, NO, NO, NO, NO }, },


### PR DESCRIPTION
```
$ task 0000000d-000a-0000-0000-000000000000 export
Cannot subtract strings
$ task 0000000d-0000-0000-0000-000000000000 export
The expression could not be evaluated.
```