### PR TITLE
Restrict Lexer's integer and number detection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,8 @@
            Thanks to arooni.
 - TW #2390 Regression: Relative dates should be implicitly anchored around 'now'
            Thanks to Dominik Russo.
+- TW #2392 Filtering for project-names containing hyphen and zero-leading number
+           Thanks to Nicola Chiapolini.
 
 ------ current release ---------------------------
 

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -687,16 +687,24 @@ bool Lexer::isNumber (std::string& token, Lexer::Type& type)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Lexer::Type::number
-//   \d+
+//   0
+//   [1-9]\d*
+//   Integers do not start with a leading 0, unless they are zero.
 bool Lexer::isInteger (std::string& token, Lexer::Type& type)
 {
   std::size_t marker = _cursor;
+
+  bool leading_zero = (_text[marker] == '0');
 
   if (unicodeLatinDigit (_text[marker]))
   {
     ++marker;
     while (unicodeLatinDigit (_text[marker]))
       utf8_next_char (_text, marker);
+
+    // Leading zero is only allowed in the case of number 0
+    if (leading_zero and marker - _cursor > 1)
+      return false;
 
     token = _text.substr (_cursor, marker - _cursor);
     type = Lexer::Type::number;

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -608,7 +608,8 @@ bool Lexer::isHexNumber (std::string& token, Lexer::Type& type)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Lexer::Type::number
-//   \d+
+//   0
+//   [1-9]\d*
 //   [ . \d+ ]
 //   [ e|E [ +|- ] \d+ [ . \d+ ] ]
 //   not followed by non-operator.
@@ -616,9 +617,16 @@ bool Lexer::isNumber (std::string& token, Lexer::Type& type)
 {
   std::size_t marker = _cursor;
 
+  bool leading_zero = (_text[marker] == '0');
+
   if (unicodeLatinDigit (_text[marker]))
   {
     ++marker;
+
+    // Two (or more) digit number with a leading zero are not allowed
+    if (leading_zero && unicodeLatinDigit (_text[marker]))
+      return false;
+
     while (unicodeLatinDigit (_text[marker]))
       utf8_next_char (_text, marker);
 

--- a/test/dependencies.t
+++ b/test/dependencies.t
@@ -231,7 +231,7 @@ class TestBug697(TestCase):
         self.assertEqual("BLOCKED\n", out)
 
 
-@unittest.expectedFailure("Waiting for TW-1262")
+@unittest.expectedFailure
 class TestBug1262(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/dependencies.t
+++ b/test/dependencies.t
@@ -26,6 +26,7 @@
 #
 ###############################################################################
 
+import string
 import sys
 import os
 import unittest
@@ -231,7 +232,6 @@ class TestBug697(TestCase):
         self.assertEqual("BLOCKED\n", out)
 
 
-@unittest.expectedFailure
 class TestBug1262(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -241,8 +241,9 @@ class TestBug1262(TestCase):
         cls.t('add "Buy apples"')
 
         cls.DEPS = ("1", "2")
-        cls.t("add dep:" + ",".join(cls.DEPS) + '"Make fruit salad!"')
+        cls.t("add dep:" + ",".join(cls.DEPS) + ' "Make fruit salad!"')
 
+    @unittest.skip  # Skipping due to undeterminism
     def test_dependency_contains_matches_ID(self):
         """1262: dep.contains matches task IDs"""
         # NOTE: A more robust test is needed as alternative to this
@@ -254,13 +255,14 @@ class TestBug1262(TestCase):
 
     def test_dependency_contains_not_matches_other(self):
         """1262: dep.contains matches other characters not present in ID nor UUID"""
-        for char in set(string.letters).difference(string.hexdigits):
+        for char in set(string.ascii_letters).difference(string.hexdigits):
             self.t.runError("list dep.contains:{0}".format(char))
 
+    @unittest.expectedFailure
     def test_dependency_contains_not_UUID(self):
         """1262: dep.contains matches characters in the tasks' UUIDs"""
         # Get the UUID of the task with description "Buy"
-        code, out, err = self.t("uuid Buy")
+        code, out, err = self.t("uuids Buy")
 
         # Get only characters that show up in the UUID
         uuid = {chr for chr in out.splitlines()[0] if chr in string.hexdigits}

--- a/test/tw-2392.t
+++ b/test/tw-2392.t
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+. bash_tap_tw.sh
+
+# This sets foo to "PT13H" despite it being a string UDA
+task add test project:c.vs.2021-01
+
+# Show the problem in TAP output
+task rc.debug.parser:3 project:c.vs.2021-01 _ids
+
+[[ `task project:c.vs.2021-01 _ids` == "1" ]]


### PR DESCRIPTION
Prevent zero-leading integers from matching.

Closes #2392.