### PR TITLE
Change nagging behavior

### DIFF
--- a/src/commands/CmdDone.cpp
+++ b/src/commands/CmdDone.cpp
@@ -68,7 +68,7 @@ int CmdDone::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
-  auto nagged = false;
+  Task& lowest = filtered.front();
   for (auto& task : filtered)
   {
     Task before (task);
@@ -101,8 +101,8 @@ int CmdDone::execute (std::string&)
         ++count;
         feedback_affected ("Completed task {1} '{2}'.", task);
         feedback_unblocked (task);
-        if (!nagged)
-          nagged = nag (task);
+        if (task.urgency () < lowest.urgency ())
+          lowest = task;
         dependencyChainOnComplete (task);
         if (Context::getContext ().verbose ("project"))
           projectChanges[task.get ("project")] = onProjectChange (task);
@@ -124,7 +124,9 @@ int CmdDone::execute (std::string&)
       rc = 1;
     }
   }
-
+  
+  nag(lowest);
+  
   // Now list the project changes.
   for (const auto& change : projectChanges)
     if (change.first != "")


### PR DESCRIPTION
#### Description

The behaviour for batch-completing tasks irritated me, because task nagged every time there were more than one task was completed.

This PR fixes this and makes the done command a little faster because nag is only called once.

#### Additional information...

- [x] Have you run the test suite?
  Output of ```cd test && ./problems```:
```
Failed:
feature.default.project.t           1
template.t                          3
tw-1999.t                           1
version.t                           1

Unexpected successes:

Skipped:
export.t                            1
feature.default.project.t           3
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
template.t                          2
tw-1999.t                           1
wait.t                              1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
template.t                          1
tw-2124.t                           1
```