### PR TITLE
Fix reference for errno.h on Haiku

### DIFF
--- a/src/TLSClient.cpp
+++ b/src/TLSClient.cpp
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
-#if (defined OPENBSD || defined SOLARIS || defined NETBSD)
+#if (defined OPENBSD || defined SOLARIS || defined NETBSD || defined HAIKU)
 #include <errno.h>
 #else
 #include <sys/errno.h>


### PR DESCRIPTION
#### Description

Haiku uses errno.h instead of sys/errno.h.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

See comment below
