### PR TITLE
Fix the computation for the soww named date

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
            Thanks to chapterjson for reporting.
 - TW #2664 Tag exclusion should be detected as invalid write context
            Thanks to bentwitthold for reporting.
+- TW #2671 The value of soww named date is incorrect
+           Thanks to Lennart Kill for reporting.
 
 2.6.1 (2021-10-19) - a696b6b155f9c8af87a6a496c0d298c58e6fe369
 


### PR DESCRIPTION
This resolves #2671 by making sure that soww refers to the current work week. Fix implemented in https://github.com/GothenburgBitFactory/libshared/pull/66.