### PR TITLE
Support relative include for themes in taskrc

### DIFF
--- a/doc/man/task-color.5.in
+++ b/doc/man/task-color.5.in
@@ -236,11 +236,10 @@ include other files into the .taskrc file, different sets of color rules can
 be included.
 
 To get a good idea of what a color theme looks like, try adding this entry to
-your .taskrc file (note that your installation may use a slightly different path
-from the example):
+your .taskrc file:
 
 .RS
-include ${CMAKE_INSTALL_PREFIX}/${TASK_RCDIR}/dark-256.theme
+include dark-256.theme
 .RE
 
 You can use any of the standard Taskwarrior themes:

--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -85,7 +85,8 @@ include <file>
 
 There may be whitespace around 'include' and <file>. The file may be an
 absolute or relative path, and the special character '~' is expanded to mean
-$HOME.
+$HOME. If relative path is specified, it will be searched in installation
+directory of configuration files, which contains themes.
 The entry must be on a single line, no continuations.
 
 .RS
@@ -152,9 +153,9 @@ ones containing just the relevant configuration data like colors, etc.
 There are two excellent uses of includes in your .taskrc, shown here:
 
 .RS
-include ${CMAKE_INSTALL_PREFIX}/${TASK_RCDIR}/holidays.en-US.rc
+include holidays.en-US.rc
 .br
-include ${CMAKE_INSTALL_PREFIX}/${TASK_RCDIR}/dark-16.theme
+include dark-16.theme
 .RE
 
 This includes two standard files that are distributed with Taskwarrior, which
@@ -818,7 +819,7 @@ be included like this:
 .RS
 .RS
 .br
-include ${CMAKE_INSTALL_PREFIX}/${TASK_RCDIR}/holidays.en-US.rc
+include holidays.en-US.rc
 .RE
 .RE
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -440,6 +440,8 @@ int Context::initialize (int argc, const char** argv)
   int rc = 0;
   home_dir = getenv ("HOME");
 
+  std::vector <std::string> searchPaths { TASK_RCDIR };
+
   try
   {
     ////////////////////////////////////////////////////////////////////////////
@@ -494,8 +496,8 @@ int Context::initialize (int argc, const char** argv)
     // Artificial scope for timing purposes.
     {
       Timer timer;
-      config.parse (configurationDefaults);
-      config.load (rc_file._data);
+      config.parse (configurationDefaults, 1, searchPaths);
+      config.load (rc_file._data, 1, searchPaths);
       debugTiming (format ("Config::load ({1})", rc_file._data), timer);
     }
 
@@ -1191,20 +1193,20 @@ void Context::createDefaultConfig ()
              << "\n#data.location=~/.local/share/task\n"
              << "#hooks.location=~/.config/task/hooks\n"
              << "\n# Color theme (uncomment one to use)\n"
-             << "#include " << TASK_RCDIR << "/light-16.theme\n"
-             << "#include " << TASK_RCDIR << "/light-256.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-16.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-256.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-red-256.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-green-256.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-blue-256.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-violets-256.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-yellow-green.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-gray-256.theme\n"
-             << "#include " << TASK_RCDIR << "/dark-gray-blue-256.theme\n"
-             << "#include " << TASK_RCDIR << "/solarized-dark-256.theme\n"
-             << "#include " << TASK_RCDIR << "/solarized-light-256.theme\n"
-             << "#include " << TASK_RCDIR << "/no-color.theme\n"
+             << "#include light-16.theme\n"
+             << "#include light-256.theme\n"
+             << "#include dark-16.theme\n"
+             << "#include dark-256.theme\n"
+             << "#include dark-red-256.theme\n"
+             << "#include dark-green-256.theme\n"
+             << "#include dark-blue-256.theme\n"
+             << "#include dark-violets-256.theme\n"
+             << "#include dark-yellow-green.theme\n"
+             << "#include dark-gray-256.theme\n"
+             << "#include dark-gray-blue-256.theme\n"
+             << "#include solarized-dark-256.theme\n"
+             << "#include solarized-light-256.theme\n"
+             << "#include no-color.theme\n"
              << '\n';
 
     // Write out the new file.


### PR DESCRIPTION
#### Description

Support relative include for themes in taskrc. Fix #1847.
This is required for package manager like nix, which installs different version of a package to different paths. We need to keep paths of `include` in taskrc to be always valid between updates.

This PR depends on https://github.com/GothenburgBitFactory/libshared/pull/38 to be merged.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

  All tests passed.