### PR TITLE
ci: Re-enable testing on Arch Linux

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,9 @@ jobs:
           - name: "OpenSUSE 15.0"
             runner: ubuntu-latest
             dockerfile: opensuse1500
+          - name: "Archlinux Base (Rolling)"
+            runner: ubuntu-latest
+            dockerfile: arch
           - name: "Mac OS X 10.13"
             runner: macos-latest
             dockerfile: osx


### PR DESCRIPTION
This reverts commit 17ab0dfcf4b3bdfa1d710891b00e347b9841ec75.
    
The underlying issue with the Arch Linux was fixed, see references in the above commit for more details.
