### PR TITLE
clang-tidy: use '' for single character find

### DIFF
--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -1533,7 +1533,7 @@ void CLI2::findIDs ()
           for (auto& element : elements)
           {
             changes = true;
-            auto hyphen = element.find ("-");
+            auto hyphen = element.find ('-');
             if (hyphen != std::string::npos)
               _id_ranges.push_back (std::pair <std::string, std::string> (element.substr (0, hyphen), element.substr (hyphen + 1)));
             else
@@ -1588,7 +1588,7 @@ void CLI2::findIDs ()
             for (const auto& element : elements)
             {
               changes = true;
-              auto hyphen = element.find ("-");
+              auto hyphen = element.find ('-');
               if (hyphen != std::string::npos)
                 _id_ranges.push_back (std::pair <std::string, std::string> (element.substr (0, hyphen), element.substr (hyphen + 1)));
               else

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -1689,7 +1689,7 @@ bool Lexer::decomposeSubstitution (
     if (readWord (text, "/", cursor, parsed_to))
     {
       std::string parsed_flags = text.substr (cursor);
-      if (parsed_flags.find ("/") == std::string::npos)
+      if (parsed_flags.find ('/') == std::string::npos)
       {
         dequote (parsed_from, "/");
         dequote (parsed_to,   "/");
@@ -1718,7 +1718,7 @@ bool Lexer::decomposePattern (
       ignored.length ())
   {
     auto parsed_flags = text.substr (cursor);
-    if (parsed_flags.find ("/") == std::string::npos)
+    if (parsed_flags.find ('/') == std::string::npos)
     {
       flags   = parsed_flags;
       pattern = text.substr (1, cursor - 2 - flags.length ());

--- a/src/ViewTask.cpp
+++ b/src/ViewTask.cpp
@@ -279,7 +279,7 @@ std::string ViewTask::render (std::vector <Task>& data, std::vector <int>& seque
     out += extra;
 
     // Trim right.
-    out.erase (out.find_last_not_of (" ") + 1);
+    out.erase (out.find_last_not_of (' ') + 1);
     out += "\n";
 
     // Stop if the line limit is exceeded.
@@ -365,7 +365,7 @@ std::string ViewTask::render (std::vector <Task>& data, std::vector <int>& seque
       out += (odd ? extra_odd : extra_even);
 
       // Trim right.
-      out.erase (out.find_last_not_of (" ") + 1);
+      out.erase (out.find_last_not_of (' ') + 1);
       out += "\n";
 
       // Stop if the line limit is exceeded.

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -500,7 +500,7 @@ int CmdInfo::execute (std::string& output)
           if (end != std::string::npos)
           {
             auto uda = var.first.substr (12, end - 12);
-            auto dot = uda.find (".");
+            auto dot = uda.find ('.');
             if (dot == std::string::npos)
             {
               // urgency.uda.<name>.coefficient


### PR DESCRIPTION
Found with performance-faster-string-find

Signed-off-by: Rosen Penev <rosenp@gmail.com>

#### Additional information...

- [x ] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.


```
Failed:

Unexpected successes:

Skipped:
dependencies.t                      1
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
```