### PR TITLE
Fix matching project name during urgency calculation

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1841,6 +1841,7 @@ float Task::urgency_c () const
   value += fabsf (Task::urgencyBlockingCoefficient)    > epsilon ? (urgency_blocking ()    * Task::urgencyBlockingCoefficient)    : 0.0;
   value += fabsf (Task::urgencyAgeCoefficient)         > epsilon ? (urgency_age ()         * Task::urgencyAgeCoefficient)         : 0.0;
 
+  const std::string taskProjectName = get("project");
   // Tag- and project-specific coefficients.
   for (auto& var : Task::coefficients)
   {
@@ -1855,8 +1856,11 @@ float Task::urgency_c () const
         {
           std::string project = var.first.substr (21, end - 21);
 
-          if (get ("project").find (project) == 0)
+          if (taskProjectName == project ||
+              taskProjectName.find(project + '.') == 0)
+          {
             value += var.second;
+          }
         }
 
         // urgency.user.tag.<tag>.coefficient

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -468,8 +468,12 @@ int CmdInfo::execute (std::string& output)
               (end = var.first.find (".coefficient")) != std::string::npos)
           {
             auto project = var.first.substr (21, end - 21);
-            if (task.get ("project").find (project) == 0)
+            const std::string taskProjectName = task.get("project");
+            if (taskProjectName == project ||
+                taskProjectName.find(project + '.') == 0)
+            {
               urgencyTerm (urgencyDetails, "PROJECT " + project, 1.0, var.second);
+            }
           }
 
           // urgency.user.tag.<tag>.coefficient


### PR DESCRIPTION
#### Description
`~/.taskrc`
```
urgency.user.project.work.coefficient=2.0
urgency.user.project.workout.coefficient=1.0
```

```
$ ~ task project:workout add 'Evening working out'
Created task 13.
The project 'workout' has changed.  Project 'workout' is 0% complete (2 of 2 tasks remaining).
$ ~ task 13
No command specified - assuming 'information'.

Name          Value
ID            13
Description   Evening working out
Status        Pending
Project       workout
Entered       2021-07-07 21:18:19 (1s)
Last modified 2021-07-07 21:18:19 (1s)
Virtual tags  LATEST PENDING PROJECT READY UNBLOCKED
UUID          5432f1b1-5a4b-4129-a947-f7da6e30d0f2
Urgency          3

    PROJECT work         1 *    2 =      2
    PROJECT workout      1 *    1 =      1
                                    ------
                                         3
```

As you can see, while `Project` line correctly assumes, task's assigned project is equal to `workout`. Yet, for urgency calculation summary it is clearly taking into consideration also `work`'s coefficients. Which — to me — is unexpected behavior. I did my research to find if it is actually desired behavior, but failed to find anything related to project name matching (being loose/too much inclusive or fuzzy).

If this is a desired behavior, please ignore this PR.

#### Additional information...

- [ ] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.
  `/.problems` seems to report a lot of errors on HEAD without my changes. Anyway, here is a report with my changes too:
  
```
  Failed:
abbreviation.t                      7
add.t                              14
alias.t                            10
annotate.t                          9
append.t                            3
args.t                              2
backlog.t                           3
bash_completion.t                   7
blocked.t                           1
bulk.t                             10
burndown.t                          1
calc.t                              2
calendar.t                         35
caseless.t                          1
color.cmd.t                         5
color.rules.t                       3
columns.t                          14
commands.t                          2
completed.t                         1
configuration.t                     7
confirmation.t                      2
context.t                          31
count.t                             1
custom.config.t                     4
custom.recur_ind.t                  1
custom.t                            5
custom.tag_ind.t                    1
date.iso.t                          2
dateformat.t                        5
datesort.t                          1
debug.t                             4
default.t                           3
delete.t                            6
denotate.t                          1
dependencies.t                     19
diag.t                              2
diag_color.t                        4
dom2.t                              6
due.t                               2
duplicate.t                         5
edit.t                              3
encoding.t                          2
enpassant.t                         5
exec.t                              4
export.t                           21
feature.559.t                       1
feature.default.project.t          10
feature.print.empty.columns.t       1
feature.recurrence.t                2
feedback.t                          4
filter.t                           41
fontunderline.t                     1
format.t                            8
gc.t                                3
helpers.t                           6
history.t                           4
hooks.env.t                         3
hooks.on-add.t                      8
hooks.on-exit.t                     4
hooks.on-launch.t                   4
hooks.on-modify.t                   8
hyphenate.t                         3
ids.t                               3
import.t                           23
info.t                              3
limit.t                             1
list.all.projects.t                 1
log.t                               4
logo.t                              2
math.t                              2
modify.t                            2
nag.t                               3
obfuscate.t                         1
oldest.t                            1
operators.t                         2
overdue.t                           1
partial.t                           2
prepend.t                           3
pri_sort.t                          1
project.t                          24
purge.t                             5
quotes.t                            4
rc.override.t                       3
recurrence.t                       27
reports.t                           1
search.t                           21
sequence.t                          7
shell.t                             1
show.t                              6
sorting.t                           1
special.t                           1
start.t                             9
stats.t                             1
substitute.t                        5
sugar.t                             2
summary.t                           3
tag.t                               9
taskrc.t                            1
timesheet.t                         1
tw-1379.t                          11
tw-1837.t                           1
tw-1999.t                           1
tw-20.t                             1
tw-262.t                           11
tw-295.t                            1
tw-46.t                             1
uda.t                              21
uda_orphan.t                        3
uda_report.t                        2
uda_sort.t                          3
undo.t                              6
unicode.t                           5
unique.t                            1
upgrade.t                           1
urgency.t                           2
urgency_inherit.t                   1
uuid.t                             14
verbose.t                           9
version.t                           5
wait.t                              5

Unexpected successes:

Skipped:
calc.t                              6
feature.default.project.t           1
tw-1999.t                           1

Expected failures:
dependencies.t                      1
quotes.t                            1
tw-2124.t                           1
  ```
