### PR TITLE
add library build dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ There are many binary packages available, but to install from source requires:
 * cmake
 * make
 * C++ compiler, currently gcc 7.1+ or clang 5.0+ for full C++17 support
+* GnuTLS
+* libuuid
 
 Download the tarball, and expand it:
 


### PR DESCRIPTION
#### Description

Added GnuTLS and libuuid to build dependency list in the README. I noticed they were on [this page](https://taskwarrior.org/docs/first_time.html), but not in the README where people look first.

#### Additional information...

- [x] Have you run the test suite?
  Test suite ran with no unexpected failures.
