### PR TITLE
CmdConfig: Properly preserve comments at the end of the line

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -91,6 +91,7 @@
 - TW #2569 The `json.depends.array` configuration option is now ignored.
            Dependencies are always represented as an array in JSON output.
            Thanks to Dustin J. Mitchell
+- TW #2581 Config entry with a trailing comment cannot be modified
 
 ------ current release ---------------------------
 

--- a/src/commands/CmdConfig.cpp
+++ b/src/commands/CmdConfig.cpp
@@ -64,23 +64,27 @@ bool CmdConfig::setConfigVariable (
 
   for (auto& line : contents)
   {
+    // Get l-trimmed version of the line
+    auto trimmed_line = trim (line, " ");
+
     // If there is a comment on the line, it must follow the pattern.
     auto comment = line.find ('#');
-    auto pos     = line.find (name + '=');
+    auto pos = trimmed_line.find (name + '=');
 
-    if (pos != std::string::npos &&
-        (comment == std::string::npos ||
-         comment > pos))
+    // TODO: Use std::regex here
+    if (pos == 0)
     {
       found = true;
       if (!confirmation ||
           confirm (format ("Are you sure you want to change the value of '{1}' from '{2}' to '{3}'?", name, Context::getContext ().config.get (name), value)))
       {
-        line = name + '=' + json::encode (value);
+        auto new_line = line.substr (0, pos + name.length () + 1) + json::encode (value);
 
         if (comment != std::string::npos)
           line += ' ' + line.substr (comment);
 
+        // Rewrite the line
+        line = new_line;
         change = true;
       }
     }
@@ -115,13 +119,13 @@ int CmdConfig::unsetConfigVariable (const std::string& name, bool confirmation /
   {
     auto lineDeleted = false;
 
-    // If there is a comment on the line, it must follow the pattern.
-    auto comment = line->find ('#');
-    auto pos     = line->find (name + '=');
+    // Get l-trimmed version of the line
 
-    if (pos != std::string::npos &&
-        (comment == std::string::npos ||
-         comment > pos))
+    // If there is a comment on the line, it must follow the pattern.
+    auto pos = trim (*line, " ").find (name + '=');
+
+    // TODO: Use std::regex here
+    if (pos == 0)
     {
       found = true;
 

--- a/src/commands/CmdConfig.cpp
+++ b/src/commands/CmdConfig.cpp
@@ -80,8 +80,9 @@ bool CmdConfig::setConfigVariable (
       {
         auto new_line = line.substr (0, pos + name.length () + 1) + json::encode (value);
 
+        // Preserve the comment
         if (comment != std::string::npos)
-          line += ' ' + line.substr (comment);
+          new_line += "  " + line.substr (comment);
 
         // Rewrite the line
         line = new_line;

--- a/test/tw-2581.t
+++ b/test/tw-2581.t
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Test setting configuration variable with a trailing comment works
+. bash_tap_tw.sh
+
+# Add configuration variable with a trailing comment into taskrc
+echo 'weekstart=Monday  # Europe standard' >> taskrc
+cat taskrc
+
+# Use config the change the value to "Sunday"
+task config weekstart Sunday
+
+# Ensure the comment was preserved and value changed
+cat taskrc | grep weekstart=Sunday
+[[ `cat taskrc | grep weekstart=Sunday` == 'weekstart=Sunday  # Europe standard' ]]


### PR DESCRIPTION
Trailing comments previously caused crash of the application.
    
Closes #2581.
