### PR TITLE
centos8: Fix missing repo metadata

### DIFF
--- a/test/docker/centos8
+++ b/test/docker/centos8
@@ -1,5 +1,9 @@
 FROM centos:8
 
+# Fix missing repo metadata
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN dnf update -y
 RUN dnf install python3 git gcc gcc-c++ make gnutls-devel libuuid-devel glibc-langpack-en -y
 RUN dnf install epel-release -y


### PR DESCRIPTION
CentOS8 has reached EOL and as such the repository information has been moved to different location. Given the LTS nature of the distro, we will continue testing on this platform until it causes an extra burden.