### PR TITLE
Detect tag exclusion in context definition

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@
 
 - TW #2648 xdg-open is not available on Mac OS-X
            Thanks to chapterjson for reporting.
+- TW #2664 Tag exclusion should be detected as invalid write context
+           Thanks to bentwitthold for reporting.
 
 2.6.1 (2021-10-19) - a696b6b155f9c8af87a6a496c0d298c58e6fe369
 

--- a/src/commands/CmdContext.cpp
+++ b/src/commands/CmdContext.cpp
@@ -221,14 +221,13 @@ void CmdContext::defineContext (const std::vector <std::string>& words, std::str
           ! confirm (format ("The filter '{1}' matches 0 pending tasks. Do you wish to continue?", value)))
         throw std::string ("Context definition aborted.");
 
-    std::string modifier_token = "";
-    bool valid_write_context = CmdContext::validateWriteContext (lexedArgs, modifier_token);
+    std::string reason = "";
+    bool valid_write_context = CmdContext::validateWriteContext (lexedArgs, reason);
 
     if (! valid_write_context)
     {
       std::stringstream warning;
-      warning << format ("The filter '{1}' is not a valid modification string, because it contains ", value)
-              << ( modifier_token.empty () ? "the OR operator." : format ("an attribute modifier ({1}).", modifier_token) )
+      warning << format ("The filter '{1}' is not a valid modification string, because it contains {2}.", value, reason)
               << "\nAs such, value for the write context cannot be set (context will not apply on task add / task log).\n\n"
               << format ("Please use 'task config context.{1}.write <default mods>' to set default attribute values for new tasks in this context manually.\n\n", words[1]);
       out << colorizeFootnote (warning.str ());

--- a/src/commands/CmdContext.cpp
+++ b/src/commands/CmdContext.cpp
@@ -110,7 +110,8 @@ std::string CmdContext::joinWords (const std::vector <std::string>& words, unsig
 // Validate the context as valid for writing and fail the write context definition
 // A valid write context:
 //   - does not contain any operators except AND
-//   - does not use modifiers
+//   - does not contain tag exclusion
+//   - does not use modifiers, except for 'equals' and 'is'
 //
 // Returns True if the context is a valid write context. If the context is
 // invalid due to a wrong modifier use, the modifier string will contain the

--- a/src/commands/CmdContext.cpp
+++ b/src/commands/CmdContext.cpp
@@ -115,10 +115,12 @@ std::string CmdContext::joinWords (const std::vector <std::string>& words, unsig
 // Returns True if the context is a valid write context. If the context is
 // invalid due to a wrong modifier use, the modifier string will contain the
 // first invalid modifier.
+//
 bool CmdContext::validateWriteContext (const std::vector <A2>& lexedArgs, std::string& modifier_token)
 {
   bool contains_or = false;
   bool contains_modifier = false;
+  bool contains_tag_exclusion = false;
 
   for (auto &arg: lexedArgs) {
     if (arg._lextype == Lexer::Type::op)
@@ -137,9 +139,18 @@ bool CmdContext::validateWriteContext (const std::vector <A2>& lexedArgs, std::s
         break;
       }
     }
+
+    if (arg._lextype == Lexer::Type::tag) {
+      if (arg.attribute ("sign") == "-")
+      {
+        contains_tag_exclusion = true;
+        break;
+      }
+    }
+
   }
 
-  return not contains_or and not contains_modifier;
+  return not contains_or and not contains_modifier and not contains_tag_exclusion;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/commands/CmdContext.cpp
+++ b/src/commands/CmdContext.cpp
@@ -117,41 +117,36 @@ std::string CmdContext::joinWords (const std::vector <std::string>& words, unsig
 // invalid due to a wrong modifier use, the modifier string will contain the
 // first invalid modifier.
 //
-bool CmdContext::validateWriteContext (const std::vector <A2>& lexedArgs, std::string& modifier_token)
+bool CmdContext::validateWriteContext (const std::vector <A2>& lexedArgs, std::string& reason)
 {
-  bool contains_or = false;
-  bool contains_modifier = false;
-  bool contains_tag_exclusion = false;
-
   for (auto &arg: lexedArgs) {
     if (arg._lextype == Lexer::Type::op)
       if (arg.attribute ("raw") == "or")
       {
-        contains_or = true;
-        break;
+        reason = "contains the 'OR' operator";
+        return false;
       }
 
     if (arg._lextype == Lexer::Type::pair) {
       auto modifier = arg.attribute ("modifier");
       if (modifier != "" && modifier != "is" && modifier != "equals")
       {
-        contains_modifier = true;
-        modifier_token = arg.attribute ("raw");
-        break;
+        reason = format ("contains an attribute modifier '{1}'", arg.attribute ("raw"));
+        return false;
       }
     }
 
     if (arg._lextype == Lexer::Type::tag) {
       if (arg.attribute ("sign") == "-")
       {
-        contains_tag_exclusion = true;
-        break;
+        reason = format ("contains tag exclusion '{1}'", arg.attribute ("raw"));
+        return false;
       }
     }
 
   }
 
-  return not contains_or and not contains_modifier and not contains_tag_exclusion;
+  return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/commands/CmdContext.cpp
+++ b/src/commands/CmdContext.cpp
@@ -123,7 +123,10 @@ bool CmdContext::validateWriteContext (const std::vector <A2>& lexedArgs, std::s
   for (auto &arg: lexedArgs) {
     if (arg._lextype == Lexer::Type::op)
       if (arg.attribute ("raw") == "or")
+      {
         contains_or = true;
+        break;
+      }
 
     if (arg._lextype == Lexer::Type::pair) {
       auto modifier = arg.attribute ("modifier");

--- a/test/context.t
+++ b/test/context.t
@@ -121,15 +121,15 @@ class ContextManagementTest(TestCase):
         self.assertEqual(self.t.taskrc_content.count(context_line), 1)
 
         # Assert the config does not contain write context definition
-        context_line = 'context.work.write=due.before:today\n'
+        context_line = 'context.urgent.write=due.before:today\n'
         self.assertNotIn(context_line, self.t.taskrc_content)
 
         # Assert that the write context was not set at all
-        self.assertNotIn('context.work.write=', self.t.taskrc_content)
+        self.assertNotIn('context.urgent.write=', self.t.taskrc_content)
 
         # Assert that legacy style was not used
         # Assert the config contains read context definition
-        context_line = 'context.work=due.before:today\n'
+        context_line = 'context.urgent=due.before:today\n'
         self.assertNotIn(context_line, self.t.taskrc_content)
 
     def test_context_define_invalid_for_write_due_to_operator(self):
@@ -146,15 +146,15 @@ class ContextManagementTest(TestCase):
         self.assertEqual(self.t.taskrc_content.count(context_line), 1)
 
         # Assert the config does not contain write context definition
-        context_line = 'context.work.write=due:today or +next\n'
+        context_line = 'context.urgent.write=due:today or +next\n'
         self.assertNotIn(context_line, self.t.taskrc_content)
 
         # Assert that the write context was not set at all
-        self.assertNotIn('context.work.write=', self.t.taskrc_content)
+        self.assertNotIn('context.urgent.write=', self.t.taskrc_content)
 
         # Assert that legacy style was not used
         # Assert the config contains read context definition
-        context_line = 'context.work=due:today or +next\n'
+        context_line = 'context.urgent=due:today or +next\n'
         self.assertNotIn(context_line, self.t.taskrc_content)
 
     def test_context_delete(self):

--- a/test/context.t
+++ b/test/context.t
@@ -157,6 +157,31 @@ class ContextManagementTest(TestCase):
         context_line = 'context.urgent=due:today or +next\n'
         self.assertNotIn(context_line, self.t.taskrc_content)
 
+    def test_context_define_invalid_for_write_due_to_tag_exclusion(self):
+        """Test definition of a context that is not a valid write context because it contains a tag exclusion."""
+        self.t.config("confirmation", "off")
+        code, out, err = self.t('context define nowork due:today -work')
+        self.assertIn("Context 'nowork' defined", out)
+
+        # Assert the config contains read context definition
+        context_line = 'context.nowork.read=due:today -work\n'
+        self.assertIn(context_line, self.t.taskrc_content)
+
+        # Assert that it contains the definition only once
+        self.assertEqual(self.t.taskrc_content.count(context_line), 1)
+
+        # Assert the config does not contain write context definition
+        context_line = 'context.nowork.write=due:today -work\n'
+        self.assertNotIn(context_line, self.t.taskrc_content)
+
+        # Assert that the write context was not set at all
+        self.assertNotIn('context.nowork.write=', self.t.taskrc_content)
+
+        # Assert that legacy style was not used
+        # Assert the config contains read context definition
+        context_line = 'context.nowork=due:today -work\n'
+        self.assertNotIn(context_line, self.t.taskrc_content)
+
     def test_context_delete(self):
         """Test simple context deletion."""
         self.t('context define work project:Work', input='y\ny\n')


### PR DESCRIPTION
Tag exclusion makes for invalid write context, and as such it should be detected akin to the `or` operator and query-like attribute modifiers.

Closes #2664.