### PR TITLE
Add special case for taskserver mis-formatting of depends

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -657,6 +657,20 @@ void Task::parse (const std::string& input)
               ++annotation_count;
 
             data[name] = decode (json::decode (value));
+
+            // Fix for issue#2689: taskserver sometimes encodes the depends
+            // property as a JSON-encoded one-element array of strings.  So, if
+            // depends has form `[".."]`, then apply another layer of JSON
+            // decoding.
+            if (name == "depends" && data[name].length () >= 4) {
+              auto l = data[name].length ();
+              if (data[name][0] == '[' &&
+                  data[name][1] == '"' &&
+                  data[name][l-2] == '"' &&
+                  data[name][l-1] == ']') {
+                data[name] = data[name].substr(2, l-4);
+              }
+            }
           }
 
           attLine.skip (' ');

--- a/test/t.t.cpp
+++ b/test/t.t.cpp
@@ -119,6 +119,48 @@ int main (int, char**)
   value = ff4.get ("description");
   test.is (value, "Description", "ff4 description");
 
+  // depends as a comma-separated set of strings
+  sample = "["
+           "uuid:\"00000000-0000-0000-0000-000000000000\" "
+           "description:\"d\" "
+           "depends:\"cfee3170-f153-4075-aa1d-e20bcac2841b,f5982cca-2ea1-4bfd-832c-9bd571dc0743\""
+           "]";
+  ff4 = Task (sample);
+  value = ff4.get ("uuid");
+  test.is (value, "00000000-0000-0000-0000-000000000000", "ff4 uuid");
+  value = ff4.get ("depends");
+  test.is (value, "cfee3170-f153-4075-aa1d-e20bcac2841b,f5982cca-2ea1-4bfd-832c-9bd571dc0743", "ff4 depends");
+  test.ok (ff4.has ("dep_cfee3170-f153-4075-aa1d-e20bcac2841b"), "ff4 dep attr");
+  test.ok (ff4.has ("dep_f5982cca-2ea1-4bfd-832c-9bd571dc0743"), "ff4 dep attr");
+
+  // depends as JSON string (issue#2689)
+  sample = "["
+           "uuid:\"00000000-0000-0000-0000-000000000000\" "
+           "description:\"d\" "
+           "depends:\"[\\\"cfee3170-f153-4075-aa1d-e20bcac2841b,f5982cca-2ea1-4bfd-832c-9bd571dc0743\\\"]\""
+           "]";
+  ff4 = Task (sample);
+  value = ff4.get ("uuid");
+  test.is (value, "00000000-0000-0000-0000-000000000000", "ff4 uuid");
+  value = ff4.get ("depends");
+  test.is (value, "cfee3170-f153-4075-aa1d-e20bcac2841b,f5982cca-2ea1-4bfd-832c-9bd571dc0743", "ff4 depends");
+  test.ok (ff4.has ("dep_cfee3170-f153-4075-aa1d-e20bcac2841b"), "ff4 dep attr");
+  test.ok (ff4.has ("dep_f5982cca-2ea1-4bfd-832c-9bd571dc0743"), "ff4 dep attr");
+
+  // depends as HTML-entity-encoded JSON string (issue#2689)
+  sample = "["
+           "uuid:\"00000000-0000-0000-0000-000000000000\" "
+           "description:\"d\" "
+           "depends:\"&open;\\\"cfee3170-f153-4075-aa1d-e20bcac2841b,f5982cca-2ea1-4bfd-832c-9bd571dc0743\\\"&close;\""
+           "]";
+  ff4 = Task (sample);
+  value = ff4.get ("uuid");
+  test.is (value, "00000000-0000-0000-0000-000000000000", "ff4 uuid");
+  value = ff4.get ("depends");
+  test.is (value, "cfee3170-f153-4075-aa1d-e20bcac2841b,f5982cca-2ea1-4bfd-832c-9bd571dc0743", "ff4 depends");
+  test.ok (ff4.has ("dep_cfee3170-f153-4075-aa1d-e20bcac2841b"), "ff4 dep attr");
+  test.ok (ff4.has ("dep_f5982cca-2ea1-4bfd-832c-9bd571dc0743"), "ff4 dep attr");
+
 /*
 
 TODO Task::composeCSV


### PR DESCRIPTION
#### Description

In #2689, it has been observed that a round-trip to taskserver can, under some circumstances, change
```
depends:"someuuid,someotheruuid"
```
to
```
depends:"&open;\\\"someuuid,someotheruuid\\\"&close;"
```

This PR adds a special-case to reverse this error and fixes #2689.