### PR TITLE
Consider +PENDING as +ACTIVE as triggers for pendingOnly shortcut

### DIFF
--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -214,6 +214,7 @@ bool Filter::pendingOnly () const
   int countOr        = 0;
   int countXor       = 0;
   int countNot       = 0;
+  bool pendingTag = false;
 
   for (const auto& a : Context::getContext ().cli2._args)
   {
@@ -232,11 +233,20 @@ bool Filter::pendingOnly () const
     }
   }
 
+  for (const auto& word : Context::getContext ().cli2._original_args)
+  {
+    if (word.attribute ("raw") == "+PENDING")  pendingTag = true;
+  }
+
+
   if (countUUID)
     return false;
 
   if (countOr || countXor || countNot)
     return false;
+
+  if (pendingTag)
+    return true;
 
   if (countStatus)
   {

--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -227,8 +227,8 @@ bool Filter::pendingOnly () const
       if (a._lextype == Lexer::Type::op  && raw == "not")          ++countNot;
       if (a._lextype == Lexer::Type::dom && canonical == "status") ++countStatus;
       if (                                  raw == "pending")      ++countPending;
-      if (                                  raw == "waiting")      ++countPending;
-      if (                                  raw == "recurring")    ++countPending;
+      if (                                  raw == "waiting")      ++countWaiting;
+      if (                                  raw == "recurring")    ++countRecurring;
     }
   }
 

--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -215,6 +215,7 @@ bool Filter::pendingOnly () const
   int countXor       = 0;
   int countNot       = 0;
   bool pendingTag = false;
+  bool activeTag  = false;
 
   for (const auto& a : Context::getContext ().cli2._args)
   {
@@ -235,7 +236,8 @@ bool Filter::pendingOnly () const
 
   for (const auto& word : Context::getContext ().cli2._original_args)
   {
-    if (word.attribute ("raw") == "+PENDING")  pendingTag = true;
+    if (word.attribute ("raw") == "+PENDING") pendingTag = true;
+    if (word.attribute ("raw") == "+ACTIVE")  activeTag = true;
   }
 
 
@@ -245,7 +247,7 @@ bool Filter::pendingOnly () const
   if (countOr || countXor || countNot)
     return false;
 
-  if (pendingTag)
+  if (pendingTag || activeTag)
     return true;
 
   if (countStatus)


### PR DESCRIPTION
This ensures we don't need to load the `completed.data` when the query only concerns pending tasks. The mechanism is not perfect, but it should serve as a good enough patch for now.

Closes #2201.