### PR TITLE
Variant: Do not use implicit fall-through in operator_partial

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,8 @@
            Thanks to Daniel Mowitz.
 - TW #2451 Command task $month doesn't behave correctly
            Thanks to Matias Laporte.
+- TW #2502 Two GCC warnings on 2.6.0.
+           Thanks to Scott Kostyshak.
 - TW #2503 Warn against executing an empty execute command.
            Thanks to heinrichat.
 

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1098,8 +1098,15 @@ bool Variant::operator_partial (const Variant& other) const
     {
     // Same-day comparison.
     case type_string:
-      if (left.trivial () || right.trivial ())
-        return false;
+      {
+        if (left.trivial () || right.trivial ())
+          return false;
+
+        right.cast (type_date);
+        Datetime left_date (left._date);
+        Datetime right_date (right._date);
+        return left_date.sameDay (right_date);
+      }
 
     case type_boolean:
     case type_integer:

--- a/test/variant_partial.t.cpp
+++ b/test/variant_partial.t.cpp
@@ -40,6 +40,8 @@ int main (int, char**)
   Variant v3 ("foo");
   Variant v4 (1234567890, Variant::type_date);
   Variant v5 (1200, Variant::type_duration);
+  Variant v6 (1234522800, Variant::type_date);  // 2009-02-13, 12.00pm UTC
+  Variant v7 ("2009-02-13");
 
   Variant v00 = v0.operator_partial (v0);
   t.is (v00.type (), Variant::type_boolean, "true == true --> boolean");
@@ -184,6 +186,14 @@ int main (int, char**)
   Variant v55 = v5.operator_partial (v5);
   t.is (v55.type (), Variant::type_boolean, "1200 == 1200 --> boolean");
   t.is (v55.get_bool (), true,              "1200 == 1200 --> true");
+
+  Variant v56 = v6.operator_partial (v7);
+  t.is (v56.type (), Variant::type_boolean, "1234522800 == '2009-02-13' --> boolean");
+  t.is (v56.get_bool (), true,              "1234522800 == '2009-02-13' --> true");
+
+  Variant v57 = v7.operator_partial (v6);
+  t.is (v57.type (), Variant::type_boolean, "'2009-02-13' == 1234522800 --> boolean");
+  t.is (v57.get_bool (), true,              "'2009-02-13' == 1234522800 --> true");
 
   return 0;
 }


### PR DESCRIPTION
The code handling the comparison between the date and string types would
convert the variants to correct types, but only through multi-level
fall-through in the switch statement, which is always a bit of a
dangerous construct.

Added explicit return for the non-trivial case, preventing the need for
the fall-through.

Also added some tests to ensure this works correctly (even though this
was technically working correctly before this fix as well).

Closes #2502.