### PR TITLE
Improve performance 2-8x

### DIFF
--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -523,6 +523,9 @@ void CLI2::analyze ()
   // Determine arg types: FILTER, MODIFICATION, MISCELLANEOUS.
   categorizeArgs ();
   parenthesizeOriginalFilter ();
+
+  // Cache frequently looked up items
+  _command = getCommand ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -752,6 +755,10 @@ std::string CLI2::getBinary () const
 ////////////////////////////////////////////////////////////////////////////////
 std::string CLI2::getCommand (bool canonical) const
 {
+  // Shortcut if analysis has been finalized
+  if (_command != "")
+    return _command;
+
   for (const auto& a : _args)
     if (a.hasTag ("CMD"))
       return a.attribute (canonical ? "canonical" : "raw");

--- a/src/CLI2.h
+++ b/src/CLI2.h
@@ -116,7 +116,8 @@ public:
 
   std::vector <std::pair <std::string, std::string>> _id_ranges            {};
   std::vector <std::string>                          _uuid_list            {};
-  bool                                               _context_added {false};
+  std::string                                        _command            {""};
+  bool                                               _context_added   {false};
 };
 
 #endif

--- a/src/CLI2.h
+++ b/src/CLI2.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <Lexer.h>
 #include <FS.h>
 
@@ -77,7 +78,7 @@ public:
   void addContext (bool readable, bool writeable);
   void prepareFilter ();
   const std::vector <std::string> getWords ();
-  bool canonicalize (std::string&, const std::string&, const std::string&) const;
+  bool canonicalize (std::string&, const std::string&, const std::string&);
   std::string getBinary () const;
   std::string getCommand (bool canonical = true) const;
   const std::string dump (const std::string& title = "CLI2 Parser") const;
@@ -109,6 +110,7 @@ private:
 public:
   std::multimap <std::string, std::string>           _entities             {};
   std::map <std::string, std::string>                _aliases              {};
+  std::unordered_map <int, std::string>              _canonical_cache      {};
   std::vector <A2>                                   _original_args        {};
   std::vector <A2>                                   _args                 {};
 

--- a/src/DOM.cpp
+++ b/src/DOM.cpp
@@ -265,7 +265,10 @@ bool getDOM (const std::string& name, const Task& task, Variant& value)
   Lexer lexer (elements[0]);
   std::string token;
   Lexer::Type type;
-  if (lexer.token (token, type))
+
+  // If this can be ID/UUID reference (the name contains '.'),
+  // lex it to figure out. Otherwise don't lex, as lexing can be slow.
+  if ((elements.size() > 1) and lexer.token (token, type))
   {
     if (type == Lexer::Type::uuid &&
         token.length () == elements[0].length ())

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -224,6 +224,8 @@ void Eval::evaluatePostfixStack (
 
   // This is stack used by the postfix evaluator.
   std::vector <Variant> values;
+  values.reserve(tokens.size());
+
   for (const auto& token : tokens)
   {
     // Unary operators.

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -580,13 +580,14 @@ void Task::parse (const std::string& input)
 
     if (input[0] == '[')
     {
-      Pig pig (input);
-      std::string line;
-      if (pig.skip     ('[')       &&
-          pig.getUntil (']', line) &&
-          pig.skip     (']')       &&
-          (pig.skip ('\n') || pig.eos ()))
+      // Not using Pig to parse here (which would be idiomatic), because we
+      // don't need to differentiate betwen utf-8 and normal characters.
+      // Pig's scanning the string can be expensive.
+      auto ending_bracket = input.find_last_of (']');
+      if (ending_bracket != std::string::npos)
       {
+        std::string line = input.substr(1, ending_bracket);
+
         if (line.length () == 0)
           throw std::string ("Empty record in input.");
 

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -596,8 +596,8 @@ void Task::parse (const std::string& input)
         std::string value;
         while (!attLine.eos ())
         {
-          if (attLine.getUntil (':', name) &&
-              attLine.skip (':')           &&
+          if (attLine.getUntilAscii (':', name) &&
+              attLine.skip (':')                &&
               attLine.getQuoted ('"', value))
           {
 #ifdef PRODUCT_TASKWARRIOR


### PR DESCRIPTION
This set of changes improves performance by 2-10x depending on the data and command issued:

Previously:
```
$ time bash -c 'for i in `seq 1 100`; do task2.6.0 project:Work -random count > /dev/null; done'

real	0m12.698s
user	0m12.326s
sys	0m0.348s
```

After:
```
time bash -c 'for i in `seq 1 100`; do task project:Work -random count > /dev/null; done'

real	0m1.684s
user	0m1.365s
sys	0m0.316s
```