### PR TITLE
Add filter attribute modifier 'by'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -156,6 +156,7 @@ The following submitted code, packages or analysis, and deserve special thanks:
   Anthony VB
   Julien Rabinow
   Daniel Mowitz
+  Scott Mcdermott
 
 Thanks to the following, who submitted detailed bug reports and excellent
 suggestions:

--- a/ChangeLog
+++ b/ChangeLog
@@ -72,6 +72,9 @@
            Thanks to Pablo Vizcay.
 - TW #2530 Taskwarrior 2.5.3 time based filtering regression
            Thanks to Matthias Tafelmeier.
+- TW #2536 Feature: inclusive range-end attribute modifier 'by' so 'end of'
+           named dates can be filtered inclusively
+           Thanks to Scott Mcdermott
 
 ------ current release ---------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,11 @@ New Features in Taskwarrior 2.6.0
     functionality.
   - The `task import` command can now accept annotations with missing entry
     values. Current time will be assumed.
+  - The new 'by' filter attribute modifier compares using '<=' rather than '<'
+    as 'before' uses.  This allows the last second of the day to match with
+    'due.by:eod', which it would not otherwise.  It also works with
+    whole units like days, e.g. 'add test due:2021-07-17' would not match
+    'due.before:tomorrow' (on the 16th), but would match 'due.by:tomorrow'.
 
 
 New Commands in Taskwarrior 2.6.0

--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -55,6 +55,7 @@ More filter examples:
   task                                      <command> <mods>
   task 28                                   <command> <mods>
   task +weekend                             <command> <mods>
+  task +bills due.by:eom                    <command> <mods>
   task project:Home due.before:today        <command> <mods>
   task ebeeab00-ccf8-464b-8b58-f7f2d606edfb <command> <mods>
 
@@ -819,6 +820,8 @@ Attribute modifiers improve filters.  Supported modifiers are:
 .br
 .B  after      (synonyms over, above)
 .br
+.B  by
+.br
 .B  none
 .br
 .B  any
@@ -865,6 +868,24 @@ The
 modifier is the inverse of the
 .I before
 modifier.
+
+The
+.I by
+modifier is the same as 'before', except it also includes the moment in
+question.  For example:
+
+    task add test due:eoy
+
+will be found when using the inclusive filter 'by':
+
+    task due.by:eoy
+
+but not when the non-inclusive filter 'before' is used:
+
+    task due.before:eoy
+
+this applies equally to other named dates such as 'eom', 'eod', etc; the
+modifier compares using '<=' rather than '<' like 'before' does.
 
 The
 .I none

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -1341,6 +1341,11 @@ void CLI2::desugarFilterAttributes ()
           op.attribute ("raw", ">");
           rhs.attribute ("raw", value);
         }
+        else if (mod == "by")
+        {
+          op.attribute ("raw", "<=");
+          rhs.attribute ("raw", value);
+        }
         else if (mod == "none")
         {
           op.attribute ("raw", "==");

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -397,6 +397,7 @@ static const char* modifierNames[] =
 {
   "before",     "under",    "below",
   "after",      "over",     "above",
+  "by",
   "none",
   "any",
   "is",         "equals",

--- a/test/due.t
+++ b/test/due.t
@@ -118,6 +118,25 @@ class TestBug418(TestCase):
         self.assertNotIn("nine", out)
 
 
+class TestBug2519(TestCase):
+    def setUp(self):
+        self.t = Task()
+
+    def test_due_today_includes_eod(self):
+        """Verify that virtual tag +TODAY matches a task due eod"""
+        self.t("add zero due:eod")
+
+        code, out, err = self.t("+TODAY ls")
+        self.assertIn("zero", out)
+
+    def test_eoy_is_not_before_eoy(self):
+        """Verify that end of year is not before end of year"""
+        self.t("add zero due:eoy")
+
+        code, out, err = self.t.runError("due.before:eoy")
+        self.assertNotIn("1", out)
+
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
     unittest.main(testRunner=TAPTestRunner())

--- a/test/filter.t
+++ b/test/filter.t
@@ -836,6 +836,34 @@ class TestBefore(TestCase):
         self.assertIn("2", out)
 
 
+class TestBy(TestCase):
+    def setUp(self):
+        self.t = Task()
+
+    def test_by_eoy_includes_eoy(self):
+        """ Verify by-end-of-year includes task due *at* end-of-year """
+        self.t("add zero due:eoy")
+
+        code, out, err = self.t("due.by:eoy")
+        self.assertIn("zero", out)
+
+    def test_by_tomorrow_includes_tomorrow(self):
+        """ Verify that by-tomorrow also includes tomorrow itself """
+        self.t.faketime("2021-07-16 21:00:00")
+        self.t("add zero due:2021-07-17")
+
+        code, out, err = self.t("due.by:tomorrow")
+        self.assertIn("zero", out)
+
+    def test_by_yesterday_does_not_include_today(self):
+        """ Verify that by-yesterday does not include today """
+        self.t("add zero")
+
+        code, out, err = self.t.runError("entry.by:yesterday")
+        self.assertIn("No matches", err)
+        self.assertNotIn("zero", out)
+
+
 class Test1424(TestCase):
     def setUp(self):
         self.t = Task()


### PR DESCRIPTION
#### Description

Adds the modifier 'by' to those possible for filter attributes.  This uses `<=` for comparison rather than `<` as the existing `before` modifier does.  Includes docs, tests and credit.  Also added a test for #2519 which isn't technically part of this patch per se, but was the genesis and is related so it makes sense to include it in this PR.

See #2519 for full discussion and #2536 for the issue this PR closes.

#### Additional information...

- [x] Have you run the test suite?

```
 $ ./problems
Failed:                        

Unexpected successes:          

Skipped:                       
dependencies.t                      1
feature.default.project.t           1
tw-1999.t                           1

Expected failures:             
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
```