### PR TITLE
CmdCalendar: Consider waiting due tasks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,8 @@
            Thanks to Dominik Russo.
 - TW #2392 Filtering for project-names containing hyphen and zero-leading number
            Thanks to Nicola Chiapolini.
+- TW #2393 Highlight due dates for waiting tasks in the calendar
+           Thanks to emkamau.
 
 ------ current release ---------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ New Features in Taskwarrior 2.6.0
   - 64-bit numeric values (up to 9,223,372,036,854,775,807) are now supported.
   - Later/someday named datetime values now resolve to 9999-12-30 (instead of
     2038-01-18).
+  - Calendar now supports displaying due dates until year 9999.
+  - Calendar now displays waiting tasks with due dates on the calendar.
 
 
 New Commands in Taskwarrior 2.6.0

--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -187,8 +187,12 @@ int CmdCalendar::execute (std::string& output)
         }
       }
     }
-    mFrom = oldest.month();
-    yFrom = oldest.year();
+
+    // Default to current month if no due date is present
+    if (oldest != Datetime (9999, 12, 31)) {
+      mFrom = oldest.month();
+      yFrom = oldest.year();
+    }
   }
 
   if (Context::getContext ().config.getBoolean ("calendar.offset"))

--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -172,7 +172,7 @@ int CmdCalendar::execute (std::string& output)
   if (getPendingDate == true)
   {
     // Find the oldest pending due date.
-    Datetime oldest (2037, 12, 31);
+    Datetime oldest (9999, 12, 31);
     for (auto& task : tasks)
     {
       auto status = task.getStatus ();

--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -175,7 +175,8 @@ int CmdCalendar::execute (std::string& output)
     Datetime oldest (2037, 12, 31);
     for (auto& task : tasks)
     {
-      if (task.getStatus () == Task::pending)
+      auto status = task.getStatus ();
+      if (status == Task::pending || status == Task::waiting)
       {
         if (task.has ("due") &&
             !task.hasTag ("nocal"))
@@ -562,8 +563,10 @@ std::string CmdCalendar::renderMonths (
           Context::getContext ().config.set ("due", 0);
           for (auto& task : all)
           {
-            if (task.getStatus () == Task::pending &&
-                !task.hasTag ("nocal")             &&
+            auto status = task.getStatus ();
+            if ((status == Task::pending ||
+                 status == Task::waiting ) &&
+                !task.hasTag ("nocal")     &&
                 task.has ("due"))
             {
               std::string due = task.get ("due");


### PR DESCRIPTION
The purpose of displaying due dates on the calendar is to convey the relative business of any given day. Waiting status signifies a task should not be displayed in reports yet, but for the purposes of planning, it should be displayed in the calendar overview.

Additionally improves calendar range and defaults.
    
Closes #2393.