### PR TITLE
Remove build date/time from diagnostic message

### DIFF
--- a/src/commands/CmdDiagnostics.cpp
+++ b/src/commands/CmdDiagnostics.cpp
@@ -122,8 +122,6 @@ int CmdDiagnostics::execute (std::string& output)
   out << bold.colorize ("Build Features")
       << '\n'
 
-  // Build date.
-      << "      Built: " << __DATE__ << ' ' << __TIME__ << '\n'
 #ifdef HAVE_COMMIT
       << "     Commit: " << COMMIT << '\n'
 #endif


### PR DESCRIPTION
#### Description

This message does not really help, and makes the binary non-deterministic.

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.
