### PR TITLE
All 'end of' named dates should point to the last second of the referenced interval

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -342,3 +342,4 @@ suggestions:
   coaxial
   Arvedui
   reportaman
+  Pablo Vizcay

--- a/ChangeLog
+++ b/ChangeLog
@@ -67,6 +67,9 @@
            Thanks to heinrichat.
 - TW #2514 Duration values can be mis-reported in the task info output
            Thanks to reportaman.
+- TW #2519 Named date eod should be last minute of today and not first of
+           tomorrow.
+           Thanks to Pablo Vizcay.
 
 ------ current release ---------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,12 @@ Newly Deprecated Features in Taskwarrior 2.6.0
 
   - The 'PARENT' and 'CHILD' virtual tags are replaced by 'TEMPLATE' and 'INSTANCE'.
 
+Fixed regressions in 2.6.0
+
+  - The "end of <date>" named dates ('eod', 'eow', ...) were pointing to the
+    first second of the next day, instead of last second of the referenced
+    interval. This was a regression introduced in 2.5.2.
+
 Removed Features in 2.6.0
 
   -

--- a/test/math.t
+++ b/test/math.t
@@ -44,7 +44,7 @@ class TestMath(TestCase):
         cls.t.config("dateformat", "YYYY-MM-DD")
 
         # YYYY-12-21.
-        cls.when = "%d-12-22T00:00:00\n" % datetime.now().year
+        cls.when = "%d-12-21T23:59:59\n" % datetime.now().year
 
         # Different ways of specifying YYYY-12-21.
         cls.t("add one   due:eoy-10days")

--- a/test/math.t
+++ b/test/math.t
@@ -52,7 +52,7 @@ class TestMath(TestCase):
         cls.t("add three 'due:eoy-10days'")
         cls.t("add four  due:'eoy - 10days'")
         cls.t("add five  'due:eoy - 10days'")
-        cls.t("add six   'due:{}-01-01T00:00:00 - 10days'".format (datetime.now().year + 1))
+        cls.t("add six   'due:{}-12-31T23:59:59 - 10days'".format (datetime.now().year))
 
     def test_compact_unquoted(self):
         """compact unquoted"""


### PR DESCRIPTION
This was the behaviour implemented in TW 2.5.1 and before.
    
Closes #2519.
