### PR TITLE
Fix final failing test on 2.5.3

### DIFF
--- a/src/ViewTask.cpp
+++ b/src/ViewTask.cpp
@@ -310,11 +310,10 @@ std::string ViewTask::render (std::vector <Task>& data, std::vector <int>& seque
       row_color.blend (rule_color);
     }
 
-    const int off = overage < 0 ? overage : 0;
     for (unsigned int c = 0; c < _columns.size (); ++c)
     {
       cells.push_back (std::vector <std::string> ());
-      _columns[c]->render (cells[c], data[sequence[s]], widths[c]+off, row_color);
+      _columns[c]->render (cells[c], data[sequence[s]], widths[c], row_color);
 
       if (cells[c].size () > max_lines)
         max_lines = cells[c].size ();


### PR DESCRIPTION
#### Description

This reverts commit 64243e6ec1919e5ce41f95b00cffe8b263ebb980 which was introduced by #2223.

#### Additional information...

As discussed in #2345 there is one final test on the 2.5.3 branch which is failing. This test is passing fine on 2.6.0 and also used to pass fine on 2.5.2 because the failure is caused by #2223 which was merged into `master` directly (which 2.5.3 is now based on).
#2223 attempted to fix #2023 by introducing a workaround to handle linewrapping. However, since the 2.5.2 release most commands now actually use a table rather than `ViewTask` (thanks @liskin).

Thus, reverting 64243e6 does not actually cause any problems as shown below:
![screenshot_1607262855](https://user-images.githubusercontent.com/21973473/101282048-f485c780-37d2-11eb-830b-b4beafa06463.png)


- [x] Have you run the test suite?
```
% ./run_all
Passed:                          3776
Failed:                             0
Unexpected successes:               0
Skipped:                            5
Expected failures:                 11
Runtime:                        20.24 seconds
```
