### PR TITLE
Tests to cover rc.verbose:nothing order invariance

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,8 @@
            Thanks to Beka, Max Rossmannek.
 - TW #2101 Numeric UDA values above 2,147,483,647 overflow without warning
            Thanks to Adam Monsen.
+- TW #2247 Configuration override rc.verbose:off not respected
+           Thanks to Vignesh Prabhu.
 - TW #2290 Support moving the config file to XDG_CONFIG_HOME
            Thanks to Julien Rabinow.
 - TW #2292 CmdEdit: Interruption should remove lock file

--- a/NEWS
+++ b/NEWS
@@ -52,6 +52,10 @@ Fixed regressions in 2.6.0
   - The "end of <date>" named dates ('eod', 'eow', ...) were pointing to the
     first second of the next day, instead of last second of the referenced
     interval. This was a regression introduced in 2.5.2.
+  - The rc.verbose:nothing configuration override was applied only if it were
+    the first configuration override. Otherwise task would by default inform
+    about the other overrides (see #2247). This was a regression introduced in
+    2.5.2.
 
 Removed Features in 2.6.0
 

--- a/test/verbose.t
+++ b/test/verbose.t
@@ -122,6 +122,24 @@ class TestVerbosity(TestCase):
         code, out, err = self.t("rc.verbose:project add proj:T two")
         self.assertIn("The project 'T' has changed.", err)
 
+    def test_bug_2247(self):
+        """
+        Verbosity override is applied regardless of the order of the arguments.
+        """
+
+        code, out, err = self.t("rc.color:0 add test")
+        self.assertIn("Configuration override", err)
+
+        # Once rc.verbose:nothing is set, no output about configuration overrides should appear
+        code, out, err = self.t("rc.verbose:nothing add test")
+        self.assertNotIn("Configuration override", err)
+
+        code, out, err = self.t("rc.color:0 rc.verbose:nothing add test")
+        self.assertNotIn("Configuration override", err)
+
+        code, out, err = self.t("rc.verbose:nothing rc.color:0 add test")
+        self.assertNotIn("Configuration override", err)
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner


### PR DESCRIPTION
Closes #2247.