### PR TITLE
Fix tests on 2.5.2 branch

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1278,7 +1278,18 @@ Variant& Variant::operator-= (const Variant& other)
     break;
 
   case type_string:
-    throw std::string (STRING_VARIANT_SUB_STRING);
+    switch (right._type)
+    {
+    case type_string:
+      cast (type_string);   _string   += '-' + right._string;   break;
+    case type_boolean:
+    case type_integer:
+    case type_real:
+    case type_date:
+    case type_duration:
+      throw std::string (STRING_VARIANT_SUB_STRING);
+      break;
+    }
     break;
 
   case type_date:

--- a/test/diag.t
+++ b/test/diag.t
@@ -48,7 +48,7 @@ class TestDiagnostics(TestCase):
         self.t.activate_hooks()
         code, out, err = self.t.diag()
         self.tap(out)
-        self.assertRegex(out, "Compliance:\s+C\+\+14")
+        self.assertRegex(out, "Compliance:\s+C\+\+17")
         self.assertRegex(out, "libgnutls:\s+\d+\.\d+\.\d+")
         self.assertIn("edlin", out)
         self.assertIn("strict", out)

--- a/test/project.t
+++ b/test/project.t
@@ -381,6 +381,7 @@ class TestBug1455(TestCase):
     def setUp(self):
         self.t = Task()
 
+    @unittest.expectedFailure
     def test_project_hierarchy_filter(self):
         """1455: Test project:school)
 

--- a/test/project.t
+++ b/test/project.t
@@ -251,6 +251,22 @@ class TestBug299(TestCase):
         self.assertRegex(out, "three.*baz")
 
 
+class TestBug555(TestCase):
+    def setUp(self):
+        self.t = Task()
+
+    def test_log_with_project_segfault(self):
+        """555: log with a project causes a segfault
+
+        Reported in bug 555
+        """
+        code, out, err = self.t("rc.verbose:new-uuid log description project:p")
+
+        self.assertNotIn("Segmentation fault", out)
+        self.assertNotIn("Segmentation fault", err)
+        self.assertIn("Logged task", out)
+
+
 class TestBug605(TestCase):
     def setUp(self):
         self.t = Task()

--- a/test/variant_subtract.t.cpp
+++ b/test/variant_subtract.t.cpp
@@ -139,9 +139,10 @@ int main (int, char**)
   try {Variant v32 = v3 - v2; t.fail ("foo - 3.14 --> error");}
   catch (...)                {t.pass ("foo - 3.14 --> error");}
 
-  // string - string   -> ERROR
-  try {Variant v33 = v3 - v3; t.fail ("foo - foo --> error");}
-  catch (...)                {t.pass ("foo - foo --> error");}
+  // string - string   -> concatenated string
+  Variant v33 = v3 - v3;
+  t.is (v33.type (), Variant::type_string, "foo - foo --> string");
+  t.is (v33.get_string (), "foo-foo",      "foo - foo --> foo-foo");
 
   // string - date     -> ERROR
   try {Variant v34 = v3 - v4; t.fail ("foo - 1234567890 --> error");}

--- a/test/wait.t
+++ b/test/wait.t
@@ -62,7 +62,7 @@ class TestWait(TestCase):
         self.assertIn("visible", out)
         self.assertIn("hidden", out)
 
-        self.assertIn("Un-waiting task 'hidden'", err)
+        self.assertIn("Un-waiting task 2 'hidden'", err)
 
 
 class TestBug434(TestCase):


### PR DESCRIPTION
#### Description

This PR backports some of the test fixes already present on the 2.6.0 branch onto the 2.5.2 branch.
It also fixes some other details in the tests which were outdated.

#### Additional information...

- [x] Have you run the test suite?
```
% ./problems
Failed:
filter.t                            5
project.t                           1
search.t                            1
```

The above failures are still related to the following problems:
- [ ] `project.t`, `search.t` and one in `filter.t`: related to a syntax issue. We can choose to document it properly and fix the unittests to reflect this syntax. Some discussion on this took place in #2345.
- [ ] `filter.t` part 1: 2 failures are related to #1654 which is closed but not fixed. I think we should re-open the issue and mark the failures as expected for now with a TODO label
- [ ] `filter.t` part 2: the remaining 2 failures are related to the open issue #1928. I suggest doing the same as above (mark as expected and add a TODO flag).