### PR TITLE
Added output of number of tasks to be modified in batch mode

### DIFF
--- a/src/commands/CmdAnnotate.cpp
+++ b/src/commands/CmdAnnotate.cpp
@@ -70,6 +70,9 @@ int CmdAnnotate::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     Task before (task);

--- a/src/commands/CmdAnnotate.cpp
+++ b/src/commands/CmdAnnotate.cpp
@@ -71,7 +71,7 @@ int CmdAnnotate::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdAppend.cpp
+++ b/src/commands/CmdAppend.cpp
@@ -70,6 +70,9 @@ int CmdAppend::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     Task before (task);

--- a/src/commands/CmdAppend.cpp
+++ b/src/commands/CmdAppend.cpp
@@ -71,7 +71,7 @@ int CmdAppend::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdDelete.cpp
+++ b/src/commands/CmdDelete.cpp
@@ -72,8 +72,8 @@ int CmdDelete::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
-  if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  if(filtered.size() > 1) { 
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdDelete.cpp
+++ b/src/commands/CmdDelete.cpp
@@ -72,6 +72,9 @@ int CmdDelete::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     Task before (task);

--- a/src/commands/CmdDenotate.cpp
+++ b/src/commands/CmdDenotate.cpp
@@ -88,7 +88,7 @@ int CmdDenotate::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdDenotate.cpp
+++ b/src/commands/CmdDenotate.cpp
@@ -87,6 +87,9 @@ int CmdDenotate::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     Task before (task);

--- a/src/commands/CmdDone.cpp
+++ b/src/commands/CmdDone.cpp
@@ -69,6 +69,10 @@ int CmdDone::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   Task& lowest = filtered.front();
+
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     Task before (task);

--- a/src/commands/CmdDone.cpp
+++ b/src/commands/CmdDone.cpp
@@ -71,7 +71,7 @@ int CmdDone::execute (std::string&)
   Task& lowest = filtered.front();
 
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdModify.cpp
+++ b/src/commands/CmdModify.cpp
@@ -71,6 +71,9 @@ int CmdModify::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   auto count = 0;
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     Task before (task);

--- a/src/commands/CmdModify.cpp
+++ b/src/commands/CmdModify.cpp
@@ -72,7 +72,7 @@ int CmdModify::execute (std::string&)
 
   auto count = 0;
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdPrepend.cpp
+++ b/src/commands/CmdPrepend.cpp
@@ -70,6 +70,9 @@ int CmdPrepend::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     Task before (task);

--- a/src/commands/CmdPrepend.cpp
+++ b/src/commands/CmdPrepend.cpp
@@ -71,7 +71,7 @@ int CmdPrepend::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdStart.cpp
+++ b/src/commands/CmdStart.cpp
@@ -69,6 +69,9 @@ int CmdStart::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   bool nagged = false;
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     if (! task.has ("start"))

--- a/src/commands/CmdStart.cpp
+++ b/src/commands/CmdStart.cpp
@@ -70,7 +70,7 @@ int CmdStart::execute (std::string&)
 
   bool nagged = false;
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdStop.cpp
+++ b/src/commands/CmdStop.cpp
@@ -68,7 +68,7 @@ int CmdStop::execute (std::string&)
   std::map <std::string, std::string> projectChanges;
 
   if(filtered.size() > 1) {
-    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+    feedback_affected("This command will alter {1} tasks.", filtered.size());
   }
   for (auto& task : filtered)
   {

--- a/src/commands/CmdStop.cpp
+++ b/src/commands/CmdStop.cpp
@@ -67,6 +67,9 @@ int CmdStop::execute (std::string&)
   // Accumulated project change notifications.
   std::map <std::string, std::string> projectChanges;
 
+  if(filtered.size() > 1) {
+    std::cout << "This command will alter " << format(filtered.size()) << " tasks." << std::endl;
+  }
   for (auto& task : filtered)
   {
     if (task.has ("start"))


### PR DESCRIPTION
#### Description

Added number of tasks as output for batch operations, see issue #2532.

#### Additional information...

- [X] Have you run the test suite?
Passed:                          2717
Failed:                             0
Unexpected successes:               0
Skipped:                            0
Expected failures:                  4
Runtime:                         0.35 seconds

