### PR TITLE
fix: remove lock file on interruption of 'task edit' (#2292)

### DIFF
--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -826,12 +826,16 @@ ARE_THESE_REALLY_HARMFUL:
     {
       std::cerr << "Error: " << problem << '\n';
 
-      // Preserve the edits.
-      before = after;
-      File::write (file.str (), before);
+      File::remove (file.str());
 
       if (confirm ("Taskwarrior couldn't handle your edits.  Would you like to try again?"))
+      {
+        // Preserve the edits.
+        before = after;
+        File::write (file.str (), before);
+
         goto ARE_THESE_REALLY_HARMFUL;
+      }
     }
     else
       changes = true;


### PR DESCRIPTION
Fixes #2292