### PR TITLE
add convenience feedback funtion for sync messages

### DIFF
--- a/src/commands/CmdSync.cpp
+++ b/src/commands/CmdSync.cpp
@@ -32,6 +32,7 @@
 #include <Context.h>
 #include <Filter.h>
 #include <Color.h>
+#include <main.h>
 #include <shared.h>
 #include <format.h>
 #include <util.h>
@@ -260,20 +261,20 @@ int CmdSync::execute (std::string& output)
         // Present a clear status message.
         if (upload_count == 0 && download_count == 0)
           // Note: should not happen - expect code 201 instead.
-          Context::getContext ().footnote ("Sync successful.");
+          feedback_sync ("Sync successful.");
         else if (upload_count == 0 && download_count > 0)
-          Context::getContext ().footnote (format ("Sync successful.  {1} changes downloaded.", download_count));
+          feedback_sync (format ("Sync successful.  {1} changes downloaded.", download_count));
         else if (upload_count > 0 && download_count == 0)
-          Context::getContext ().footnote (format ("Sync successful.  {1} changes uploaded.", upload_count));
+          feedback_sync (format ("Sync successful.  {1} changes uploaded.", upload_count));
         else if (upload_count > 0 && download_count > 0)
-          Context::getContext ().footnote (format ("Sync successful.  {1} changes uploaded, {2} changes downloaded.", upload_count, download_count));
+          feedback_sync (format ("Sync successful.  {1} changes uploaded, {2} changes downloaded.", upload_count, download_count));
       }
 
       status = 0;
     }
     else if (code == "201")
     {
-      Context::getContext ().footnote ("Sync successful.  No changes.");
+      feedback_sync ("Sync successful.  No changes.");
       status = 0;
     }
     else if (code == "301")

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -310,6 +310,27 @@ void feedback_affected (const std::string& effect, const Task& task)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Implements:
+//    <string>
+void feedback_sync (const std::string& effect)
+{
+  if (Context::getContext ().verbose ("sync"))
+    std::cout << effect << "\n";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Implements:
+//
+// The 'effect' string should contain:
+//    {1}    Quantity
+void feedback_sync (const std::string& effect, int quantity)
+{
+  if (Context::getContext ().verbose ("sync"))
+    std::cout << format (effect, quantity)
+              << "\n";
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Implements feedback and error when adding a reserved tag name.
 void feedback_reserved_tags (const std::string& tag)
 {

--- a/src/main.h
+++ b/src/main.h
@@ -72,6 +72,8 @@ std::string renderAttribute (const std::string&, const std::string&, const std::
 void feedback_affected (const std::string&);
 void feedback_affected (const std::string&, int);
 void feedback_affected (const std::string&, const Task&);
+void feedback_sync (const std::string&);
+void feedback_sync (const std::string&, int);
 void feedback_reserved_tags (const std::string&);
 void feedback_special_tags (const Task&, const std::string&);
 void feedback_unblocked (const Task&);


### PR DESCRIPTION
#### Description

I added a convenience function to output feedback from the sync command, which outputs to stdout instead of stderr, see issue #1921 . Howevver, I'm wondering if it is correct that footnotes are output to std::cerr

Context.cpp:674
```
    if (verbose ("footnote"))
    {
      for (auto& f : footnotes)
        if (color ())
          std::cerr << colorizeFootnote (f) << '\n';
        else
          std::cerr << f << '\n';
    }
```
and if for some reason the sync output should be treated as a footnote rather than usual output. In that case, I would simply check the verbosity token before the output section.

#### Additional information...

- [x] Have you run the test suite?
Passed:                          2717
Failed:                             0
Unexpected successes:               0
Skipped:                            0
Expected failures:                  4
Runtime:                         0.42 seconds