### PR TITLE
Cherry-pick PRs accidentally merged to master into 2.5.2

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -604,7 +604,7 @@ by third-party applications.
 Reports a unique set of attribute values. For example, to see all the active
 projects:
 
-  task +PENDING _unique projects
+  task +PENDING _unique project
 
 .TP
 .B task <filter> _uuids

--- a/src/TLSClient.cpp
+++ b/src/TLSClient.cpp
@@ -37,11 +37,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
-#if (defined OPENBSD || defined SOLARIS || defined NETBSD)
 #include <errno.h>
-#else
-#include <sys/errno.h>
-#endif
 #include <sys/types.h>
 #include <netdb.h>
 #include <gnutls/x509.h>


### PR DESCRIPTION
#### Description

#2223, #2280, #2320 were merged to master but not to 2.5.2 nor 2.6.0.
This PR cherry-picks #2280 and #2320 to 2.5.2.
PR #2223 is skipped for two reasons:

1. most commands now use Table instead of ViewTask, so the benefit of the change is quite limited
2. it really is a quick dirty hack that needs more review/work before being merged