### PR TITLE
Refactor to store tags as individual attributes

### DIFF
--- a/src/Task.h
+++ b/src/Task.h
@@ -125,7 +125,7 @@ public:
   int getTagCount () const;
   bool hasTag (const std::string&) const;
   void addTag (const std::string&);
-  void addTags (const std::vector <std::string>&);
+  void setTags (const std::vector <std::string>&);
   std::vector <std::string> getTags () const;
   void removeTag (const std::string&);
 
@@ -170,6 +170,10 @@ private:
   void validate_before (const std::string&, const std::string&);
   const std::string encode (const std::string&) const;
   const std::string decode (const std::string&) const;
+  bool isTagAttr (const std::string&) const;
+  const std::string tag2Attr (const std::string&) const;
+  const std::string attr2Tag (const std::string&) const;
+  void fixTagsAttribute ();
 
 public:
   float urgency_project     () const;

--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -366,7 +366,7 @@ void CmdEdit::parseTask (Task& task, const std::string& after, const std::string
   // tags
   value = findValue (after, "\n  Tags:");
   task.remove ("tags");
-  task.addTags (split (value, ' '));
+  task.setTags (split (value, ' '));
 
   // description.
   value = findMultilineValue (after, "\n  Description:", "\n  Created:");

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -413,6 +413,7 @@ int CmdInfo::execute (std::string& output)
     for (auto& att : all)
     {
       if (att.substr (0, 11) != "annotation_" &&
+          att.substr (0, 5) != "tags_" &&
           Context::getContext ().columns.find (att) == Context::getContext ().columns.end ())
       {
          row = view.addRow ();

--- a/test/tag.t
+++ b/test/tag.t
@@ -44,11 +44,16 @@ class TestTags(TestCase):
     def setUp(self):
         """Executed before each test in the class"""
 
+    def split_tags(self, tags):
+        return sorted(tags.strip().split(','))
+
     def test_tag_manipulation(self):
         """Test addition and removal of tags"""
         self.t("add +one This +two is a test +three")
         code, out, err = self.t("_get 1.tags")
-        self.assertEqual("one,two,three\n", out)
+        self.assertEqual(
+            sorted(["one", "two", "three"]),
+            self.split_tags(out))
 
         # Remove tags.
         self.t("1 modify -three -two -one")
@@ -58,7 +63,9 @@ class TestTags(TestCase):
         # Add tags.
         self.t("1 modify +four +five +six")
         code, out, err = self.t("_get 1.tags")
-        self.assertEqual("four,five,six\n", out)
+        self.assertEqual(
+            sorted(["four", "five", "six"]),
+            self.split_tags(out))
 
         # Remove tags.
         self.t("1 modify -four -five -six")


### PR DESCRIPTION
Each tag is stored as `tag_<tagname>: x`.  The `x` is required because
empty attributes are treated as nonexistent.

For compatibility, the `tags` attribute is updated in sync with the 
per-tag attributes.  This compatibility support may be dropped in later
versions.

Note that synchronization _updates_ use JSON format, which does not 
change with this patch, and thus no compatibility issues exist.  The 
synchronization _initialization_, however, uses FF4, meaning that a
sync server initialized from a version of `task` with this patch will
contain `tag_<tagname>` attributes, which will look like orphaned UDAs
to older versions.  However, as updates to tasks are synchronized via 
the sync server, the updates will not contain these attributes and they
will show as "deleted" in the `task info` display on the older version.
Aside from the noise in the `task info` output, this is harmless.                                                                                                                                                                   