### PR TITLE
Search for libnetwork on Haiku

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,17 @@ else (HAVE_UUID_UNPARSE_LOWER)
   message ("-- Found libuuid, using internal uuid_unparse_lower")
 endif (HAVE_UUID_UNPARSE_LOWER)
 
+if (HAIKU)
+  # search for socket() in libnetwork on Haiku
+  message("-- Looking for libnetwork")
+  find_library (NETWORK_LIBRARY NAMES network)
+  if (NETWORK_LIBRARY)
+    set (TASK_LIBRARIES    ${TASK_LIBRARIES} ${NETWORK_LIBRARY})
+  else (NETWORK_LIBRARY)
+    message(FATAL_ERROR "-- libnetwork not found.")
+  endif (NETWORK_LIBRARY)
+endif (HAIKU)
+
 if (SOLARIS)
   # accept() is in libsocket according to its manpage
   message("-- Looking for libsocket")


### PR DESCRIPTION
#### Description

We need libnetwork on Haiku for socket(), setsockopt() ...
Used `-DCMAKE_EXE_LINKER_FLAGS=-lnetwork` before, but this patch makes that obsolete.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.
