### PR TITLE
Added coloring of scheduled dates in calendar report

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -77,6 +77,8 @@
            Thanks to Scott Mcdermott
 - TW #1824 Fixed countdown formatting
            Thanks to Sebastian Uharek
+- #2208    Feature: added coloring of dates with scheduled tasks to calendar
+           Thanks to Sebastian Uharek
 
 ------ current release ---------------------------
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -227,6 +227,7 @@ std::string configurationDefaults =
   "color.calendar.due.today=color15 on color1\n"
   "color.calendar.due=color0 on color1\n"
   "color.calendar.holiday=color0 on color11\n"
+  "color.calendar.scheduled=rgb013 on color15\n"
   "color.calendar.overdue=color0 on color9\n"
   "color.calendar.today=color15 on rgb013\n"
   "color.calendar.weekend=on color235\n"

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -98,6 +98,7 @@ int CmdShow::execute (std::string& output)
     " color.calendar.due"
     " color.calendar.due.today"
     " color.calendar.holiday"
+    " color.calendar.scheduled"
     " color.calendar.overdue"
     " color.calendar.today"
     " color.calendar.weekend"


### PR DESCRIPTION
Color can be defined by color.calendar.scheduled, see issue #2208 

#### Additional information...

- [x] Have you run the test suite?
Passed:                          2717
Failed:                             0
Unexpected successes:               0
Skipped:                            0
Expected failures:                  4
Runtime:                         0.35 seconds

