### PR TITLE
Prefer /usr/bin/env and searching from PATH

### DIFF
--- a/test/quotes.t
+++ b/test/quotes.t
@@ -130,7 +130,7 @@ class TestBug1436(TestCase):
 
            This problem is entirely testing artifact, and not Taskwarrior.
         """
-        self.echo = Task(taskw=utils.binary_location("/bin/echo"))
+        self.echo = Task(taskw=utils.binary_location("echo", USE_PATH=True))
 
         # One level of backshashes gets eaten by bash
         # Verify with: $ echo xxx \\\\yyy zzz

--- a/test/tw-1883.t
+++ b/test/tw-1883.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test for TW-1883 (#1896 on Github)
 # https://github.com/GothenburgBitFactory/taskwarrior/issues/1896
 

--- a/test/tw-1895.t
+++ b/test/tw-1895.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . bash_tap_tw.sh
 

--- a/test/tw-2124.t
+++ b/test/tw-2124.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # A test case for TW-2124.
 # https://github.com/GothenburgBitFactory/taskwarrior/issues/2124
 

--- a/test/tw-2257.t
+++ b/test/tw-2257.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . bash_tap_tw.sh
 

--- a/test/tw-2386.t
+++ b/test/tw-2386.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . bash_tap_tw.sh
 


### PR DESCRIPTION
#### Description

- Prefer `/usr/bin/env` in shebangs, since `bash` may not be installed in `/bin` in some systems (like NixOS). And we already use `/usr/bin/env` in most of scripts.
- Use `echo` from `PATH` instead of hard-coded `/bin/echo`, for the same reason.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.
