### PR TITLE
clang-tidy: use bool literals

### DIFF
--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -910,7 +910,7 @@ bool Lexer::isPath (std::string& token, Lexer::Type& type)
   std::size_t marker = _cursor;
   int slashCount = 0;
 
-  while (1)
+  while (true)
   {
     if (_text[marker] == '/')
     {

--- a/src/recur2.cpp
+++ b/src/recur2.cpp
@@ -291,7 +291,7 @@ static std::vector <Datetime> generateAllDueDates (const Task& templateTask)
   int recurrence_counter = 0;
   Datetime now;
 
-  while (1)
+  while (true)
   {
     Datetime nextDue = generateNextDueDate (due, recur, lastN);
 


### PR DESCRIPTION
Found with modernize-use-bool-literals

Signed-off-by: Rosen Penev <rosenp@gmail.com>

- [ x] Have you run the test suite?
```
Failed:
version.t                           1

Unexpected successes:

Skipped:
dependencies.t                      1
export.t                            1
feature.default.project.t           4
hooks.on-modify.t                   1
import.t                            1
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
```

failure looks bogus.