### PR TITLE
CmdExec: Prevent user from executing an empty command

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,8 @@
            Thanks to Daniel Mowitz.
 - TW #2451 Command task $month doesn't behave correctly
            Thanks to Matias Laporte.
+- TW #2503 Warn against executing an empty execute command.
+           Thanks to heinrichat.
 
 ------ current release ---------------------------
 

--- a/src/commands/CmdExec.cpp
+++ b/src/commands/CmdExec.cpp
@@ -49,7 +49,15 @@ CmdExec::CmdExec ()
 ////////////////////////////////////////////////////////////////////////////////
 int CmdExec::execute (std::string&)
 {
-  return system (join (" ", Context::getContext ().cli2.getWords ()).c_str ());
+  std::string command = join (" ", Context::getContext ().cli2.getWords ());
+
+  if (command.empty())
+  {
+    Context::getContext ().error ("Cannot execute an empty command.");
+    return 1;
+  }
+  else
+    return system (command.c_str ());
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #2503. This should prevent some unnecessary confusion.