### PR TITLE
Add missing "QUARTER" to feedback_reserved_tags

### DIFF
--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -325,6 +325,7 @@ void feedback_reserved_tags (const std::string& tag)
       tag == "PENDING"   ||
       tag == "PRIORITY"  ||
       tag == "PROJECT"   ||
+      tag == "QUARTER"   ||
       tag == "READY"     ||
       tag == "SCHEDULED" ||
       tag == "TAGGED"    ||


### PR DESCRIPTION
#### Description

A while ago I noticed that 630a1530e0e0495f602ec5b687630b54945b2882 only added the QUARTER virtual tag to src/Task.cpp, and when I checked that again today, it was still missing from src/feedback.cpp, so I'm fixing that.

#### Additional information...

- [ ] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

  (not expecting any breakage, so I'll leave this to the CI)