### PR TITLE
Bash paths correctly dereferenced to account for spaces

### DIFF
--- a/scripts/bash/task.sh
+++ b/scripts/bash/task.sh
@@ -50,14 +50,16 @@
 #
 ################################################################################
 #the following variable is substituted for by ../../test/bash_completion.t
-taskcommand='task rc.verbose:nothing rc.confirmation:no rc.hooks:off'
+taskbin='task'
+taskrc=''
+taskcommand="rc.verbose:nothing rc.confirmation:no rc.hooks:off ${taskrc}"
 
 _task_get_tags() {
-    $taskcommand _tags
+    "$taskbin" $taskcommand _tags
 }
 
 _task_get_config() {
-    $taskcommand _config
+    "$taskbin" $taskcommand _config
 }
 
 _task_offer_priorities() {
@@ -65,14 +67,14 @@ _task_offer_priorities() {
 }
 
 _task_offer_projects() {
-    COMPREPLY=( $(compgen -W "$($taskcommand _projects)" -- ${cur/*:/}) )
+    COMPREPLY=( $(compgen -W "$("$taskbin" $taskcommand _projects)" -- ${cur/*:/}) )
 }
 
 _task_offer_contexts() {
-    COMPREPLY=( $(compgen -W "$($taskcommand _context) define delete list none show" -- $cur) )
+    COMPREPLY=( $(compgen -W "$("$taskbin" $taskcommand _context) define delete list none show" -- $cur) )
 }
 
-_task_context_alias=$($taskcommand show | grep 'alias.*context' | cut -d' ' -f1 | cut -d. -f2)
+_task_context_alias=$("$taskbin" $taskcommand show | grep 'alias.*context' | cut -d' ' -f1 | cut -d. -f2)
 
 _task()
 {
@@ -92,9 +94,9 @@ _task()
 #   echo "prev='$prev'"
 #   echo "prev2='$prev2'"
 
-    abbrev_min=$($taskcommand show | grep "abbreviation.minimum" | awk {'print  $2'})
-    commands_aliases=$(echo $($taskcommand _commands; $taskcommand _aliases) | tr " " "\n"|sort|tr "\n" " ")
-    opts="$commands_aliases $($taskcommand _columns)"
+    abbrev_min=$("$taskbin" $taskcommand show | grep "abbreviation.minimum" | awk {'print  $2'})
+    commands_aliases=$(echo $("$taskbin" $taskcommand _commands; "$taskbin" $taskcommand _aliases) | tr " " "\n"|sort|tr "\n" " ")
+    opts="$commands_aliases $("$taskbin" $taskcommand _columns)"
 
     case "${prev}" in
         $_task_context_alias|cont|conte|contex|context)

--- a/test/bash_completion.t
+++ b/test/bash_completion.t
@@ -60,8 +60,10 @@ def prepare_tasksh(t):
         for line in fh:
             line = line.rstrip()
 
-            if line == "taskcommand='task rc.verbose:nothing rc.confirmation:no rc.hooks:off'":
-                line = "taskcommand='{0} rc.verbose:nothing rc.confirmation:no rc.hooks:off rc:{1}'".format(t.taskw, t.taskrc)
+            if line == "taskbin='task'":
+                line = "taskbin='{0}'".format(t.taskw)
+            if line == "taskrc=''":
+                line = "taskrc='rc:{0}'".format(t.taskrc)
 
             tasksh.append(line)
 

--- a/test/bash_tap_tw.sh
+++ b/test/bash_tap_tw.sh
@@ -35,7 +35,7 @@ function find_task_binary {
     for t in "${bashtap_org_pwd}/task" "${bashtap_org_pwd}/src/task" "${bashtap_org_pwd}/../task" "${bashtap_org_pwd}/../src/task" "${bashtap_org_pwd}/../build/src/task"; do
         if [ -f "$t" ] && [ -x "$t" ]; then
             t_abs=$(bashtap_get_absolute_path "$t")
-            eval "function task { ${t_abs} rc:taskrc \"\$@\"; }"
+            eval "function task { '${t_abs}' rc:taskrc \"\$@\"; }"
             return 0
         fi
     done


### PR DESCRIPTION
#### Description
Previously, if the path of the repo had spaces in it (eg "~/Documents/Open Source/taskwarrior"), some of the test scripts would fail. This was due to the bash variables representing the binary not being correctly dereferenced as strings, which lead to bash interpreting the path as two arguments instead of one. The affected scripts have been updated to treat the binary as a string and should operate correctly regardless of special characters in the path.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

The version test is currently failing upstream of my changes.

Failed:                        
version.t                           1

Unexpected successes:          

Skipped:                       
dependencies.t                      1
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:             
dependencies.t                      3
filter.t                            2
hyphenate.t                         1
lexer.t                             4
project.t                           1
quotes.t                            1
search.t                            1
