### PR TITLE
clang-tidy: use raw string literals

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -992,7 +992,7 @@ void TDB2::revert_backlog (
   const std::string& current,
   const std::string& prior)
 {
-  std::string uuid_att = "\"uuid\":\"" + uuid + '"';
+  std::string uuid_att = R"("uuid":")" + uuid + '"';
 
   bool found = false;
   for (auto task = b.rbegin (); task != b.rend (); ++task)

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1010,9 +1010,9 @@ std::string Task::composeJSON (bool decorate /*= false*/) const
           out << ',';
 
         Datetime d (i.first.substr (11));
-        out << "{\"entry\":\""
+        out << R"({"entry":")"
             << d.toISO ()
-            << "\",\"description\":\""
+            << R"(","description":")"
             << json::encode (i.second)
             << "\"}";
 

--- a/test/lexer.t.cpp
+++ b/test/lexer.t.cpp
@@ -99,7 +99,7 @@ int main (int, char**)
   t.notok (l1.token (token, type), "'       \\t ' --> no tokens");
 
   // \u20ac = Euro symbol.
-  Lexer l2 (" one 'two \\'three\\''+456-(1.3*2 - 0x12) 1.2e-3.4    foo.bar and '\\u20ac'");
+  Lexer l2 (R"( one 'two \'three\''+456-(1.3*2 - 0x12) 1.2e-3.4    foo.bar and '\u20ac')");
 
   tokens.clear ();
   while (l2.token (token, type))
@@ -246,13 +246,13 @@ int main (int, char**)
 
   std::string text = "one 'two' three\\ four";
   cursor = 0;
-  t.ok (Lexer::readWord (text, cursor, word),               "readWord \"one 'two' three\\ four\" --> true");
+  t.ok (Lexer::readWord (text, cursor, word),               R"(readWord "one 'two' three\ four" --> true)");
   t.is (word, "one",                                        "  word '" + word + "'");
   cursor++;
-  t.ok (Lexer::readWord (text, cursor, word),               "readWord \"one 'two' three\\ four\" --> true");
+  t.ok (Lexer::readWord (text, cursor, word),               R"(readWord "one 'two' three\ four" --> true)");
   t.is (word, "'two'",                                      "  word '" + word + "'");
   cursor++;
-  t.ok (Lexer::readWord (text, cursor, word),               "readWord \"one 'two' three\\ four\" --> true");
+  t.ok (Lexer::readWord (text, cursor, word),               R"(readWord "one 'two' three\ four" --> true)");
   t.is (word, "three four",                                 "  word '" + word + "'");
 
   text = "one     ";
@@ -356,9 +356,9 @@ int main (int, char**)
     { "'one two'",                                    { { "'one two'",                                    Lexer::Type::string                  }, NO, NO, NO, NO }, },
     { "\"three\"",                                    { { "\"three\"",                                    Lexer::Type::string                  }, NO, NO, NO, NO }, },
     { "'\\''",                                        { { "'''",                                          Lexer::Type::string                  }, NO, NO, NO, NO }, },
-    { "\"\\\"\"",                                     { { "\"\"\"",                                       Lexer::Type::string                  }, NO, NO, NO, NO }, },
+    { R"("\"")",                                     { { R"(""")",                                       Lexer::Type::string                  }, NO, NO, NO, NO }, },
     { "\"\tfoo\t\"",                                  { { "\"\tfoo\t\"",                                  Lexer::Type::string                  }, NO, NO, NO, NO }, },
-    { "\"\\u20A43\"",                                 { { "\"₤3\"",                                       Lexer::Type::string                  }, NO, NO, NO, NO }, },
+    { R"("\u20A43")",                                 { { "\"₤3\"",                                       Lexer::Type::string                  }, NO, NO, NO, NO }, },
     { "\"U+20AC4\"",                                  { { "\"€4\"",                                       Lexer::Type::string                  }, NO, NO, NO, NO }, },
 
     // Number
@@ -574,8 +574,8 @@ int main (int, char**)
   t.is (Lexer::trimLeft ("",              " \t"), "",            "Lexer::trimLeft '' -> ''");
   t.is (Lexer::trimLeft ("xxx"),                  "xxx",         "Lexer::trimLeft 'xxx' -> 'xxx'");
   t.is (Lexer::trimLeft ("xxx",           " \t"), "xxx",         "Lexer::trimLeft 'xxx' -> 'xxx'");
-  t.is (Lexer::trimLeft ("  \t xxx \t  "),        "\t xxx \t  ", "Lexer::trimLeft '  \\t xxx \\t  ' -> '\\t xxx \\t  '");
-  t.is (Lexer::trimLeft ("  \t xxx \t  ", " \t"), "xxx \t  ",    "Lexer::trimLeft '  \\t xxx \\t  ' -> 'xxx \\t  '");
+  t.is (Lexer::trimLeft ("  \t xxx \t  "),        "\t xxx \t  ", R"(Lexer::trimLeft '  \t xxx \t  ' -> '\t xxx \t  ')");
+  t.is (Lexer::trimLeft ("  \t xxx \t  ", " \t"), "xxx \t  ",    R"(Lexer::trimLeft '  \t xxx \t  ' -> 'xxx \t  ')");
 
   // std::string Lexer::trimRight (const std::string& in, const std::string& t /*= " "*/)
   t.is (Lexer::trimRight (""),                     "",            "Lexer::trimRight '' -> ''");
@@ -583,8 +583,8 @@ int main (int, char**)
   t.is (Lexer::trimRight ("",              " \t"), "",            "Lexer::trimRight '' -> ''");
   t.is (Lexer::trimRight ("xxx"),                  "xxx",         "Lexer::trimRight 'xxx' -> 'xxx'");
   t.is (Lexer::trimRight ("xxx",           " \t"), "xxx",         "Lexer::trimRight 'xxx' -> 'xxx'");
-  t.is (Lexer::trimRight ("  \t xxx \t  "),        "  \t xxx \t", "Lexer::trimRight '  \\t xxx \\t  ' -> '  \\t xxx \\t'");
-  t.is (Lexer::trimRight ("  \t xxx \t  ", " \t"), "  \t xxx",    "Lexer::trimRight '  \\t xxx \\t  ' -> '  \\t xxx'");
+  t.is (Lexer::trimRight ("  \t xxx \t  "),        "  \t xxx \t", R"(Lexer::trimRight '  \t xxx \t  ' -> '  \t xxx \t')");
+  t.is (Lexer::trimRight ("  \t xxx \t  ", " \t"), "  \t xxx",    R"(Lexer::trimRight '  \t xxx \t  ' -> '  \t xxx')");
 
   // std::string Lexer::trim (const std::string& in, const std::string& t /*= " "*/)
   t.is (Lexer::trim (""),                     "",          "Lexer::trim '' -> ''");
@@ -592,7 +592,7 @@ int main (int, char**)
   t.is (Lexer::trim ("",              " \t"), "",          "Lexer::trim '' -> ''");
   t.is (Lexer::trim ("xxx"),                  "xxx",       "Lexer::trim 'xxx' -> 'xxx'");
   t.is (Lexer::trim ("xxx",           " \t"), "xxx",       "Lexer::trim 'xxx' -> 'xxx'");
-  t.is (Lexer::trim ("  \t xxx \t  "),        "\t xxx \t", "Lexer::trim '  \\t xxx \\t  ' -> '\\t xxx \\t'");
+  t.is (Lexer::trim ("  \t xxx \t  "),        "\t xxx \t", R"(Lexer::trim '  \t xxx \t  ' -> '\t xxx \t')");
   t.is (Lexer::trim ("  \t xxx \t  ", " \t"), "xxx",       "Lexer::trim '  \\t xxx \\t  ' -> 'xxx'");
 
   return 0;

--- a/test/t.t.cpp
+++ b/test/t.t.cpp
@@ -180,9 +180,9 @@ TODO Task::decode
 
   // [one:two three:four]
   good = true;
-  try {task = Task ("[one:\"two\" three:\"four\"]");}
+  try {task = Task (R"([one:"two" three:"four"])");}
   catch (const std::string& e){test.diag (e); good = false;}
-  test.ok (good, "Task::Task ('[one:\"two\" three:\"four\"]')");
+  test.ok (good, R"(Task::Task ('[one:"two" three:"four"]'))");
   test.is (task.get ("one"), "two", "one=two");
   test.is (task.get ("three"), "four", "three=four");
 
@@ -197,12 +197,12 @@ TODO Task::decode
 
   // Task::get_int
   task.set ("one", 1);
-  test.is (task.composeF4 (), "[name:\"value\" one:\"1\"]", "Task::set");
+  test.is (task.composeF4 (), R"([name:"value" one:"1"])", "Task::set");
   test.is (task.get_int ("one"), 1, "Task::get_int");
 
   // Task::get_ulong
   task.set ("two", "4294967295");
-  test.is (task.composeF4 (), "[name:\"value\" one:\"1\" two:\"4294967295\"]", "Task::set");
+  test.is (task.composeF4 (), R"([name:"value" one:"1" two:"4294967295"])", "Task::set");
   test.is ((size_t)task.get_ulong ("two"), (size_t)4294967295UL, "Task::get_ulong");
 
   // Task::remove
@@ -226,7 +226,7 @@ TODO Task::decode
   test.ok (good, "Task::Task ('{}')");
 
   good = true;
-  try {Task t5 ("{\"uuid\":\"00000000-0000-0000-000000000001\",\"description\":\"foo\",\"entry\":\"1234567890\"}");}
+  try {Task t5 (R"({"uuid":"00000000-0000-0000-000000000001","description":"foo","entry":"1234567890"})");}
   catch (const std::string& e){test.diag (e); good = false;}
   test.ok (good, "Task::Task ('{<minimal>}')");
 
@@ -235,20 +235,20 @@ TODO Task::decode
   t6.set ("entry", "20130602T224000Z");
   t6.set ("description", "DESC");
   t6.addTag ("tag1");
-  test.is (t6.composeF4 (), "[description:\"DESC\" entry:\"20130602T224000Z\" tags:\"tag1\"]", "F4 good");
-  test.is (t6.composeJSON (), "{\"description\":\"DESC\",\"entry\":\"20130602T224000Z\",\"tags\":[\"tag1\"]}", "JSON good");
+  test.is (t6.composeF4 (), R"([description:"DESC" entry:"20130602T224000Z" tags:"tag1"])", "F4 good");
+  test.is (t6.composeJSON (), R"({"description":"DESC","entry":"20130602T224000Z","tags":["tag1"]})", "JSON good");
 
   t6.addTag ("tag2");
-  test.is (t6.composeF4 (), "[description:\"DESC\" entry:\"20130602T224000Z\" tags:\"tag1,tag2\"]", "F4 good");
-  test.is (t6.composeJSON (), "{\"description\":\"DESC\",\"entry\":\"20130602T224000Z\",\"tags\":[\"tag1\",\"tag2\"]}", "JSON good");
+  test.is (t6.composeF4 (), R"([description:"DESC" entry:"20130602T224000Z" tags:"tag1,tag2"])", "F4 good");
+  test.is (t6.composeJSON (), R"({"description":"DESC","entry":"20130602T224000Z","tags":["tag1","tag2"]})", "JSON good");
 
   good = true;
   Task t7;
-  try {t7 = Task ("{\"description\":\"DESC\",\"entry\":\"20130602T224000Z\",\"tags\":[\"tag1\",\"tag2\"]}");}
+  try {t7 = Task (R"({"description":"DESC","entry":"20130602T224000Z","tags":["tag1","tag2"]})");}
   catch (const std::string& e){test.diag (e); good = false;}
   test.ok (good, "Task::Task ('{two tags}')");
-  test.is (t7.composeF4 (), "[description:\"DESC\" entry:\"1370212800\" tags:\"tag1,tag2\"]", "F4 good");
-  test.is (t7.composeJSON (), "{\"description\":\"DESC\",\"entry\":\"20130602T224000Z\",\"tags\":[\"tag1\",\"tag2\"]}", "JSON good");
+  test.is (t7.composeF4 (), R"([description:"DESC" entry:"1370212800" tags:"tag1,tag2"])", "F4 good");
+  test.is (t7.composeJSON (), R"({"description":"DESC","entry":"20130602T224000Z","tags":["tag1","tag2"]})", "JSON good");
 
   return 0;
 }

--- a/test/tdb2.t.cpp
+++ b/test/tdb2.t.cpp
@@ -69,7 +69,7 @@ int main (int, char**)
     t.is ((int) backlog.size (),   0, "TDB2 Read empty backlog");
 
     // Add a task.
-    Task task ("[description:\"description\" name:\"value\"]");
+    Task task (R"([description:"description" name:"value"])");
     context.tdb2.add (task);
 
     pending   = context.tdb2.pending.get_tasks ();


### PR DESCRIPTION
Found with modernize-raw-string-literals

Signed-off-by: Rosen Penev <rosenp@gmail.com>

- [x] Have you run the test suite?

```
Passed:                          3789
Failed:                             0
Unexpected successes:               0
Skipped:                           12
Expected failures:                 13
Runtime:                        38.38 seconds
[100%] Built target test
```
