### PR TITLE
Only consider pending tasks as candidates for +WAITING virtual tag

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,11 +6,13 @@
 - TW #2620 Old-style context definition should only be interpreted as read
            context.
            Thanks to bongoman and Tom Dörr for reporting.
+- TW #2622 Tags and dependencies appear as orphaned UDAs.
+           Thanks to Scott Mcdermott for reporting.
+- TW #2626 Waiting report lists deleted and/or completed tasks.
+           Thanks to Don Harper for reporting.
 - TW #2629 New-style context definition should take precendence over old-style
            even if the new-style is an empty string.
            Thanks to Denis Kasak for reporting.
-- TW #2622 Tags and dependencies appear as orphaned UDAs.
-           Thanks to Scott Mcdermott for reporting.
 
 ------ current release ---------------------------
 

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -578,12 +578,14 @@ bool Task::is_overdue () const
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
+// Task is considered waiting if it's pending and the wait attribute is set as
+// future datetime value.
+// While this is not consistent with other attribute-based virtual tags, such
+// as +BLOCKED, it is more backwards compatible with how +WAITING virtual tag
+// behaved in the past, when waiting had a dedicated status value.
 bool Task::is_waiting () const
 {
-  // note that is_waiting can return true for tasks in an actual status other
-  // than pending; in this case +WAITING will be set but the status will not be
-  // "waiting"
-  if (has ("wait"))
+  if (has ("wait") && get ("status") == "pending")
   {
     Datetime now;
     Datetime wait (get_date ("wait"));

--- a/test/uda.t
+++ b/test/uda.t
@@ -314,7 +314,7 @@ class Test1447(TestCase):
         self.t = Task()
 
     def test_filter_uda(self):
-        """1447: Verify ability to filter on empty UDA"""
+        """1447: Verify ability to filter on empty UDA that resembles named date"""
         self.t.config('uda.sep.type', 'string')
         self.t('add one')
         self.t('add two sep:foo')

--- a/test/wait.t
+++ b/test/wait.t
@@ -87,14 +87,18 @@ class Test1486(TestCase):
 
     def test_waiting(self):
         """1486: Verify waiting report shows waiting tasks"""
-        self.t.config('uda.sep.type', 'string')
-
         self.t('add regular')
-        self.t('add waited wait:later')
+        self.t('add waited and pending wait:later')
+        self.t('add waited but deleted wait:later')
+        self.t('add waited but done wait:later')
+        self.t('rc.confirmation=off 3 delete')
+        self.t('4 done')
 
         code, out, err = self.t('waiting')
         self.assertEqual(0, code, "Exit code was non-zero ({0})".format(code))
-        self.assertIn('waited', out)
+        self.assertIn('waited and pending', out)
+        self.assertNotIn('waited but deleted', out)
+        self.assertNotIn('waited but done', out)
         self.assertNotIn('regular', out)
 
 


### PR DESCRIPTION
This makes `+WAITING` consistent with (now deprecated) `status:waiting`, which has been the case in the past.

Closes #2626.