### PR TITLE
Make modify and delete commands respect rc.recurrence.confirmation config option. #2309 #2325

### DIFF
--- a/src/commands/CmdDelete.cpp
+++ b/src/commands/CmdDelete.cpp
@@ -137,9 +137,10 @@ int CmdDelete::execute (std::string&)
         else
         {
           std::vector <Task> children = Context::getContext ().tdb2.children (task);
-          if (children.size () &&
-              (Context::getContext ().config.getBoolean ("recurrence.confirmation") ||
-               confirm (STRING_CMD_DELETE_CONFIRM_R)))
+          if (children.size() &&
+                  ((Context::getContext ().config.get ("recurrence.confirmation") == "prompt"
+                    && confirm (STRING_CMD_DELETE_CONFIRM_R)) ||
+                   Context::getContext ().config.getBoolean ("recurrence.confirmation")))
           {
             for (auto& child : children)
             {

--- a/src/commands/CmdModify.cpp
+++ b/src/commands/CmdModify.cpp
@@ -200,8 +200,9 @@ int CmdModify::modifyRecurrenceParent (
 
   auto children = Context::getContext ().tdb2.children (task);
   if (children.size () &&
-      (! Context::getContext ().config.getBoolean ("recurrence.confirmation") ||
-        confirm (STRING_CMD_MODIFY_RECUR)))
+          ((Context::getContext ().config.get ("recurrence.confirmation") == "prompt"
+            && confirm (STRING_CMD_MODIFY_RECUR)) ||
+           Context::getContext ().config.getBoolean ("recurrence.confirmation")))
   {
     for (auto& child : children)
     {


### PR DESCRIPTION
#### Description
Fix #2325
Fix #2309 
Make delete and modify commands only prompt about propagating changes to children when rc.recurrence.confirmation is set to 'prompt'.
#### Additional information...

- [x] Have you run the test suite?
* Passes all in `make test`
