### PR TITLE
tests: Add a regression test for #2530

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -70,6 +70,8 @@
 - TW #2519 Named date eod should be last minute of today and not first of
            tomorrow.
            Thanks to Pablo Vizcay.
+- TW #2530 Taskwarrior 2.5.3 time based filtering regression
+           Thanks to Matthias Tafelmeier.
 
 ------ current release ---------------------------
 

--- a/test/tw-2530.t
+++ b/test/tw-2530.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+. bash_tap_tw.sh
+
+# Setup the tasks
+task add wait:1w this should INDEED show up
+task add this should NOT show up
+sleep 1
+
+# Check that the wait.before filter displays the correct number of tasks
+task wait.before:1w all
+
+# Assertion: The task without wait attribute does not show up
+[[ -z `task wait.before:1w all | grep NOT` ]]
+
+# Assertion: The task with the wait attribute DOES show up
+[[ ! -z `task wait.before:1w all | grep INDEED` ]]
+
+# Assertion: There is exactly one task matching the filter
+[[ `task wait.before:1w count` == 1 ]]


### PR DESCRIPTION
Regression #2530 occurred in 2.5.3, fixed in 2.6.0. This tests makes sure we have this case covered in the suite.

Closes #2350.