### PR TITLE
Fixes #2580

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -793,6 +793,11 @@ void Task::parseJSON (const json::object* root_obj)
       {
         std::map <std::string, std::string> annos;
 
+        // Fail if 'annotations' is not an array
+        if (i.second->type() != json::j_array) {
+            throw format ("Annotations is malformed: {1}", i.second->dump ());
+        }
+
         auto atts = (json::array*)i.second;
         for (auto& annotations : atts->_data)
         {

--- a/test/import.t
+++ b/test/import.t
@@ -292,6 +292,12 @@ class TestImportValidate(TestCase):
         code, out, err = self.t.runError("import", input=j)
         self.assertIn("The status 'foo' is not valid.", err)
 
+    def test_import_malformed_annotation(self):
+        """Verify invalid 'annnotations' is caught"""
+        j = '{"description": "bad", "annotations": "bad"}'
+        code, out, err = self.t.runError("import", input=j)
+        self.assertIn('Annotations is malformed: "bad"', err)
+
 
 class TestImportWithoutISO(TestCase):
     def setUp(self):


### PR DESCRIPTION
#### Description
Check annotations field before parsing

Add test case for annotations

#### Additional information...

- [x] Have you run the test suite?
```
Failed:
delete.t                            2
urgency.t                           1

Unexpected successes:

Skipped:
dependencies.t                      1
export.t                            1
feature.default.project.t           4
filter.t                            1
hooks.on-modify.t                   1
import.t                            1
nag.t                               5
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:
dependencies.t                      3
filter.t                            3
hyphenate.t                         1
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
```

I am able to run `delete.t` and `urgency.t` separately though
./delete.t
```
ok 1 - delete.t: Verify that add/delete/undo yields a Pending task
ok 2 - delete.t: Verify that a completed task can be deleted
ok 3 - delete.t: Delete prompt with closed STDIN causes infinite loop and floods stdout (bulk)
ok 4 - delete.t: Verify that en-passant works with delete
ok 5 - delete.t: Delete prompt with closed STDIN causes infinite loop and floods stdout (multiple)
ok 6 - delete.t: Delete prompt with closed STDIN causes infinite loop and floods stdout (single)
```

./urgency.t
```
ok 1 - urgency.t: 837: Verify urgency goes to zero after unblocking
ok 2 - urgency.t: Verify urgency calculations involving active tasks
ok 3 - urgency.t: Verify all tasks when no filter is specified
ok 4 - urgency.t: Verify urgency calculations involving annotations
ok 5 - urgency.t: Verify urgency coefficient override
ok 6 - urgency.t: Verify urgency calculations involving dependencies
ok 7 - urgency.t: Verify urgency calculations involving due dates
ok 8 - urgency.t: Verify urgency calculations involving +next
ok 9 - urgency.t: Verify no error when no tasks match
ok 10 - urgency.t: Verify urgency calculations involving priority
ok 11 - urgency.t: Verify urgency calculations involving project
ok 12 - urgency.t: Verify urgency calculations involving a scheduled task
ok 13 - urgency.t: Verify urgency calculations involving tags
ok 14 - urgency.t: Verify urgency calculations involving user project
ok 15 - urgency.t: Verify urgency calculations involving user tag
ok 16 - urgency.t: Verify _urgency using UUID lookup
ok 17 - urgency.t: Verify urgency calculations involving waiting tasks
```
