### PR TITLE
CmdInfo: fix missing spaces causing run-on in virtual tag list

### DIFF
--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -342,8 +342,8 @@ int CmdInfo::execute (std::string& output)
       if (task.hasTag ("PARENT"))    virtualTags += "PARENT ";         // 2017-01-07: Deprecated in 2.6.0
       if (task.hasTag ("PENDING"))   virtualTags += "PENDING ";
       if (task.hasTag ("PRIORITY"))  virtualTags += "PRIORITY ";
-      if (task.hasTag ("PROJECT"))   virtualTags += "PROJECT";
-      if (task.hasTag ("QUARTER"))   virtualTags += "QUARTER";
+      if (task.hasTag ("PROJECT"))   virtualTags += "PROJECT ";
+      if (task.hasTag ("QUARTER"))   virtualTags += "QUARTER ";
       if (task.hasTag ("READY"))     virtualTags += "READY ";
       if (task.hasTag ("SCHEDULED")) virtualTags += "SCHEDULED ";
       if (task.hasTag ("TAGGED"))    virtualTags += "TAGGED ";


### PR DESCRIPTION
#### Description

This patch fixes a cosmetic issue that would cause run-on tag names to be shown in the output when viewing a task and displaying its list of virtual tags.  Some lines were missing spaces, because their virtual tag definitions did not include a space like all the rest, and these spaces were relied on for output formatting.

#### Additional information...

> Have you run the test suite?

Have not run the test suite; presumably this is a cosmetic change.  Did test the fix itself and it does make the run-on tags disappear.