### PR TITLE
parseJSON: Allow annotations with missing entry values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,9 @@
 - TW #1788 When deleting recurring task all tasks, including completed tasks,
            are marked as deleted
            Thanks to Alan Young.
+- TW #1804 Importing malformed annotation (without entry timestamp) causes
+           segmentation fault.
+           Thanks to David Badura.
 - TW #1896 Parser cannot handle empty parentheses
            Thanks to Tomas Babej.
 - TW #1908 Cannot create task with explicit description 'start ....'

--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ New Features in Taskwarrior 2.6.0
   - The currently selected context is now applied for "task add" and "task log"
     commands. Section on contexts in the manpage was updated to describe this
     functionality.
+  - The `task import` command can now accept annotations with missing entry
+    values. Current time will be assumed.
 
 
 New Commands in Taskwarrior 2.6.0

--- a/scripts/reproduce-dockerfile
+++ b/scripts/reproduce-dockerfile
@@ -5,7 +5,7 @@ FROM centos:8
 
 RUN dnf update -y
 RUN yum install epel-release -y
-RUN dnf install python38 git gcc gcc-c++ cmake make gnutls-devel libuuid-devel libfaketime sudo man -y
+RUN dnf install python38 git gcc gcc-c++ cmake make gnutls-devel libuuid-devel libfaketime sudo man gdb -y
 
 RUN useradd warrior
 RUN echo warrior ALL=NOPASSWD:ALL > /etc/sudoers.d/warrior

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -757,14 +757,19 @@ void Task::parseJSON (const json::object* root_obj)
         for (auto& annotations : atts->_data)
         {
           auto annotation = (json::object*)annotations;
+
           auto when = (json::string*)annotation->_data["entry"];
           auto what = (json::string*)annotation->_data["description"];
 
-          if (! when)
-            throw format ("Annotation is missing an entry date: {1}", root_obj-> dump ());
+          if (! when) {
+            annotation->_data.erase ("entry");  // Erase NULL entry inserted by failed lookup above
+            throw format ("Annotation is missing an entry date: {1}", annotation-> dump ());
+          }
 
-          if (! what)
-            throw format ("Annotation is missing a description: {1}", root_obj->dump ());
+          if (! what) {
+            annotation->_data.erase ("description");  // Erase NULL description inserted by failed lookup above
+            throw format ("Annotation is missing a description: {1}", annotation->dump ());
+          }
 
           // Extract 64-bit annotation entry value
           // Time travelers from 2038, we have your back.

--- a/test/tw-1804.t
+++ b/test/tw-1804.t
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+. bash_tap_tw.sh
+
+# Import a task with annotation without an description
+# Should fail
+OUTPUT=`echo '{"description":"Buy the milk","annotations":[{"entry": 1234567890}]}' | task import - 2>&1` || :
+[[ $OUTPUT =~ "missing a description" ]]
+
+# Check that the task was NOT added
+[[ `task count` == 0 ]]
+
+# Import a task with annotation without an entry
+echo '{"description":"Buy the milk","annotations":[{"description":"and Cheese"}]}' | task import -
+
+# Check that the task was added
+[[ `task count` == 1 ]]
+[[ `task milk count` == 1 ]]
+[[ `task _get 1.annotations.count` == 1 ]]


### PR DESCRIPTION
This relaxes previous stringent requirements on the input attributes of annotations during import. In particular, annotations that have a missing "entry" value can still be imported - the current time will be assumed.

Also prevents a segfault when importing an annotation without a description.
    
Closes #1804.
