### PR TITLE
Fixed bug with double escaped single quotes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,8 @@
            Thanks to Florian.
 - TW #1955 Adding tasks in context.
            Thanks to Jean-Francois Joly, Matt Smith.
+- TW #1960 Fixed bug with double escaped single quotes.
+           Thanks to Sebastian Uharek
 - TW #2004 "shell" should not be expand to "exec tasksh"
            Thanks to Arvedui
 - TW #2007 Compute number of current tasks correctly

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -36,6 +36,8 @@
 #include <format.h>
 #include <CmdCustom.h>
 #include <CmdTimesheet.h>
+#include <utf8.h>
+
 
 // Overridden by rc.abbreviation.minimum.
 int CLI2::minimumMatchLength = 3;
@@ -413,24 +415,31 @@ void CLI2::lexArguments ()
       _args.push_back (a);
     }
 
-    // Process muktiple-token arguments.
+    // Process multiple-token arguments.
     else
     {
       std::string quote = "'";
+
       // Escape unescaped single quotes
       std::string escaped = "";
+      std::string::size_type cursor = 0;
+
       bool nextEscaped = false;
-      for(auto c : _original_args[i].attribute ("raw")) {
-        if(!nextEscaped && (c == '\\')) {
+
+      while (int num = utf8_next_char (_original_args[i].attribute ("raw"), cursor))
+      {
+        std::string character = utf8_character (num);
+        if (!nextEscaped && (character == "\\"))
           nextEscaped = true;
-        } else {
-          if(c == '\'' && !nextEscaped) escaped += "\\";
+        else {
+          if (character == "\'" && !nextEscaped)
+            escaped += "\\";
           nextEscaped = false;
         }
-        escaped += c;
+        escaped += character;
       }
 
-      std::string::size_type cursor = 0;
+      cursor = 0;
       std::string word;
       if (Lexer::readWord (quote + escaped + quote, quote, cursor, word))
       {

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -417,8 +417,18 @@ void CLI2::lexArguments ()
     else
     {
       std::string quote = "'";
-      std::string escaped = _original_args[i].attribute ("raw");
-      escaped = str_replace (escaped, quote, "\\'");
+      // Escape unescaped single quotes
+      std::string escaped = "";
+      bool nextEscaped = false;
+      for(auto c : _original_args[i].attribute ("raw")) {
+        if(!nextEscaped && (c == '\\')) {
+          nextEscaped = true;
+        } else {
+          if(c == '\'' && !nextEscaped) escaped += "\\";
+          nextEscaped = false;
+        }
+        escaped += c;
+      }
 
       std::string::size_type cursor = 0;
       std::string word;

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -422,10 +422,12 @@ void CLI2::lexArguments ()
 
       // Escape unescaped single quotes
       std::string escaped = "";
+
+      // For performance reasons. The escaped string is as long as the original.
+      escaped.reserve (_original_args[i].attribute ("raw").size ());
+
       std::string::size_type cursor = 0;
-
       bool nextEscaped = false;
-
       while (int num = utf8_next_char (_original_args[i].attribute ("raw"), cursor))
       {
         std::string character = utf8_character (num);

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -418,7 +418,7 @@ void CLI2::lexArguments ()
     // Process multiple-token arguments.
     else
     {
-      std::string quote = "'";
+      const std::string quote = "'";
 
       // Escape unescaped single quotes
       std::string escaped = "";
@@ -434,7 +434,7 @@ void CLI2::lexArguments ()
         if (!nextEscaped && (character == "\\"))
           nextEscaped = true;
         else {
-          if (character == "\'" && !nextEscaped)
+          if (character == quote && !nextEscaped)
             escaped += "\\";
           nextEscaped = false;
         }

--- a/test/tw-2189.t
+++ b/test/tw-2189.t
@@ -1,0 +1,17 @@
+#!/bin/bash
+. bash_tap_tw.sh
+
+task add "foo \' bar"
+task list
+
+# Assert the task was correctly added
+[[ ! -z `task list | grep "foo ' bar"` ]]
+[[ `task _get 1.description` == "foo ' bar" ]]
+
+# Bonus: Assert escaped double quotes are also handled correctly
+task add 'foo \" bar'
+task list
+
+# Assert the task was correctly added
+[[ ! -z `task list | grep 'foo " bar'` ]]
+[[ `task _get 2.description` == 'foo " bar' ]]


### PR DESCRIPTION
#### Description
Before, the parser always escaped single quotes, independent of the quotes being escaped already. This is now fixed. This should fix #1960  and #2189 .

#### Additional information...

- [x] Have you run the test suite?
```
Passed:                          3817
Failed:                             0
Unexpected successes:               0
Skipped:                           18
Expected failures:                 13
Runtime:                        11.25 seconds
```