### PR TITLE
Improve Variant handling of Durations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2.6.0 () -
 
+- TW #1654 "Due" parsing behaviour seems inconsistent
+           Thanks to Max Rossmannek.
 - TW #2004 "shell" should not be expand to "exec tasksh"
            Thanks to Arvedui
 - TW #2007 Compute number of current tasks correctly
@@ -24,6 +26,8 @@
 - TW #2389 For certain terminal widths, annotations with utf-8 chars can lead
            task to hang
            Thanks to arooni.
+- TW #2390 Regression: Relative dates should be implicitly anchored around 'now'
+           Thanks to Dominik Russo.
 
 ------ current release ---------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ New Features in Taskwarrior 2.6.0
   - Newer Unicode characters, such as emojis are correctly handled and displayed.
     Taskwarrior now supports all Unicode characters up to Unicode 11.
   - Datetime values until year 9999 are now supported.
+    Duration values of up to 1 000 000 years are now supported.
   - 64-bit numeric values (up to 9,223,372,036,854,775,807) are now supported.
   - Later/someday named datetime values now resolve to 9999-12-30 (instead of
     2038-01-18).

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1930,7 +1930,9 @@ void Variant::cast (const enum type new_type)
     case type_real:     _real = static_cast<double>(_date); break;
     case type_string:   _string = (std::string) *this;      break;
     case type_date:                                         break;
-    case type_duration: _duration = _date;                  break;
+    // TODO: Not exactly correct (should duration convert into date?), but
+    // currently needed for symmetry, which is assumed by operators.
+    case type_duration: _duration = _date - time (nullptr); break;
     }
     break;
 
@@ -1941,7 +1943,7 @@ void Variant::cast (const enum type new_type)
     case type_integer:  _integer = (long long) _duration;       break;
     case type_real:     _real = static_cast<double>(_duration); break;
     case type_string:   _string = (std::string) *this;          break;
-    case type_date:     _date = _duration;                      break;
+    case type_date:     _date = time (nullptr) + _duration;     break;
     case type_duration:                                         break;
     }
     break;

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1295,12 +1295,12 @@ Variant& Variant::operator-= (const Variant& other)
   case type_date:
     switch (right._type)
     {
-    case type_boolean:  right.cast (type_integer); _date -= right._integer;    break;
-    case type_integer:                             _date -= right._integer;    break;
-    case type_real:                                _date -= (int) right._real; break;
+    case type_boolean:  right.cast (type_integer);      _date -= right._integer;         break;
+    case type_integer:                                  _date -= right._integer;         break;
+    case type_real:                                     _date -= (int) right._real;      break;
     case type_string:   throw std::string (STRING_VARIANT_SUB_STRING);
-    case type_date:     cast (type_duration);      _duration -= right._date;   break;
-    case type_duration:                            _date -= right._duration;   break;
+    case type_date:     _type = Variant::type_duration; _duration = _date - right._date; break;
+    case type_duration:                                 _date -= right._duration;        break;
     }
     break;
 
@@ -1408,12 +1408,12 @@ Variant& Variant::operator+= (const Variant& other)
   case type_duration:
     switch (right._type)
     {
-    case type_boolean:  right.cast (type_duration); _duration += right._duration;   break;
-    case type_integer:                              _duration += right._integer;    break;
-    case type_real:                                 _duration += (int) right._real; break;
-    case type_string:   cast (type_string);         _string += right._string;       break;
-    case type_date:     cast (type_date);           _date += right._date;           break;
-    case type_duration:                             _duration += right._duration;   break;
+    case type_boolean:  right.cast (type_duration); _duration += right._duration;      break;
+    case type_integer:                              _duration += right._integer;       break;
+    case type_real:                                 _duration += (int) right._real;    break;
+    case type_string:   cast (type_string);         _string += right._string;          break;
+    case type_date:     _type = Variant::type_date; _date += right._date + _duration;  break;
+    case type_duration:                             _duration += right._duration;      break;
     }
     break;
   }

--- a/src/columns/ColTypeDate.cpp
+++ b/src/columns/ColTypeDate.cpp
@@ -222,14 +222,13 @@ void ColumnTypeDate::modify (Task& task, const std::string& value)
     evaluatedValue = Variant (value);
   }
 
-  // If v is duration, add 'now' to it, else store as date.
+  // If v is duration, we need to convert it to date (and implicitly add now),
+  // else store as date.
   std::string label = "  [1;37;43mMODIFICATION[0m ";
   if (evaluatedValue.type () == Variant::type_duration)
   {
     Context::getContext ().debug (label + _name + " <-- '" + format ("{1}", format (evaluatedValue.get_duration ())) + "' <-- '" + (std::string) evaluatedValue + "' <-- '" + value + '\'');
-    Datetime date_now;
-    Variant now (date_now.toEpoch (), Variant::type_date);
-    evaluatedValue += now;
+    evaluatedValue.cast (Variant::type_date);
   }
   else
   {

--- a/test/dependencies.t
+++ b/test/dependencies.t
@@ -231,7 +231,7 @@ class TestBug697(TestCase):
         self.assertEqual("BLOCKED\n", out)
 
 
-@unittest.skip("WaitingFor TW-1262")
+@unittest.expectedFailure("Waiting for TW-1262")
 class TestBug1262(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/filter.t
+++ b/test/filter.t
@@ -966,7 +966,6 @@ class TestBug1609(TestCase):
         self.assertIn("two", out)
 
 
-@unittest.expectedFailure
 class TestBug1630(TestCase):
     def setUp(self):
         """Executed before each test in the class"""
@@ -975,7 +974,6 @@ class TestBug1630(TestCase):
         self.t("add one due:7d")
         self.t("add two due:10d")
 
-    @unittest.expectedFailure
     def test_attribute_modifier_with_duration(self):
         """1630: Verify that 'due.before:9d' is correctly interpreted"""
         code, out, err = self.t("due.before:9d list rc.verbose:nothing")
@@ -983,7 +981,6 @@ class TestBug1630(TestCase):
         self.assertIn("one", out)
         self.assertNotIn("two", out)
 
-    @unittest.expectedFailure
     def test_attribute_no_modifier_with_duration(self):
         """1630: Verify that 'due:7d' is correctly interpreted"""
         code, out, err = self.t("due:7d list rc.verbose:nothing")

--- a/test/variant_cast.t.cpp
+++ b/test/variant_cast.t.cpp
@@ -36,6 +36,8 @@ int main (int, char**)
 {
   UnitTest t (81);
 
+  time_t now = time (nullptr);
+
   try
   {
     // Variant::type_boolean --> *
@@ -208,8 +210,10 @@ int main (int, char**)
 
     Variant v45 ((time_t) 1234567890, Variant::type_date);
     v45.cast (Variant::type_duration);
-    t.ok (v45.type () == Variant::type_duration, "cast date --> duration");
-    t.ok (v45.get_duration () == 1234567890,     "cast date --> duration");
+    t.ok (v45.type () == Variant::type_duration,        "cast date --> duration");
+    t.ok (v45.get_duration () <= 1234567890 - now,      "cast date --> duration");
+    // Assuming this unit test takes less than 10 min to execute
+    t.ok (v45.get_duration () > 1234567890 - now - 600, "cast date --> duration");
 
     // Variant::type_duration --> *
     Variant v50 ((time_t) 12345, Variant::type_duration);
@@ -235,12 +239,13 @@ int main (int, char**)
     Variant v54 ((time_t) 12345, Variant::type_duration);
     v54.cast (Variant::type_date);
     t.ok (v54.type () == Variant::type_date,    "cast duration --> date");
-    t.is (v54.get_date (), 12345,               "cast duration --> date");
+    t.ok (v54.get_date () >= 12345 + now,       "cast duration --> duration");
+    t.ok (v54.get_date () <  12345 + now + 600, "cast duration --> duration");
 
     Variant v55 ((time_t) 12345, Variant::type_duration);
     v55.cast (Variant::type_duration);
-    t.ok (v55.type () == Variant::type_duration, "cast duration --> duration");
-    t.ok (v55.get_duration () == 12345,          "cast duration --> duration");
+    t.ok (v55.type () == Variant::type_duration,    "cast duration --> duration");
+    t.is (v55.get_duration (), 12345,               "cast duration --> duration");
   }
 
   catch (const std::string& e)

--- a/test/variant_gt.t.cpp
+++ b/test/variant_gt.t.cpp
@@ -158,8 +158,10 @@ int main (int, char**)
   t.is (v44.get_bool (), false,             "1234567890 > 1234567890 --> false");
 
   Variant v45 = v4 > v5;
+  // 1234567890 corresponds to Fri Feb 13 06:31:30 PM EST 2009 hence 1200
+  // (evaluated as now+1200s) be in future for any date after 2009-02-13
   t.is (v45.type (), Variant::type_boolean, "1234567890 > 1200 --> boolean");
-  t.is (v45.get_bool (), true,              "1234567890 > 1200 --> true");
+  t.is (v45.get_bool (), false,             "1234567890 > 1200 --> false");
 
   Variant v50 = v5 > v0;
   t.is (v50.type (), Variant::type_boolean, "1200 > true --> boolean");
@@ -178,8 +180,9 @@ int main (int, char**)
   t.is (v53.get_bool (), true,              "1200 > 'foo' --> true");
 
   Variant v54 = v5 > v4;
+  // Same reasoning as v45
   t.is (v54.type (), Variant::type_boolean, "1200 > 1234567890 --> boolean");
-  t.is (v54.get_bool (), false,             "1200 > 1234567890 --> false");
+  t.is (v54.get_bool (), true,              "1200 > 1234567890 --> true");
 
   Variant v55 = v5 > v5;
   t.is (v55.type (), Variant::type_boolean, "1200 > 1200 --> boolean");

--- a/test/variant_gte.t.cpp
+++ b/test/variant_gte.t.cpp
@@ -158,8 +158,10 @@ int main (int, char**)
   t.is (v44.get_bool (), true,              "1234567890 >= 1234567890 --> true");
 
   Variant v45 = v4 >= v5;
+  // 1234567890 corresponds to Fri Feb 13 06:31:30 PM EST 2009 hence 1200
+  // (evaluated as now+1200s) be in future for any date after 2009-02-13
   t.is (v45.type (), Variant::type_boolean, "1234567890 >= 1200 --> boolean");
-  t.is (v45.get_bool (), true,              "1234567890 >= 1200 --> true");
+  t.is (v45.get_bool (), false,             "1234567890 >= 1200 --> false");
 
   Variant v50 = v5 >= v0;
   t.is (v50.type (), Variant::type_boolean, "1200 >= true --> boolean");
@@ -178,8 +180,9 @@ int main (int, char**)
   t.is (v53.get_bool (), true,              "1200 >= 'foo' --> true");
 
   Variant v54 = v5 >= v4;
+  // Same reasoning as v45
   t.is (v54.type (), Variant::type_boolean, "1200 >= 1234567890 --> boolean");
-  t.is (v54.get_bool (), false,             "1200 >= 1234567890 --> false");
+  t.is (v54.get_bool (), true,              "1200 >= 1234567890 --> true");
 
   Variant v55 = v5 >= v5;
   t.is (v55.type (), Variant::type_boolean, "1200 >= 1200 --> boolean");

--- a/test/variant_lt.t.cpp
+++ b/test/variant_lt.t.cpp
@@ -158,8 +158,10 @@ int main (int, char**)
   t.is (v44.get_bool (), false,             "1234567890 < 1234567890 --> false");
 
   Variant v45 = v4 < v5;
+  // 1234567890 corresponds to Fri Feb 13 06:31:30 PM EST 2009 hence 1200
+  // (evaluated as now+1200s) be in future for any date after 2009-02-13
   t.is (v45.type (), Variant::type_boolean, "1234567890 < 1200 --> boolean");
-  t.is (v45.get_bool (), false,             "1234567890 < 1200 --> false");
+  t.is (v45.get_bool (), true,              "1234567890 < 1200 --> true");
 
   Variant v50 = v5 < v0;
   t.is (v50.type (), Variant::type_boolean, "1200 < true --> boolean");
@@ -178,8 +180,9 @@ int main (int, char**)
   t.is (v53.get_bool (), false,             "1200 < 'foo' --> false");
 
   Variant v54 = v5 < v4;
+  // Same logic as v45.
   t.is (v54.type (), Variant::type_boolean, "1200 < 1234567890 --> boolean");
-  t.is (v54.get_bool (), true,              "1200 < 1234567890 --> true");
+  t.is (v54.get_bool (), false,             "1200 < 1234567890 --> false");
 
   Variant v55 = v5 < v5;
   t.is (v55.type (), Variant::type_boolean, "1200 < 1200 --> boolean");


### PR DESCRIPTION
This MR brings several improvements and fixes to the handling of Duration types in the Variant object:
* The relative duration values (such as `7d` or `P1M`) are anchored with respect to `now` during casting to `type_date`
* Durations can now be up to ~ 1 million years
* Tests are adjusted accordingly

Closes #1654, #2390.