### PR TITLE
fix a typo in the help commnad

### DIFF
--- a/src/commands/CmdHelp.cpp
+++ b/src/commands/CmdHelp.cpp
@@ -140,7 +140,7 @@ int CmdHelp::execute (std::string& output)
              "  (  )                    Precedence\n"
              "\n"
              "  task due.before:eom priority.not:L   list\n"
-             "  task '(due < eom or priority != L)'  list\n"
+             "  task '(due < eom and priority != L)'  list\n"
              "\n"
              "The default .taskrc file can be overridden with:\n"
              "  task ... rc:<alternate file> ...\n"


### PR DESCRIPTION
#### Description

Previously the `task help` command gave this output:
```text
Alternately algebraic expressions support:
  and  or  xor            Logical operators
  <  <=  =  !=  >=  >     Relational operators
  (  )                    Precedence

  task due.before:eom priority.not:L   list
  task '(due < eom or priority != L)'  list
```
The last two lines are not equivalent; this PR changes the word `or` in the last line to `and`:
```text
  task due.before:eom priority.not:L   list
  task '(due < eom and priority != L)'  list
```