### PR TITLE
clang-tidy: add missing reserve calls

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -196,6 +196,7 @@ void Hooks::onExit () const
 
     // Convert to a vector of strings.
     std::vector <std::string> input;
+    input.reserve(tasks.size());
     for (auto& t : tasks)
       input.push_back (t.composeJSON ());
 

--- a/src/columns/ColDepends.cpp
+++ b/src/columns/ColDepends.cpp
@@ -87,6 +87,7 @@ void ColumnDepends::measure (Task& task, unsigned int& minimum, unsigned int& ma
       auto blocking = dependencyGetBlocking (task);
 
       std::vector <int> blocking_ids;
+      blocking_ids.reserve(blocking.size());
       for (auto& i : blocking)
         blocking_ids.push_back (i.id);
 
@@ -129,6 +130,7 @@ void ColumnDepends::render (
       auto blocking = dependencyGetBlocking (task);
 
       std::vector <int> blocking_ids;
+      blocking_ids.reserve(blocking.size());
       for (const auto& t : blocking)
         blocking_ids.push_back (t.id);
 

--- a/src/commands/CmdIDs.cpp
+++ b/src/commands/CmdIDs.cpp
@@ -236,6 +236,7 @@ int CmdUUIDs::execute (std::string& output)
   filter.subset (filtered);
 
   std::vector <std::string> uuids;
+  uuids.reserve(filtered.size());
   for (auto& task : filtered)
     uuids.push_back (task.get ("uuid"));
 
@@ -273,6 +274,7 @@ int CmdCompletionUuids::execute (std::string& output)
   filter.subset (filtered);
 
   std::vector <std::string> uuids;
+  uuids.reserve(filtered.size());
   for (auto& task : filtered)
     uuids.push_back (task.get ("uuid"));
 

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -47,6 +47,7 @@ static void countTasks (const std::vector <Task>&, const std::string&, int&, int
 std::string taskIdentifiers (const std::vector <Task>& tasks)
 {
   std::vector <std::string> identifiers;
+  identifiers.reserve(tasks.size());
   for (auto task: tasks)
     identifiers.push_back (task.identifier (true));
 


### PR DESCRIPTION
Found with performance-inefficient-vector-operation

Signed-off-by: Rosen Penev <rosenp@gmail.com>

- [x ] Have you run the test suite?
```
Failed:
version.t                           1

Unexpected successes:

Skipped:
dependencies.t                      1
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
```

probably a bogus failure.