### PR TITLE
use emplace

### DIFF
--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -302,7 +302,7 @@ void CLI2::entity (const std::string& category, const std::string& name)
       return;
 
   // The category/name pair was not found, therefore add it.
-  _entities.insert (std::pair <std::string, std::string> (category, name));
+  _entities.emplace (category, name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -325,7 +325,7 @@ void CLI2::add (const std::vector <std::string>& arguments, int offset /* = 0 */
   std::vector <A2> replacement {_original_args.begin(), _original_args.begin() + offset + 1};
 
   for (const auto& arg : arguments)
-    replacement.push_back (A2 (arg, Lexer::Type::word));
+    replacement.emplace_back (arg, Lexer::Type::word);
 
   for (unsigned int i = 1 + offset; i < _original_args.size (); ++i)
     replacement.push_back (_original_args[i]);
@@ -849,7 +849,7 @@ void CLI2::aliasExpansion ()
         Lexer::Type type;
         Lexer lex (_aliases[raw]);
         while (lex.token (lexeme, type))
-          reconstructed.push_back (A2 (lexeme, type));
+          reconstructed.emplace_back (lexeme, type);
 
         action = true;
         changes = true;
@@ -879,7 +879,7 @@ void CLI2::aliasExpansion ()
         Lexer::Type type;
         Lexer lex (_aliases[i.attribute ("raw")]);
         while (lex.token (lexeme, type))
-          reconstructedOriginals.push_back (A2 (lexeme, type));
+          reconstructedOriginals.emplace_back (lexeme, type);
 
         action = true;
         changes = true;
@@ -1536,7 +1536,7 @@ void CLI2::findIDs ()
           {
             changes = true;
             std::string number = a.attribute ("raw");
-            _id_ranges.push_back (std::pair <std::string, std::string> (number, number));
+            _id_ranges.emplace_back (number, number);
           }
         }
         else if (a._lextype == Lexer::Type::set)
@@ -1549,9 +1549,9 @@ void CLI2::findIDs ()
             changes = true;
             auto hyphen = element.find ('-');
             if (hyphen != std::string::npos)
-              _id_ranges.push_back (std::pair <std::string, std::string> (element.substr (0, hyphen), element.substr (hyphen + 1)));
+              _id_ranges.emplace_back (element.substr (0, hyphen), element.substr (hyphen + 1));
             else
-              _id_ranges.push_back (std::pair <std::string, std::string> (element, element));
+              _id_ranges.emplace_back (element, element);
           }
         }
 
@@ -1589,7 +1589,7 @@ void CLI2::findIDs ()
             changes = true;
             a.unTag ("MODIFICATION");
             a.tag ("FILTER");
-            _id_ranges.push_back (std::pair <std::string, std::string> (raw, raw));
+            _id_ranges.emplace_back (raw, raw);
           }
           else if (a._lextype == Lexer::Type::set)
           {
@@ -1604,9 +1604,9 @@ void CLI2::findIDs ()
               changes = true;
               auto hyphen = element.find ('-');
               if (hyphen != std::string::npos)
-                _id_ranges.push_back (std::pair <std::string, std::string> (element.substr (0, hyphen), element.substr (hyphen + 1)));
+                _id_ranges.emplace_back (element.substr (0, hyphen), element.substr (hyphen + 1));
               else
-                _id_ranges.push_back (std::pair <std::string, std::string> (element, element));
+                _id_ranges.emplace_back (element, element);
             }
           }
         }
@@ -2145,7 +2145,7 @@ void CLI2::defaultCommand ()
 
         while (lex.token (lexeme, type))
         {
-          reconstructedOriginals.push_back (A2 (lexeme, type));
+          reconstructedOriginals.emplace_back (lexeme, type);
 
           A2 cmd (lexeme, type);
           cmd.tag ("DEFAULT");

--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -122,7 +122,7 @@ void Eval::evaluateInfixExpression (const std::string& e, Variant& v) const
   std::string token;
   Lexer::Type type;
   while (l.token (token, type))
-    tokens.push_back (std::pair <std::string, Lexer::Type> (token, type));
+    tokens.emplace_back (token, type);
 
   // Parse for syntax checking and operator replacement.
   if (_debug)
@@ -149,7 +149,7 @@ void Eval::evaluatePostfixExpression (const std::string& e, Variant& v) const
   std::string token;
   Lexer::Type type;
   while (l.token (token, type))
-    tokens.push_back (std::pair <std::string, Lexer::Type> (token, type));
+    tokens.emplace_back (token, type);
 
   if (_debug)
     Context::getContext ().debug ("[1;37;42mFILTER[0m Postfix      " + dump (tokens));

--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -64,7 +64,7 @@ void Filter::subset (const std::vector <Task>& input, std::vector <Task>& output
   std::vector <std::pair <std::string, Lexer::Type>> precompiled;
   for (auto& a : Context::getContext ().cli2._args)
     if (a.hasTag ("FILTER"))
-      precompiled.push_back (std::pair <std::string, Lexer::Type> (a.getToken (), a._lextype));
+      precompiled.emplace_back (a.getToken (), a._lextype);
 
   if (precompiled.size ())
   {
@@ -107,7 +107,7 @@ void Filter::subset (std::vector <Task>& output)
   std::vector <std::pair <std::string, Lexer::Type>> precompiled;
   for (auto& a : Context::getContext ().cli2._args)
     if (a.hasTag ("FILTER"))
-      precompiled.push_back (std::pair <std::string, Lexer::Type> (a.getToken (), a._lextype));
+      precompiled.emplace_back (a.getToken (), a._lextype);
 
   // Shortcut indicates that only pending.data needs to be loaded.
   bool shortcut = false;

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -170,7 +170,7 @@ void TF2::add_task (Task& task)
 
   // For faster lookup
   if (Context::getContext ().cli2.getCommand () == "import")
-    _tasks_map.insert (std::pair<std::string, Task> (task.get("uuid"), task));
+    _tasks_map.emplace (task.get("uuid"), task);
 
   Task::status status = task.getStatus ();
   if (task.id == 0 &&
@@ -410,7 +410,7 @@ void TF2::load_tasks (bool from_gc /* = false */)
         _tasks.push_back (task);
 
       if (Context::getContext ().cli2.getCommand () == "import")  // For faster lookup only
-        _tasks_map.insert (std::pair<std::string, Task> (task.get("uuid"), task));
+        _tasks_map.emplace (task.get("uuid"), task);
     }
 
     // TDB2::gc() calls this after loading both pending and completed

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -790,7 +790,7 @@ void Task::parseJSON (const json::object* root_obj)
               name << "annotation_" << ann_timestamp;
           }
 
-          annos.insert (std::make_pair (name.str (), json::decode (what->_data)));
+          annos.emplace (name.str (), json::decode (what->_data));
         }
 
         setAnnotations (annos);

--- a/src/ViewTask.cpp
+++ b/src/ViewTask.cpp
@@ -242,7 +242,7 @@ std::string ViewTask::render (std::vector <Task>& data, std::vector <int>& seque
   std::vector <std::vector <std::string>> headers;
   for (unsigned int c = 0; c < _columns.size (); ++c)
   {
-    headers.push_back (std::vector <std::string> ());
+    headers.emplace_back ();
     _columns[c]->renderHeader (headers[c], widths[c], _sort[c] ? _sort_header : _header);
 
     if (headers[c].size () > max_lines)
@@ -312,7 +312,7 @@ std::string ViewTask::render (std::vector <Task>& data, std::vector <int>& seque
 
     for (unsigned int c = 0; c < _columns.size (); ++c)
     {
-      cells.push_back (std::vector <std::string> ());
+      cells.emplace_back ();
       _columns[c]->render (cells[c], data[sequence[s]], widths[c], row_color);
 
       if (cells[c].size () > max_lines)

--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -656,7 +656,7 @@ void CmdEdit::parseTask (Task& task, const std::string& after, const std::string
         while (annotations.find (name.str ()) != annotations.end ());
 
         auto text = Lexer::trim (value.substr (gap + 4), "\t ");
-        annotations.insert (std::make_pair (name.str (), text));
+        annotations.emplace (name.str (), text);
       }
     }
   }

--- a/src/commands/CmdGet.cpp
+++ b/src/commands/CmdGet.cpp
@@ -67,9 +67,9 @@ int CmdGet::execute (std::string& output)
         Task t;
         Variant result;
         if (getDOM (arg.attribute ("raw"), t, result))
-          results.push_back ((std::string) result);
+          results.emplace_back (result);
         else
-          results.push_back ("");
+          results.emplace_back ("");
       }
       break;
 

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -79,7 +79,7 @@ void sort_projects (
         
         // if parent does not exist yet: insert into sorted view
         if (parent_pos == sorted.end ())
-          sorted.push_back (std::make_pair (parent, 1));
+          sorted.emplace_back (parent, 1);
       }
       
       // insert new element below latest parent

--- a/test/lexer.t.cpp
+++ b/test/lexer.t.cpp
@@ -105,7 +105,7 @@ int main (int, char**)
   while (l2.token (token, type))
   {
     std::cout << "# «" << token << "» " << Lexer::typeName (type) << "\n";
-    tokens.push_back (std::pair <std::string, Lexer::Type> (token, type));
+    tokens.emplace_back (token, type);
   }
 
   t.is (tokens[0].first,                     "one",           "tokens[0] = 'one'"); // 30
@@ -147,7 +147,7 @@ int main (int, char**)
   while (l3.token (token, type))
   {
     std::cout << "# «" << token << "» " << Lexer::typeName (type) << "\n";
-    tokens.push_back (std::pair <std::string, Lexer::Type> (token, type));
+    tokens.emplace_back (token, type);
   }
 
   t.is ((int)tokens.size (),     7,                           "7 tokens");


### PR DESCRIPTION
Allows removing the constructor name as emplace forwards the arguments
directly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>