### PR TITLE
Xdg basedir spec

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -1315,6 +1315,10 @@ Specifies an alternate configuration file with highest priority.
 The environment variable specifies an alternate configuration file to use.
 
 .TP
+.B XDG_CONFIG_HOME=<path-to-alternate-config-home> task ..
+The environment variable specifies an alternate configuration file to use.
+
+.TP
 .B task rc.<name>:<value> ...
 .B task rc.<name>=<value> ...
 Specifies individual configuration file overrides.
@@ -1340,7 +1344,10 @@ this man page.
 .TP
 ~/.taskrc
 User configuration file - see also taskrc(5).  Note that this can be
-overridden on the command line or by the TASKRC environment variable.
+overridden on the command line or by the TASKRC environment variable. Also, if
+.I ~/.taskrc
+doesn't exist and XDG_CONFIG_HOME environment variable is defined, taskwarrior
+will check if $XDG_CONFIG_HOME/task/taskrc exists and attempt to read it
 
 .TP
 ~/.task

--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -9,6 +9,8 @@ taskrc \- Configuration details for the task(1) command
 .B task rc:<directory-path>/.taskrc ...
 .br
 .B TASKRC=<directory-path>/.taskrc task ...
+.br
+.B XDG_CONFIG_HOME=<directory-path>/task/taskrc task ...
 
 .SH DESCRIPTION
 .B Taskwarrior
@@ -32,6 +34,12 @@ or using the TASKRC environment variable:
 
 .RS
 $ TASKRC=/tmp/.taskrc task ...
+.RE
+
+Additionally, if no ~/.taskrc exists, taskwarrior will check if the XDG_CONFIG_HOME environment variable is defined:
+
+.RS
+$ XDG_CONFIG_HOME=~/.config task ...
 .RE
 
 Individual options can be overridden by using the
@@ -154,7 +162,7 @@ define a set of US holidays, and set up a 16-color theme to use, to color the
 reports and calendar.
 
 .SH ENVIRONMENT VARIABLES
-These environment variables override defaults and command line arguments.
+These environment variables override defaults, but not command-line arguments.
 
 .TP
 .B TASKDATA=~/.task
@@ -163,6 +171,17 @@ This overrides the default path for the Taskwarrior data files.
 .TP
 .B TASKRC=~/.taskrc
 This overrides the default RC file.
+.RE
+
+This environment variable will be checked if
+.I ~/.taskrc
+doesn't exist
+
+.TP
+.B XDG_CONFIG_HOME=~/.config
+If set, taskwarrior will look for a
+.I $XDG_CONFIG_HOME/task/taskrc
+file
 
 .SH CONFIGURATION VARIABLES
 Valid variable names and their default values are:

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -236,16 +236,12 @@ const char* getValue (int argc, const char** argv, std::string arg)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Static method.
-bool CLI2::getOverride (int argc, const char** argv, std::string& home, File& rc)
+bool CLI2::getOverride (int argc, const char** argv, File& rc)
 {
   const char* value = getValue (argc, argv, "rc");
   if (value == nullptr)
     return false;
   rc = File (value);
-  if (rc._data.rfind ("/") != std::string::npos)
-    home = rc.parent ();
-  else
-    home = ".";
   return true;
 }
 

--- a/src/CLI2.h
+++ b/src/CLI2.h
@@ -60,7 +60,7 @@ class CLI2
 public:
   static int minimumMatchLength;
 
-  static bool getOverride (int, const char**, std::string&, File&);
+  static bool getOverride (int, const char**, File&);
   static bool getDataLocation (int, const char**, Path&);
   static void applyOverrides (int, const char**);
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -440,6 +440,7 @@ int Context::initialize (int argc, const char** argv)
 {
   timer_total.start ();
   int rc = 0;
+  home_dir = getenv ("HOME");
 
   try
   {

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -455,7 +455,8 @@ int Context::initialize (int argc, const char** argv)
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    bool taskrc_overridden = CLI2::getOverride (argc, argv, home_dir, rc_file);
+    bool taskrc_overridden = false;
+
     if (! taskrc_overridden)
     {
       char *override = getenv ("TASKRC");
@@ -465,6 +466,9 @@ int Context::initialize (int argc, const char** argv)
         taskrc_overridden = true;
       }
     }
+
+    taskrc_overridden =
+        CLI2::getOverride (argc, argv, rc_file) || taskrc_overridden;
 
     // Artificial scope for timing purposes.
     {
@@ -490,7 +494,8 @@ int Context::initialize (int argc, const char** argv)
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    bool taskdata_overridden = CLI2::getDataLocation (argc, argv, data_dir);
+    bool taskdata_overridden = false;
+
     if (! taskdata_overridden)
     {
       char *override = getenv("TASKDATA");
@@ -501,6 +506,10 @@ int Context::initialize (int argc, const char** argv)
         taskdata_overridden = true;
       }
     }
+
+    taskdata_overridden =
+        CLI2::getDataLocation (argc, argv, data_dir) || taskdata_overridden;
+
     if (taskdata_overridden && verbose ("override"))
       header (format ("TASKDATA override: {1}", data_dir._data));
 


### PR DESCRIPTION
#### Description

Implements [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
Motivation: https://farbenmeer.de/de/blog/the-power-of-the-xdg-base-directory-specification
I'm aware of [this PR](https://github.com/GothenburgBitFactory/taskwarrior/pull/2248) already being open. But it looks like it doesn't implement the full spec and seems to be going into limbo, so I gave this a shot.

With these changes, taskwarrior still supports the current file locations, but make the new locations the default for new users. As suggested by @corbolais [here](https://github.com/GothenburgBitFactory/taskwarrior/pull/2316#discussion_r467478464), if files exist in both old and new locations, taskwarrior will print a warning and uses the old locations.

This is the first C++ code I've ever written -> improvement suggestions welcome.

#### Additional information...

- [x] Have you run the test suite? Yes, I don't think any of the failing tests are due to my code but in case I'm mistaken let me know and I'll fix them
```
cd test && ./problems
Failed:
bash_completion.t                   4
dateformat.t                        1
dependencies.t                      1
filter.t                            5
project.t                           1
quotes.t                            2
search.t                            1
tw-1688.t                           1
tw-1718.t                           1
undo.t                              2
version.t                           1

Unexpected successes:

Skipped:
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      2
hyphenate.t                         1
project.t                           1
[Exit 1]
```
