### PR TITLE
Parse 'context' verbose token correctly

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1029,6 +1029,7 @@ bool Context::verbose (const std::string& token)
           v != "filter"   &&  //
           v != "unwait"   &&  //
           v != "override" &&  //
+          v != "context" &&  //
           v != "recur")       //
       {
         // This list emulates rc.verbose=off in version 1.9.4.


### PR DESCRIPTION
`context` was not included among the possible verbosity tokens, resulting into the `verbose` setting being incorrectly set to `off` in some cases.