### PR TITLE
Fix typo in XDG news

### DIFF
--- a/src/commands/CmdNews.cpp
+++ b/src/commands/CmdNews.cpp
@@ -477,7 +477,7 @@ void CmdNews::version2_6_0 (std::vector<NewsItem>& items) {
     "      hooks.location=$XDG_CONFIG_HOME/task/hooks/\n\n"
     "  Solutions in the past required symlinks or more cumbersome configuration overrides.",
     "  If you configure your data.location and hooks.location as above, ensure\n"
-    "  that the XFG_DATA_HOME and XDG_CONFIG_HOME environment variables are set,\n"
+    "  that the XDG_DATA_HOME and XDG_CONFIG_HOME environment variables are set,\n"
     "  otherwise they're going to expand to empty string. Alternatively you can\n"
     "  hardcode the desired paths on your system."
   );


### PR DESCRIPTION
#### Description

This had XFG written in it, it's surely a typo of XDG since on the next line it's written correctly. Spotted this while reading the update notes.

#### Additional information...

- [ ] Have you run the test suite?

I didn't, I only changed a 1-letter typo inside a string. It was the only occurrence I found in the whole repo so I don't think it's referenced by a test.