### PR TITLE
CLI2: Apply UUID/ID context break only for readable context

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@
 - TW #1804 Importing malformed annotation (without entry timestamp) causes
            segmentation fault.
            Thanks to David Badura.
+- TW #1824 Fixed countdown formatting
+           Thanks to Sebastian Uharek
 - TW #1896 Parser cannot handle empty parentheses
            Thanks to Tomas Babej.
 - TW #1908 Cannot create task with explicit description 'start ....'
@@ -76,6 +78,8 @@
            Thanks to Scott Kostyshak.
 - TW #2503 Warn against executing an empty execute command.
            Thanks to heinrichat.
+- TW #2208 Feature: added coloring of dates with scheduled tasks to calendar
+           Thanks to Sebastian Uharek
 - TW #2514 Duration values can be mis-reported in the task info output
            Thanks to reportaman.
 - TW #2519 Named date eod should be last minute of today and not first of
@@ -86,10 +90,6 @@
 - TW #2536 Feature: inclusive range-end attribute modifier 'by' so 'end of'
            named dates can be filtered inclusively
            Thanks to Scott Mcdermott
-- TW #1824 Fixed countdown formatting
-           Thanks to Sebastian Uharek
-- #2208    Feature: added coloring of dates with scheduled tasks to calendar
-           Thanks to Sebastian Uharek
 
 ------ current release ---------------------------
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,12 +1,5 @@
 2.6.0 () -
 
-- TW #2554 Waiting is now an entirely "virtual" concept, based on a task's
-  'wait' property and the current time.  This is reflected in the +WAITING
-  tag, and in the now-deprecated `waiting` status.  Please upgrade filters
-  and other automation to use `+WAITING` or `wait.after:now` instead of
-  `status:waiting`, as support will be dropped in a future version.
-  TaskWarrior no longer explicitly "unwaits" a task, so the "unwait' verbosity
-  token is no longer available.
 - TW #1654 "Due" parsing behaviour seems inconsistent
            Thanks to Max Rossmannek.
 - TW #1788 When deleting recurring task all tasks, including completed tasks,
@@ -92,6 +85,9 @@
            Thanks to Scott Mcdermott
 - TW #2550 Write context skipped if description contains an identifier
            Thanks to Sebastian Fricke.
+- TW #2554 Remove the waiting state, and consider any task with wait>now to be
+           waiting
+           Thanks to Dustin J. Mitchell
 
 ------ current release ---------------------------
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -90,6 +90,8 @@
 - TW #2536 Feature: inclusive range-end attribute modifier 'by' so 'end of'
            named dates can be filtered inclusively
            Thanks to Scott Mcdermott
+- TW #2550 Write context skipped if description contains an identifier
+           Thanks to Sebastian Fricke.
 
 ------ current release ---------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -27,7 +27,13 @@ New Features in Taskwarrior 2.6.0
     'due.by:eod', which it would not otherwise.  It also works with
     whole units like days, e.g. 'add test due:2021-07-17' would not match
     'due.before:tomorrow' (on the 16th), but would match 'due.by:tomorrow'.
-
+  - Waiting is now an entirely "virtual" concept, based on a task's
+    'wait' property and the current time. Task is consiered "waiting" if its
+    wait attribute is in the future.  TaskWarrior no longer explicitly
+    "unwaits" a task (the wait attribute is not removed once its value is in
+    the past), so the "unwait' verbosity token is no longer available.
+    This allows for filtering for tasks that were waiting in the past
+    intervals, but are not waiting anymore.
 
 New Commands in Taskwarrior 2.6.0
 
@@ -46,6 +52,8 @@ New Configuration Options in Taskwarrior 2.6.0
 Newly Deprecated Features in Taskwarrior 2.6.0
 
   - The 'PARENT' and 'CHILD' virtual tags are replaced by 'TEMPLATE' and 'INSTANCE'.
+  - The 'waiting' status is now deprecated. We recommend using +WAITING virtual tag
+    or wait-attribute based filters, such as 'wait.before:eow' instead.
 
 Fixed regressions in 2.6.0
 

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -607,17 +607,18 @@ void CLI2::addContext (bool readable, bool writeable)
   if (contextString.empty ())
     return;
 
-  // Detect if UUID or ID is set, and bail out
-  for (auto& a : _args)
-  {
-    if (a._lextype == Lexer::Type::uuid   ||
-        a._lextype == Lexer::Type::number ||
-        a._lextype == Lexer::Type::set)
+  // For readable contexts: Detect if UUID or ID is set, and bail out
+  if (readable)
+    for (auto& a : _args)
     {
-      Context::getContext ().debug (format ("UUID/ID argument found '{1}', not applying context.", a.attribute ("raw")));
-      return;
+      if (a._lextype == Lexer::Type::uuid   ||
+          a._lextype == Lexer::Type::number ||
+          a._lextype == Lexer::Type::set)
+      {
+        Context::getContext ().debug (format ("UUID/ID argument found '{1}', not applying context.", a.attribute ("raw")));
+        return;
+      }
     }
-  }
 
   // Apply the context. Readable (filtering) takes precedence. Also set the
   // block now, since addFilter calls analyze(), which calls addContext().

--- a/test/tw-2550.t
+++ b/test/tw-2550.t
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+. bash_tap_tw.sh
+
+# Setup the context
+task config context.work.read '+work'
+task config context.work.write '+work'
+
+# Create a task outside of the context
+task add outside
+
+# Activate the context
+task context work
+
+# Add multiple tasks within the context, some of which contain numbers or uuids
+task add inside
+task add inside 2
+task add inside 3
+task add inside aabbccdd
+task add inside 4-5
+
+# Assertion: Task defined outside of the context should not show up
+[[ -z `task all | grep outside` ]]
+
+# Five tasks were defined within the context
+task count
+[[ `task count` == "5" ]]
+
+# Unset the context
+task context none
+
+# Exactly five tasks have the tag work
+task +work count
+[[ `task +work count` == "5" ]]


### PR DESCRIPTION
The purpose of this break is to not apply the context on commands like

    task 4 info

so that we can still refer to tasks directly (using their ID/UUID
references) even if they fall outside of the currectly active context.

However, this break should not be applied for writeable context. This is
because the lexer can (a bit misleadingly) label parts of the desription
of the new task as number/identifier tokens

    task add Replace 3 parts of the puzzle abc123
                     ^                     ^
                     type::number          type:uuid

which would trigger the break unnecessarily.

Closes #2550.
