### PR TITLE
convert manual loops to std::count_if

### DIFF
--- a/src/commands/CmdCount.cpp
+++ b/src/commands/CmdCount.cpp
@@ -57,11 +57,7 @@ int CmdCount::execute (std::string& output)
   filter.subset (filtered);
 
   // Find number of matching tasks.  Skip recurring parent tasks.
-  int count = 0;
-  for (const auto& task : filtered)
-    if (task.getStatus () != Task::recurring)
-      ++count;
-
+  int count = std::count_if(filtered.begin(), filtered.end(), [](const auto& task){ return task.getStatus () != Task::recurring; });
   output = format (count) + '\n';
   return 0;
 }

--- a/src/commands/CmdStats.cpp
+++ b/src/commands/CmdStats.cpp
@@ -70,17 +70,11 @@ int CmdStats::execute (std::string& output)
 
   // Count the undo transactions.
   std::vector <std::string> undoTxns = Context::getContext ().tdb2.undo.get_lines ();
-  int undoCount = 0;
-  for (auto& tx : undoTxns)
-    if (tx == "---")
-      ++undoCount;
+  int undoCount = std::count(undoTxns.begin(), undoTxns.end(), "---");
 
   // Count the backlog transactions.
   std::vector <std::string> backlogTxns = Context::getContext ().tdb2.backlog.get_lines ();
-  int backlogCount = 0;
-  for (auto& tx : backlogTxns)
-    if (tx[0] == '{')
-      ++backlogCount;
+  int backlogCount = std::count_if(backlogTxns.begin(), backlogTxns.end(), [](const auto& tx){ return tx.front() == '{'; });
 
   // Get all the tasks.
   Filter filter;

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -406,12 +406,8 @@ void feedback_backlog ()
   if (Context::getContext ().config.get ("taskd.server") != "" &&
       Context::getContext ().verbose ("sync"))
   {
-    int count = 0;
     std::vector <std::string> lines = Context::getContext ().tdb2.backlog.get_lines ();
-    for (auto& line : lines)
-      if ((line)[0] == '{')
-        ++count;
-
+    int count = std::count_if(lines.begin(), lines.end(), [](const auto& line){ return line.front() == '{'; });
     if (count)
       Context::getContext ().footnote (format (count > 1 ?  "There are {1} local changes.  Sync required."
                                                          : "There is {1} local change.  Sync required.", count));


### PR DESCRIPTION
Simpler and generates less assembly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>