### PR TITLE
Task: Correctly handle bulk removal of virtual tags/depends attributes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@
 
 - TW #2648 xdg-open is not available on Mac OS-X
            Thanks to chapterjson for reporting.
+- TW #2655 The bulk removal of depends: and tags: is ignored
+           Thanks to angelus2014 for reporting.
 - TW #2664 Tag exclusion should be detected as invalid write context
            Thanks to bentwitthold for reporting.
 - TW #2671 The value of soww named date is incorrect

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -2276,6 +2276,19 @@ void Task::modify (modType type, bool text_required /* = false */)
             value == "''"   ||
             value == "\"\"")
         {
+          // Special case: Handle bulk removal of 'tags' and 'depends" virtual
+          // attributes
+          if (name == "depends")
+          {
+            for (auto dep: getDependencyUUIDs ())
+              removeDependency(dep);
+          }
+          else if (name == "tags")
+          {
+            for (auto tag: getTags ())
+              removeTag(tag);
+          }
+
           // ::composeF4 will skip if the value is blank, but the presence of
           // the attribute will prevent ::validate from applying defaults.
           if ((has (name) && get (name) != "") ||

--- a/test/dependencies.t
+++ b/test/dependencies.t
@@ -145,6 +145,22 @@ class TestDependencies(TestCase):
         code, out, err = self.t("_get 1.tags.BLOCKED")
         self.assertEqual("\n", out)
 
+    def test_dependency_bulk_removal(self):
+        """2655: Check that one can bulk undepend a task"""
+        self.t("add three")
+        self.t("1 modify dep:2,3")
+
+        code, out, err = self.t("_get 1.tags.BLOCKED")
+        self.assertEqual("BLOCKED\n", out)
+
+        self.t("1 modify depends:")
+
+        code, out, err = self.t("_get 1.tags.BLOCKED")
+        self.assertEqual("\n", out)
+
+        code, out, err = self.t("_get 1.depends")
+        self.assertEqual("\n", out)
+
     def test_chain_repair(self):
         """Check that a broken chain is repaired"""
         self.t("add three")

--- a/test/tag.t
+++ b/test/tag.t
@@ -36,13 +36,10 @@ from basetest import Task, TestCase
 
 
 class TestTags(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        """Executed once before any test in the class"""
-        cls.t = Task()
 
     def setUp(self):
         """Executed before each test in the class"""
+        self.t = Task()
 
     def split_tags(self, tags):
         return sorted(tags.strip().split(','))
@@ -80,6 +77,19 @@ class TestTags(TestCase):
         # Remove missing tag.
         code, out, err = self.t("1 modify -missing")
         self.assertIn("Modified 0 tasks", out)
+
+    def test_tag_bulk_removal(self):
+        """2655: Test bulk removal of tags"""
+        self.t("add +one This +two is a test +three")
+        code, out, err = self.t("_get 1.tags")
+        self.assertEqual(
+            sorted(["one", "two", "three"]),
+            self.split_tags(out))
+
+        # Remove all tags in bulk
+        self.t("1 modify tags:")
+        code, out, err = self.t("_get 1.tags")
+        self.assertEqual("\n", out)
 
 
 class TestVirtualTags(TestCase):


### PR DESCRIPTION
This edge case would happen if a user issued a following command

    $ task 1 mod depends:
or

    $ task 1 mod tags:

which would not perform as expected for tasks with non-empty depends /
tags attributes.

The problem under the hood is the fact that current synchronization
between 'tags" attribute and its constituent decomposed `tag_X`
attributes is performed in a way where the set of tags obtained from
`tag_X` attributes is taken as the source of truth.

If the legacy 'tags:' attribute was set to empty, the fixTags() method
would then restore its previous value from the `tag_X` attributes,
effectively leading to a no-op.

The same happens with dependencies. The fix here is to detect removal of
depends and tags attributes, and instead of setting the legacy
attributes to empty values, we iteratively remove all tags/dependencies.

Closes #2655.