### PR TITLE
clang-tidy: use const references

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -200,7 +200,7 @@ bool Task::has (const std::string& name) const
 std::vector <std::string> Task::all ()
 {
   std::vector <std::string> all;
-  for (auto i : data)
+  for (const auto& i : data)
     all.push_back (i.first);
 
   return all;
@@ -836,7 +836,7 @@ std::string Task::composeF4 () const
   std::string ff4 = "[";
 
   bool first = true;
-  for (auto it : data)
+  for (const auto& it : data)
   {
     // Orphans have no type, treat as string.
     std::string type = Task::attributes[it.first];
@@ -931,7 +931,7 @@ std::string Task::composeJSON (bool decorate /*= false*/) const
       out << "\"tags\":[";
 
       int count = 0;
-      for (auto i : tags)
+      for (const auto& i : tags)
       {
         if (count++)
           out << ',';
@@ -970,7 +970,7 @@ std::string Task::composeJSON (bool decorate /*= false*/) const
       out << "\"depends\":[";
 
       int count = 0;
-      for (auto i : deps)
+      for (const auto& i : deps)
       {
         if (count++)
           out << ',';

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -48,7 +48,7 @@ std::string taskIdentifiers (const std::vector <Task>& tasks)
 {
   std::vector <std::string> identifiers;
   identifiers.reserve(tasks.size());
-  for (auto task: tasks)
+  for (const auto& task: tasks)
     identifiers.push_back (task.identifier (true));
 
   return join (", ", identifiers);


### PR DESCRIPTION
Found with performance-for-range-copy

Signed-off-by: Rosen Penev <rosenp@gmail.com>