### PR TITLE
Implement non-cumulative config option for burndown command

### DIFF
--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -547,6 +547,12 @@ Taskwarrior supports command aliases. This alias provides an alternate name
 any of the commands. Several commands you may use are actually aliases -
 the 'history' report, for example, or 'export'.
 
+.TP
+.B burndown.cumulative=0
+May be "1" or "0", and controls the behaviour of the burndown command. When set 
+to 1, it sums up all completed tasks, otherwise they only get plotted in the 
+interval where the task was completed. Defaults to 1.
+
 .SS DATES
 
 .TP

--- a/src/commands/CmdBurndown.cpp
+++ b/src/commands/CmdBurndown.cpp
@@ -303,24 +303,16 @@ void Chart::scan (std::vector <Task>& tasks)
       if (_bars.find (epoch) != _bars.end ())
         ++_bars[epoch]._removed;
 
+      while (from < end)
+      {
+        epoch = from.toEpoch ();
+        if (_bars.find (epoch) != _bars.end ())
+          ++_bars[epoch]._pending;
+        from = increment (from, _period);
+      }
+
       if (cumulative)
       {
-      // Maintain a running total of 'done' tasks that are off the left of the
-      // chart.
-        if (end < _earliest)
-        {
-          ++_carryover_done;
-          continue;
-        }
-
-        while (from < end)
-        {
-          epoch = from.toEpoch ();
-          if (_bars.find (epoch) != _bars.end ())
-            ++_bars[epoch]._pending;
-          from = increment (from, _period);
-        }
-
         while (from < now)
         {
           epoch = from.toEpoch ();
@@ -328,19 +320,21 @@ void Chart::scan (std::vector <Task>& tasks)
             ++_bars[epoch]._done;
           from = increment (from, _period);
         }
+
+        // Maintain a running total of 'done' tasks that are off the left of the
+        // chart.
+        if (end < _earliest)
+        {
+          ++_carryover_done;
+          continue;
+        }
       }
 
       else
       {
-        while (from < end)
-        {
-          if (_bars.find (epoch) != _bars.end ())
-            ++_bars[epoch]._pending;
-          from = increment (from, _period);
-          epoch = from.toEpoch ();
-          if (_bars.find (epoch) != _bars.end ())
-            ++_bars[epoch]._done;
-        }
+		  epoch = from.toEpoch ();
+        if (_bars.find (epoch) != _bars.end ())
+          ++_bars[epoch]._done;
       }
     }
   }

--- a/src/commands/CmdBurndown.cpp
+++ b/src/commands/CmdBurndown.cpp
@@ -235,7 +235,17 @@ void Chart::scan (std::vector <Task>& tasks)
   Datetime now;
 
   time_t epoch;
-  bool cumulative = !Context::getContext ().config.getBoolean ("burndown.nc");
+  auto& config = Context::getContext ().config;
+  bool cumulative;
+  if (config.has ("burndown.cumulative"))
+  {
+    cumulative = config.getBoolean ("burndown.cumulative");
+  }
+  else
+  {
+    cumulative = true;
+  }
+
   for (auto& task : tasks)
   {
     // The entry date is when the counting starts.

--- a/test/burndown.t
+++ b/test/burndown.t
@@ -66,7 +66,7 @@ class TestBurndownCommand(TestCase):
 
     def test_burndown_daily_non_cumulative(self):
         """Ensure burndown.daily in non-cumulative mode generates a chart"""
-        self.t.config("burndown.nc", True)
+        self.t.config("burndown.cumulative", False)
 		  code, out, err = self.t("burndown.daily")
         self.assertIn("Daily Burndown", out)
         self.assertIn(".", out)

--- a/test/burndown.t
+++ b/test/burndown.t
@@ -66,7 +66,7 @@ class TestBurndownCommand(TestCase):
 
     def test_burndown_daily_non_cumulative(self):
         """Ensure burndown.daily in non-cumulative mode generates a chart"""
-        self.t.config("burndown.cumulative", False)
+        self.t.config("burndown.cumulative", "0")
         code, out, err = self.t("burndown.daily")
         self.assertIn("Daily Burndown", out)
         self.assertIn(".", out)

--- a/test/burndown.t
+++ b/test/burndown.t
@@ -64,6 +64,15 @@ class TestBurndownCommand(TestCase):
         self.assertIn("+", out)
         self.assertIn("X", out)
 
+    def test_burndown_daily_non_cumulative(self):
+        """Ensure burndown.daily in non-cumulative mode generates a chart"""
+        self.t.config("burndown.nc", True)
+		  code, out, err = self.t("burndown.daily")
+        self.assertIn("Daily Burndown", out)
+        self.assertIn(".", out)
+        self.assertIn("+", out)
+        self.assertIn("X", out)
+
     def test_burndown_daily_color(self):
         """Ensure burndown.daily with color, generates a chart"""
         code, out, err = self.t("burndown.daily rc._forcecolor:on")

--- a/test/burndown.t
+++ b/test/burndown.t
@@ -67,7 +67,7 @@ class TestBurndownCommand(TestCase):
     def test_burndown_daily_non_cumulative(self):
         """Ensure burndown.daily in non-cumulative mode generates a chart"""
         self.t.config("burndown.cumulative", False)
-		  code, out, err = self.t("burndown.daily")
+        code, out, err = self.t("burndown.daily")
         self.assertIn("Daily Burndown", out)
         self.assertIn(".", out)
         self.assertIn("+", out)


### PR DESCRIPTION
#### Description

This should fix #1914

#### Additional information...

- [x] Have you run the test suite?

Output before implementing the feature and according test:

```bash
Failed:
template.t                          2

Unexpected successes:

Skipped:
dependencies.t                      1
export.t                            1
feature.default.project.t           4
filter.t                            1
hooks.on-modify.t                   1
import.t                            1
nag.t                               5
recurrence.t                        1
template.t                          3
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
template.t                          1
tw-2124.t                           1
```

Output after implementation:
```bash
Failed:
template.t                          2

Unexpected successes:

Skipped:
dependencies.t                      1
export.t                            1
feature.default.project.t           4
filter.t                            1
hooks.on-modify.t                   1
import.t                            1
nag.t                               5
recurrence.t                        1
template.t                          3
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
template.t                          1
tw-2124.t                           1
```