### PR TITLE
Desugar plain arguments of Lexer::type::date type

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -49,6 +49,8 @@
 - TW #2442 Bulk completions generate nagging message even if highest urgency
            task was completed
            Thanks to Daniel Mowitz.
+- TW #2451 Command task $month doesn't behave correctly
+           Thanks to Matias Laporte.
 
 ------ current release ---------------------------
 

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -1884,6 +1884,7 @@ void CLI2::lexFilterArgs ()
 //     - neither argX nor argY are an operator, except (, ), and, or, xor
 //     - candidate is one of: Lexer::Type::word
 //                            Lexer::Type::identifier
+//                            Lexer::Type::date
 //
 void CLI2::desugarFilterPlainArgs ()
 {
@@ -1905,6 +1906,7 @@ void CLI2::desugarFilterPlainArgs ()
          ppraw == "xor")                           &&
 
         (prev->_lextype == Lexer::Type::identifier ||  // candidate
+         prev->_lextype == Lexer::Type::date       ||  // candidate
          prev->_lextype == Lexer::Type::word)      &&  // candidate
 
         prev->hasTag ("FILTER")                    &&  // candidate

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -1882,7 +1882,8 @@ void CLI2::lexFilterArgs ()
 //     - task ... argX candidate argY
 //   Where:
 //     - neither argX nor argY are an operator, except (, ), and, or, xor
-//     - candidate is Lexer::Type::word
+//     - candidate is one of: Lexer::Type::word
+//                            Lexer::Type::identifier
 //
 void CLI2::desugarFilterPlainArgs ()
 {

--- a/test/tw-2451.t
+++ b/test/tw-2451.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+. bash_tap_tw.sh
+
+# Setup the tasks
+task add Participate in the marine search
+task add Find the pearls
+
+# Search for tasks containing "mar"
+task mar
+task mar count
+[[ `task mar count` == 1 ]]


### PR DESCRIPTION
This ensures that substrings of named dates can be used as search strings for description field.

Closes #2451.