### PR TITLE
Refactor to store dependencies as individual attributes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2.6.0 () -
 
+- TW #2569 The `json.depends.array` configuration option is now ignored.
+           Dependencies are always represented as an array in JSON output.
+- TW #2554 Waiting is now an entirely "virtual" concept, based on a task's
+           'wait' property and the current time.  This is reflected in the +WAITING
+           tag, and in the now-deprecated `waiting` status.  Please upgrade filters
+           and other automation to use `+WAITING` or `wait.after:now` instead of
+           `status:waiting`, as support will be dropped in a future version.
+           TaskWarrior no longer explicitly "unwaits" a task, so the "unwait' verbosity
+           token is no longer available.
 - TW #1654 "Due" parsing behaviour seems inconsistent
            Thanks to Max Rossmannek.
 - TW #1788 When deleting recurring task all tasks, including completed tasks,

--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -425,12 +425,6 @@ With json.array=0, export writes raw JSON objects to STDOUT, one per line.
 Defaults to "1".
 
 .TP
-.B json.depends.array=1
-Determines whether the export command encodes dependencies as an array of string
-UUIDs, or one comma-separated string.
-Defaults to "1".
-
-.TP
 .B _forcecolor=1
 Taskwarrior shuts off color automatically when the output is not sent directly
 to a TTY. For example, this command:

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -109,7 +109,6 @@ std::string configurationDefaults =
   "xterm.title=0                                  # Sets xterm title for some commands\n"
   "expressions=infix                              # Prefer infix over postfix expressions\n"
   "json.array=1                                   # Enclose JSON output in [ ]\n"
-  "json.depends.array=0                           # Encode dependencies as a JSON array\n"
   "abbreviation.minimum=2                         # Shortest allowed abbreviation\n"
   "\n"
   "# Dates\n"

--- a/src/Task.h
+++ b/src/Task.h
@@ -144,8 +144,10 @@ public:
 #ifdef PRODUCT_TASKWARRIOR
   void removeDependency (int);
   void removeDependency (const std::string&);
+  bool hasDependency (const std::string&) const;
   std::vector <int>         getDependencyIDs () const;
   std::vector <std::string> getDependencyUUIDs () const;
+  std::vector <Task>        getBlockedTasks () const;
   std::vector <Task>        getDependencyTasks () const;
 
   std::vector <std::string> getUDAOrphanUUIDs () const;

--- a/src/Task.h
+++ b/src/Task.h
@@ -88,7 +88,7 @@ public:
 
   void setAsNow (const std::string&);
   bool has (const std::string&) const;
-  std::vector <std::string> all ();
+  std::vector <std::string> all () const;
   const std::string identifier (bool shortened = false) const;
   const std::string get (const std::string&) const;
   const std::string& get_ref (const std::string&) const;
@@ -176,6 +176,10 @@ private:
   bool isTagAttr (const std::string&) const;
   const std::string tag2Attr (const std::string&) const;
   const std::string attr2Tag (const std::string&) const;
+  bool isDepAttr (const std::string&) const;
+  const std::string dep2Attr (const std::string&) const;
+  const std::string attr2Dep (const std::string&) const;
+  void fixDependsAttribute ();
   void fixTagsAttribute ();
 
 public:

--- a/src/columns/ColDepends.cpp
+++ b/src/columns/ColDepends.cpp
@@ -68,7 +68,9 @@ void ColumnDepends::setStyle (const std::string& value)
 void ColumnDepends::measure (Task& task, unsigned int& minimum, unsigned int& maximum)
 {
   minimum = maximum = 0;
-  if (task.has (_name))
+  auto deptasks = task.getDependencyTasks ();
+
+  if (deptasks.size () > 0)
   {
     if (_style == "indicator")
     {
@@ -77,25 +79,24 @@ void ColumnDepends::measure (Task& task, unsigned int& minimum, unsigned int& ma
 
     else if (_style == "count")
     {
-      minimum = maximum = 2 + format ((int) dependencyGetBlocking (task).size ()).length ();
+      minimum = maximum = 2 + format ((int) deptasks.size ()).length ();
     }
 
     else if (_style == "default" ||
              _style == "list")
     {
       minimum = maximum = 0;
-      auto blocking = dependencyGetBlocking (task);
 
       std::vector <int> blocking_ids;
-      blocking_ids.reserve(blocking.size());
-      for (auto& i : blocking)
+      blocking_ids.reserve(deptasks.size());
+      for (auto& i : deptasks)
         blocking_ids.push_back (i.id);
 
       auto all = join (" ", blocking_ids);
       maximum = all.length ();
 
       unsigned int length;
-      for (auto& i : blocking)
+      for (auto& i : deptasks)
       {
         length = format (i.id).length ();
         if (length > minimum)
@@ -112,7 +113,9 @@ void ColumnDepends::render (
   int width,
   Color& color)
 {
-  if (task.has (_name))
+  auto deptasks = task.getDependencyTasks ();
+
+  if (deptasks.size () > 0)
   {
     if (_style == "indicator")
     {
@@ -121,17 +124,15 @@ void ColumnDepends::render (
 
     else if (_style == "count")
     {
-      renderStringRight (lines, width, color, '[' + format (static_cast <int>(dependencyGetBlocking (task).size ())) + ']');
+      renderStringRight (lines, width, color, '[' + format (static_cast <int>(deptasks.size ())) + ']');
     }
 
     else if (_style == "default" ||
              _style == "list")
     {
-      auto blocking = dependencyGetBlocking (task);
-
       std::vector <int> blocking_ids;
-      blocking_ids.reserve(blocking.size());
-      for (const auto& t : blocking)
+      blocking_ids.reserve(deptasks.size());
+      for (const auto& t : deptasks)
         blocking_ids.push_back (t.id);
 
       auto combined = join (" ", blocking_ids);

--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -667,7 +667,8 @@ void CmdEdit::parseTask (Task& task, const std::string& after, const std::string
   value = findValue (after, "\n  Dependencies:");
   auto dependencies = split (value, ',');
 
-  task.remove ("depends");
+  for (auto& dep : task.getDependencyUUIDs ())
+    task.removeDependency (dep);
   for (auto& dep : dependencies)
   {
     if (dep.length () >= 7)

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -147,7 +147,7 @@ int CmdInfo::execute (std::string& output)
 
     // dependencies: blocked
     {
-      auto blocked = dependencyGetBlocking (task);
+      auto blocked = task.getDependencyTasks ();
       if (blocked.size ())
       {
         std::stringstream message;
@@ -162,7 +162,7 @@ int CmdInfo::execute (std::string& output)
 
     // dependencies: blocking
     {
-      auto blocking = dependencyGetBlocked (task);
+      auto blocking = task.getBlockedTasks ();
       if (blocking.size ())
       {
         std::stringstream message;

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -414,6 +414,7 @@ int CmdInfo::execute (std::string& output)
     {
       if (att.substr (0, 11) != "annotation_" &&
           att.substr (0, 5) != "tags_" &&
+          att.substr (0, 4) != "dep_" &&
           Context::getContext ().columns.find (att) == Context::getContext ().columns.end ())
       {
          row = view.addRow ();

--- a/src/commands/CmdPurge.cpp
+++ b/src/commands/CmdPurge.cpp
@@ -71,8 +71,7 @@ void CmdPurge::handleDeps (Task& task)
    for (auto& blockedConst: Context::getContext ().tdb2.all_tasks ())
    {
      Task& blocked = const_cast<Task&>(blockedConst);
-     if (blocked.has ("depends") &&
-         blocked.get ("depends").find (uuid) != std::string::npos)
+     if (blocked.hasDependency (uuid))
      {
          blocked.removeDependency (uuid);
          Context::getContext ().tdb2.modify (blocked);

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -172,7 +172,6 @@ int CmdShow::execute (std::string& output)
     " journal.time.start.annotation"
     " journal.time.stop.annotation"
     " json.array"
-    " json.depends.array"
     " list.all.projects"
     " list.all.tags"
     " locking"

--- a/src/dependency.cpp
+++ b/src/dependency.cpp
@@ -37,38 +37,6 @@
 #define STRING_DEPEND_BLOCKED        "Task {1} is blocked by:"
 
 ////////////////////////////////////////////////////////////////////////////////
-std::vector <Task> dependencyGetBlocked (const Task& task)
-{
-  auto uuid = task.get ("uuid");
-
-  std::vector <Task> blocked;
-  for (auto& it : Context::getContext ().tdb2.pending.get_tasks ())
-    if (it.getStatus () != Task::completed &&
-        it.getStatus () != Task::deleted   &&
-        it.has ("depends")                 &&
-        it.get ("depends").find (uuid) != std::string::npos)
-      blocked.push_back (it);
-
-  return blocked;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-std::vector <Task> dependencyGetBlocking (const Task& task)
-{
-  auto depends = task.get ("depends");
-
-  std::vector <Task> blocking;
-  if (depends != "")
-    for (auto& it : Context::getContext ().tdb2.pending.get_tasks ())
-      if (it.getStatus () != Task::completed &&
-          it.getStatus () != Task::deleted   &&
-          depends.find (it.get ("uuid")) != std::string::npos)
-        blocking.push_back (it);
-
-  return blocking;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Returns true if the supplied task adds a cycle to the dependency chain.
 bool dependencyIsCircular (const Task& task)
 {
@@ -150,12 +118,12 @@ bool dependencyIsCircular (const Task& task)
 //
 void dependencyChainOnComplete (Task& task)
 {
-  auto blocking = dependencyGetBlocking (task);
+  auto blocking = task.getDependencyTasks ();
 
   // If the task is anything but the tail end of a dependency chain.
   if (blocking.size ())
   {
-    auto blocked = dependencyGetBlocked (task);
+    auto blocked = task.getBlockedTasks ();
 
     // Nag about broken chain.
     if (Context::getContext ().config.getBoolean ("dependency.reminder"))
@@ -207,7 +175,7 @@ void dependencyChainOnStart (Task& task)
 {
   if (Context::getContext ().config.getBoolean ("dependency.reminder"))
   {
-    auto blocking = dependencyGetBlocking (task);
+    auto blocking = task.getDependencyTasks ();
 
     // If the task is anything but the tail end of a dependency chain, nag about
     // broken chain.

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -78,6 +78,7 @@ std::string taskDifferences (const Task& before, const Task& after)
         << format ("{1} will be deleted.", Lexer::ucFirst (name))
         << "\n";
 
+  // TODO: #2572 - rewrite to look at dep_ and tag_
   for (auto& name : afterOnly)
   {
     if (name == "depends")
@@ -384,12 +385,12 @@ void feedback_unblocked (const Task& task)
   if (Context::getContext ().verbose ("affected"))
   {
     // Get a list of tasks that depended on this task.
-    auto blocked = dependencyGetBlocked (task);
+    auto blocked = task.getBlockedTasks ();
 
     // Scan all the tasks that were blocked by this task
     for (auto& i : blocked)
     {
-      auto blocking = dependencyGetBlocking (i);
+      auto blocking = i.getDependencyTasks ();
       if (blocking.size () == 0)
       {
         if (i.id)

--- a/src/main.h
+++ b/src/main.h
@@ -59,8 +59,6 @@ std::string colorizeError (const std::string&);
 std::string colorizeDebug (const std::string&);
 
 // dependency.cpp
-std::vector <Task> dependencyGetBlocked (const Task&);
-std::vector <Task> dependencyGetBlocking (const Task&);
 bool dependencyIsCircular (const Task&);
 void dependencyChainOnComplete (Task&);
 void dependencyChainOnStart (Task&);

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -217,8 +217,8 @@ static bool sort_compare (int left, int right)
         return !ascending;
 
       // Sort on the first dependency.
-      left_number  = Context::getContext ().tdb2.id (left_deps[0].substr (0, 36));
-      right_number = Context::getContext ().tdb2.id (right_deps[0].substr (0, 36));
+      left_number  = Context::getContext ().tdb2.id (left_deps[0]);
+      right_number = Context::getContext ().tdb2.id (right_deps[0]);
 
       if (left_number == right_number)
         continue;

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -200,22 +200,25 @@ static bool sort_compare (int left, int right)
     // Depends string.
     else if (field == "depends")
     {
-      // Raw data is a comma-separated list of uuids
-      auto left_string  = (*global_data)[left].get_ref  (field);
-      auto right_string = (*global_data)[right].get_ref (field);
+      // Raw data is an un-sorted list of UUIDs.  We just need a stable
+      // sort, so we sort them lexically.
+      auto left_deps  = (*global_data)[left].getDependencyUUIDs ();
+      std::sort(left_deps.begin(), left_deps.end());
+      auto right_deps = (*global_data)[right].getDependencyUUIDs ();
+      std::sort(right_deps.begin(), right_deps.end());
 
-      if (left_string == right_string)
+      if (left_deps == right_deps)
         continue;
 
-      if (left_string == "" && right_string != "")
+      if (left_deps.size () == 0 && right_deps.size () > 0)
         return ascending;
 
-      if (left_string != "" && right_string == "")
+      if (left_deps.size () > 0 && right_deps.size () == 0)
         return !ascending;
 
       // Sort on the first dependency.
-      left_number  = Context::getContext ().tdb2.id (left_string.substr (0, 36));
-      right_number = Context::getContext ().tdb2.id (right_string.substr (0, 36));
+      left_number  = Context::getContext ().tdb2.id (left_deps[0].substr (0, 36));
+      right_number = Context::getContext ().tdb2.id (right_deps[0].substr (0, 36));
 
       if (left_number == right_number)
         continue;

--- a/test/export.t
+++ b/test/export.t
@@ -146,26 +146,12 @@ class TestExportCommand(TestCase):
         self.t(('add', 'everything depends on me task'))
         self.t(('add', 'wrong, everything depends on me task'))
         self.t('1 modify depends:2,3')
-        self.t.config('json.depends.array', 'on')
 
         deps = self.export(1)['depends']
         self.assertType(deps, list)
         self.assertEqual(len(deps), 2)
 
         for uuid in deps:
-            self.assertString(uuid, UUID_REGEXP, regexp=True)
-
-    def test_export_depends_oldformat(self):
-        self.t(('add', 'everything depends on me task'))
-        self.t(('add', 'wrong, everything depends on me task'))
-        self.t('1 modify depends:2,3')
-
-        code, out, err = self.t("rc.json.array=off rc.json.depends.array=off 1 export")
-        deps = json.loads(out)["depends"]
-        self.assertString(deps)
-        self.assertEqual(len(deps.split(",")), 2)
-
-        for uuid in deps.split(','):
             self.assertString(uuid, UUID_REGEXP, regexp=True)
 
     def test_export_urgency(self):

--- a/test/import.t
+++ b/test/import.t
@@ -187,15 +187,6 @@ class TestImport(TestCase):
         self.assertIn("Imported 3 tasks", err)
         self.assertData1()
 
-    def test_import_old_depend(self):
-        """One dependency used to be a plain string"""
-        _data = """{"uuid":"a0000000-a000-a000-a000-a00000000000","depends":"a1111111-a111-a111-a111-a11111111111","description":"zero","project":"A","status":"pending","entry":"1234567889"}"""
-        self.t("import", input=self.data1)
-        self.t("import", input=_data)
-        self.t.config("json.depends.array", "0")
-        _t = self.t.export("a0000000-a000-a000-a000-a00000000000")[0]
-        self.assertEqual(_t["depends"], "a1111111-a111-a111-a111-a11111111111")
-
     def test_import_old_depends(self):
         """Several dependencies used to be a comma seperated string"""
         _data = """{"uuid":"a0000000-a000-a000-a000-a00000000000","depends":"a1111111-a111-a111-a111-a11111111111,a2222222-a222-a222-a222-a22222222222","description":"zero","project":"A","status":"pending","entry":"1234567889"}"""
@@ -207,7 +198,6 @@ class TestImport(TestCase):
 
     def test_import_new_depend(self):
         """One dependency is a single array element"""
-        self.t.config('json.depends.array', 'on')
         _data = """{"uuid":"a0000000-a000-a000-a000-a00000000000","depends":["a1111111-a111-a111-a111-a11111111111"],"description":"zero","project":"A","status":"pending","entry":"1234567889"}"""
         self.t("import", input=self.data1)
         self.t("import", input=_data)
@@ -216,7 +206,6 @@ class TestImport(TestCase):
 
     def test_import_new_depends(self):
         """Several dependencies are an array"""
-        self.t.config('json.depends.array', 'on')
         _data = """{"uuid":"a0000000-a000-a000-a000-a00000000000","depends":["a1111111-a111-a111-a111-a11111111111","a2222222-a222-a222-a222-a22222222222"],"description":"zero","project":"A","status":"pending","entry":"1234567889"}"""
         self.t("import", input=self.data1)
         self.t("import", input=_data)


### PR DESCRIPTION
This also drops support for the transitional `json.depends.array` configuration value, which has not been necessary since ~2016.

As with tags, dependencies are stored in both a "combined", comma-separated format (for compatibility) and in an attribute-per-dependency format (for the future).

The first commit in this PR takes pains to prevent direct access to the `depends` attribute, although two places will be handled in #2572.