### PR TITLE
Uncoditionally include errno.h instead of guessing

### DIFF
--- a/src/TLSClient.cpp
+++ b/src/TLSClient.cpp
@@ -37,11 +37,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
-#if (defined OPENBSD || defined SOLARIS || defined NETBSD)
 #include <errno.h>
-#else
-#include <sys/errno.h>
-#endif
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>


### PR DESCRIPTION
#### Description

POSIX tells us that it is errno.h, musl fails to build with -Werror
because it redirects sys/errno.h->errno.h and uses `#warning`

#### Additional information...

- [ ] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.
