### PR TITLE
Fixed SIGSEGV when substituting a sequence in a task description with shorter one

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1393,7 +1393,7 @@ void Task::substitute (
       int skew = 0;
       for (unsigned int i = 0; i < start.size () && !done; ++i)
       {
-        description.replace (start[i + skew], end[i] - start[i], to);
+        description.replace (start[i] + skew, end[i] - start[i], to);
         skew += to.length () - (end[i] - start[i]);
         ++changes;
 

--- a/test/substitute.t
+++ b/test/substitute.t
@@ -84,6 +84,14 @@ class TestSubstitutions(TestCase):
         code, out, err = self.t("_get 1.description")
         self.assertEqual("aaa BbB\n", out)
 
+    def test_substitution_long_with_short(self):
+        """Verify substitution of a sequence with a shorter sequence."""
+        self.t("add aaaaBaaaa")
+        self.t("1 modify /aaaa/c/g")
+        code, out, err = self.t("_get 1.description")
+        self.assertEqual("cBc\n", out)
+
+
 class TestBug441(TestCase):
     def setUp(self):
         self.t = Task()


### PR DESCRIPTION
#### Description

I stumbled upon a SIGSEGV when I tried substituting a sequence in a task description with a shorter one.

```sh
$ task add aaaaCaaaa
Created task 1.
$ task 1 modify /aaaa/b/g
(SIGSEGV)
```

I fixed the bug and added a unit test for it.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
Failed:                        
feature.default.project.t           1
filter.t                            5
project.t                           1
search.t                            1
tw-1999.t                           1
undo.t                              2
version.t                           2

Unexpected successes:          

Skipped:                       
dependencies.t                      3
export.t                            1
feature.default.project.t           3
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           1
wait.t                              1

Expected failures:             
dependencies.t                      2
hyphenate.t                         1
project.t                           1
```
Note that these tests were failing before my changes as well. No tests are failing in `substitute.t`.