### PR TITLE
CmdEdit: Respect bulk option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,8 @@
            Thanks to Nicola Chiapolini.
 - TW #2393 Highlight due dates for waiting tasks in the calendar
            Thanks to emkamau.
+- TW #2428 The "edit" command should respect "bulk" configuration option
+           Thanks to Evan Edmond.
 
 ------ current release ---------------------------
 

--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -88,6 +88,14 @@ int CmdEdit::execute (std::string&)
     return 1;
   }
 
+  unsigned int bulk = Context::getContext ().config.getInteger ("bulk");
+
+  // If we are editing more than "bulk" tasks, ask for confirmation.
+  // Bulk = 0 denotes infinite bulk.
+  if ((filtered.size () > bulk) && (bulk != 0))
+    if (! confirm (format ("Do you wish to manually edit {1} tasks?", filtered.size ())))
+      return 2;
+
   // Find number of matching tasks.
   for (auto& task : filtered)
   {


### PR DESCRIPTION
Since 'task edit' is a data-modification operation (that is particularly hard to cancel mid-way), it should also respect the 'bulk' option like all the other modification operations (mod, start...).
    
Closes #2428.
