### PR TITLE
feedback: Consider start and end attributes when reporting task durations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -341,3 +341,4 @@ suggestions:
   ad-si
   coaxial
   Arvedui
+  reportaman

--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,8 @@
            Thanks to Scott Kostyshak.
 - TW #2503 Warn against executing an empty execute command.
            Thanks to heinrichat.
+- TW #2514 Duration values can be mis-reported in the task info output
+           Thanks to reportaman.
 
 ------ current release ---------------------------
 

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -171,9 +171,19 @@ std::string taskInfoDifferences (
     }
     else if (name == "start")
     {
+      Datetime started (before.get ("start"));
+      Datetime stopped;
+
+      if (after.has ("end"))
+        // Task was marked as finished, use end time
+        stopped = Datetime (after.get ("end"));
+      else
+        // Start attribute was removed, use modification time
+        stopped = Datetime (current_timestamp);
+
       out << format ("{1} deleted (duration: {2}).",
                      Lexer::ucFirst (name),
-                     Duration (current_timestamp - last_timestamp).format ())
+                     Duration (stopped - started).format ())
           << "\n";
     }
     else

--- a/test/tw-2514.t
+++ b/test/tw-2514.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+. bash_tap_tw.sh
+
+# Setup the tasks
+task add Something I did yesterday
+task 1 mod start:yesterday+18h
+task 1 done end:yesterday+20h
+
+# Check that 2 hour interval is reported by task info
+task info | grep -F "Start deleted"
+[[ ! -z `task info | grep -F "Start deleted (duration: 2:00:00)."` ]]


### PR DESCRIPTION
Instead of relying on the modification times, we can use the values of
the start and end attributes, if available.

This allows us to perform historical changes that result in correct
duration intervals reported by task info.

Closes #2514