### PR TITLE
Nag based on task state before modification

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -48,7 +48,7 @@ void updateRecurrenceMask (Task&);
 void handleRecurrence2 ();
 
 // nag.cpp
-bool nag (Task&);
+void nag (std::vector <Task>&);
 
 // rules.cpp
 void initializeColorRules ();

--- a/test/nag.t
+++ b/test/nag.t
@@ -91,6 +91,70 @@ class TestNagging(TestCase):
         code, out, err = self.t("1 done")
         self.assertNotIn("NAG", err)
 
+    def test_nagging_bulk(self):
+        """Verify that only one nag message occurs when completing multiple tasks"""
+        self.t("add one")
+        self.t.faketime("+1d")
+        self.t("add two")
+        self.t("add two")
+
+        code, out, err = self.t("2 done")
+
+        self.assertEqual(err.count("NAG"), 1)
+
+    def test_nagging_active(self):
+        """Bug 2163: Verify that nagging does not occur when completing the most urgent active task"""
+        self.t("add one")
+        self.t.faketime("+1d")
+        self.t("add two")
+        self.t("2 start")
+
+        code, out, err = self.t("2 done")
+
+        # Taskwarrior should not nag about more urgent tasks
+        self.assertNotIn("NAG", err)
+
+    def test_nagging_start_only_task(self):
+        """Verify that nagging does not occur when there are no other tasks while starting a task"""
+        self.t("add one")
+
+        code, out, err = self.t("1 start")
+
+        self.assertNotIn("NAG", err)
+
+    def test_nagging_start(self):
+        """Verify that nagging occurs when there are READY tasks of higher urgency while starting a task"""
+        self.t("add one")
+        self.t.faketime("+10d")
+        self.t("add two")
+
+        code, out, err = self.t("2 start")
+
+        self.assertIn("NAG", err)
+
+    def test_nagging_nonag(self):
+        """Verify that nagging does not occur when a task has the nonag tag"""
+        self.t("add one +other")
+        self.t.faketime("+10d")
+        self.t("add two +nonag")
+
+        code, out, err = self.t("2 done")
+
+        self.assertNotIn("NAG", err)
+
+    def test_nagging_nonag_bulk(self):
+        """Verify that nagging occurs even if some tasks in a bulk operation have a nonag tag"""
+        self.t("add one +other")
+        self.t.faketime("+10d")
+        self.t("add two +other")
+        self.t.faketime("+10d")
+        self.t("add three +nonag")
+
+        code, out, err = self.t("2-3 done")
+
+        self.assertIn("NAG", err)
+
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
     unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
#### Description

With this patch, taskwarrior uses the urgency of tasks before any
modifications are applied when deciding whether to show nag messages.

Previously, taskwarrior would apply modifications before deciding
whether to show nag messages, which could lead to spurious nag messages
when completing an active task.

Fixes #2163.

#### Additional information...

- [x ] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
Failed:
version.t                           1

Unexpected successes:

Skipped:
dependencies.t                      1
feature.default.project.t           1
tw-1999.t                           1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
```