### PR TITLE
Implement expected failures for bash tap tests

### DIFF
--- a/test/bash_tap.sh
+++ b/test/bash_tap.sh
@@ -7,7 +7,14 @@ function bashtap_on_error {
     # A command in the parent script failed, interpret this as a test failure.
     # $bashtap_line contains the last executed line, or an error.
     echo -n "$bashtap_output"
-    echo "not ok 1 - ${bashtap_line}"
+
+    # Determine if this failure was expected
+    if [[ ! -z "$EXPFAIL" ]]
+    then
+        todo_suffix=" # TODO"
+    fi
+
+    echo "not ok 1 - ${bashtap_line}${todo_suffix}"
     bashtap_clean_tmpdir
 }
 

--- a/test/tw-2124.t
+++ b/test/tw-2124.t
@@ -1,0 +1,15 @@
+#!/bin/bash
+# A test case for TW-2124.
+# https://github.com/GothenburgBitFactory/taskwarrior/issues/2124
+
+. bash_tap_tw.sh
+
+# Filtering for description with a dash works
+task add foo-bar
+task foo-bar list | grep foo-bar
+
+# Filtering for tag with dash does not work right now
+export EXPFAIL=true
+
+task add test +one-two
+task +one-two list


### PR DESCRIPTION
Bash-tap tests can now run in expected-failure mode, which means writing a test case for a feature that is currently failing, is as simple as:

```
#!/bin/bash
. bash_tap_tw.sh

# Filtering for tag with dash does not work right now
export EXPFAIL=true

task add test +one-two
task +one-two list
```

A test for TW #2124 is added as demonstration.