### PR TITLE
changelog: mark 2.6.0 as current release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
-2.6.0 () -
+------ current release ---------------------------
+
+2.6.0 (2021-10-03) - 8174287f917a3b24c19a6601ba36fca9bdaa78c9
 
 - TW #1654 "Due" parsing behaviour seems inconsistent
            Thanks to Jim B for reporting.
@@ -134,15 +136,12 @@
            Thanks to bharatvaj for contributing.
 - TW #2581 Config entry with a trailing comment cannot be modified
 
-
------- current release ---------------------------
+------ old releases ------------------------------
 
 2.5.3 (2021-01-05) - 2f47226f91f0b02f7617912175274d9eed85924f
 
 - #2375   task hangs then dies when certain tasks are present in a report
           Thanks to Max Rossmannek, Tomáš Janoušek and Chad Phillips.
-
------- old releases ------------------------------
 
 2.5.2 (2020-12-05) - b0c17d11639dc6e783befd89c8508f2abb9b4287
 


### PR DESCRIPTION
#### Description

This PR updates `ChangeLog` file to mark the latest version which is `2.6.0`.

(I used UTC time for the date.)

#### Additional information...

> - [ ] Have you run the test suite?

I don't think running the tests is necessary for this change.

