### PR TITLE
Fix bash_completion test failure.

### DIFF
--- a/test/bash_completion.t
+++ b/test/bash_completion.t
@@ -36,7 +36,8 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from basetest import Task, TestCase
 from basetest.utils import BIN_PREFIX
 
-TASKSH = os.path.abspath(os.path.join(BIN_PREFIX, "..", "scripts/bash/task.sh"))
+TASKSH = os.path.abspath(
+    os.path.join(BIN_PREFIX, "..", "scripts/bash/task.sh"))
 
 
 @contextmanager
@@ -84,6 +85,9 @@ class TestBashCompletionBase(TestCase):
         # Used also in tasksh script
         self.t.config("alias.samplealias", "long")
         self.t.config("abbreviation.minimum", "5")
+        self.t.config("verbose",
+                      "blank,header,footnote,label,new-id,affected,edit,"
+                      "special,project,sync,unwait,recur")
 
         self.t.tasksh_script = os.path.join(self.t.datadir, "task.sh")
 


### PR DESCRIPTION
#### Description

The PR fixes bash_completion test failure.

The test was failing on fresh checkout due to string mismatch in several
test cases. This was because  both new-id and new-uuid verbosity were set
during the test, so TW defaulted to printing out uuid, which did not match the
assertion.

This is very similar to commit abddb1ea8e1d15d63f4784ff33eefe80994715ca.

#### Additional information...

- [X] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
Failed:                        
dateformat.t                        1
dependencies.t                      1
filter.t                            5
project.t                           1
quotes.t                            2
search.t                            1
undo.t                              2
version.t                           1

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:             
dependencies.t                      2
hyphenate.t                         1
project.t                           1
```

Note: other tests failing for similar reasons.