### PR TITLE
Support editing multi-line annotations (Closes: #2283)

### DIFF
--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -173,23 +173,6 @@ std::vector <std::string> CmdEdit::findValues (
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::string CmdEdit::replaceString (
-  std::string text,
-  const std::string& search,
-  const std::string& replacement)
-{
-  std::string::size_type found = 0;
-
-  while ((found = text.find (search, found)) != std::string::npos)
-  {
-    text.replace (found, search.length (), replacement);
-    found += replacement.length ();
-  }
-
-  return text;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 std::string CmdEdit::formatDate (
   Task& task,
   const std::string& attribute,
@@ -272,7 +255,7 @@ std::string CmdEdit::formatTask (Task task, const std::string& dateformat)
   {
     Datetime dt (strtol (anno.first.substr (11).c_str (), nullptr, 10));
     before << "  Annotation:        " << dt.toString (dateformat)
-           << " -- "                  << replaceString (anno.second, "\n", ANNOTATION_EDIT_MARKER) << '\n';
+           << " -- "                  << str_replace (anno.second, "\n", ANNOTATION_EDIT_MARKER) << '\n';
   }
 
   Datetime now;
@@ -637,7 +620,7 @@ void CmdEdit::parseTask (Task& task, const std::string& after, const std::string
 
     if (eol != std::string::npos)
     {
-      auto value = Lexer::trim (replaceString (after.substr (found, eol - found), ANNOTATION_EDIT_MARKER, "\n"), "\t ");
+      auto value = Lexer::trim (str_replace (after.substr (found, eol - found), ANNOTATION_EDIT_MARKER, "\n"), "\t ");
       auto gap = value.find (" -- ");
       if (gap != std::string::npos)
       {

--- a/src/commands/CmdEdit.h
+++ b/src/commands/CmdEdit.h
@@ -41,7 +41,6 @@ private:
   std::string findValue (const std::string&, const std::string&);
   std::string findMultilineValue (const std::string&, const std::string&, const std::string&);
   std::vector <std::string> findValues (const std::string&, const std::string&);
-  std::string replaceString (std::string text, const std::string& search, const std::string& replacement);
   std::string formatDate (Task&, const std::string&, const std::string&);
   std::string formatDuration (Task&, const std::string&);
   std::string formatTask (Task, const std::string&);

--- a/src/commands/CmdEdit.h
+++ b/src/commands/CmdEdit.h
@@ -41,12 +41,14 @@ private:
   std::string findValue (const std::string&, const std::string&);
   std::string findMultilineValue (const std::string&, const std::string&, const std::string&);
   std::vector <std::string> findValues (const std::string&, const std::string&);
+  std::string replaceString (std::string text, const std::string& search, const std::string& replacement);
   std::string formatDate (Task&, const std::string&, const std::string&);
   std::string formatDuration (Task&, const std::string&);
   std::string formatTask (Task, const std::string&);
   void parseTask (Task&, const std::string&, const std::string&);
   enum class editResult { error, changes, nochanges };
   editResult editFile (Task&);
+  static const std::string ANNOTATION_EDIT_MARKER;
 };
 
 #endif


### PR DESCRIPTION
#### Description

Since e4b9c1f annotations where JSON encoded in task edit to escape
new lines (\n). But other strings where mangled as well, like https://
becoming https:\/\/, making it hard to edit.

This patch removes the JSON encoding and indents new lines instead.

#### Additional information...

- [X] Have you run the test suite?
Failed:

Unexpected successes:

Skipped:
dependencies.t                      3
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      2
filter.t                            4
hyphenate.t                         1
lexer.t                             4
project.t                           1
quotes.t                            1
search.t                            1