### PR TITLE
build: make sure internal libs are built as static

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src/libshared/src
                      ${TASK_INCLUDE_DIRS})
 
-add_library (task CLI2.cpp CLI2.h
+add_library (task STATIC CLI2.cpp CLI2.h
                   Context.cpp Context.h
                   DOM.cpp DOM.h
                   Eval.cpp Eval.h
@@ -28,7 +28,7 @@ add_library (task CLI2.cpp CLI2.h
                   sort.cpp
                   util.cpp util.h)
 
-add_library (libshared libshared/src/Color.cpp         libshared/src/Color.h
+add_library (libshared STATIC libshared/src/Color.cpp         libshared/src/Color.h
                        libshared/src/Configuration.cpp libshared/src/Configuration.h
                        libshared/src/Datetime.cpp      libshared/src/Datetime.h
                        libshared/src/Duration.cpp      libshared/src/Duration.h


### PR DESCRIPTION
these libararies are not installed so don't leave the decision up to
enviroment which might build shared libraries resulting in binary
with missing deps after installation

Fixes #2403