### PR TITLE
Fix urgency inheritance for negative-urgency tasks

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -2141,7 +2141,7 @@ float Task::urgency ()
 ////////////////////////////////////////////////////////////////////////////////
 float Task::urgency_inherit () const
 {
-  float v = FLT_MIN;
+  float v = -FLT_MAX;
 #ifdef PRODUCT_TASKWARRIOR
   // Calling getBlockedTasks is rather expensive.
   // It is called recursively for each dependency in the chain here.


### PR DESCRIPTION
Resolves #2732. Currently, if a task with negative urgency inherits its urgency from another task with negative urgency, the resulting calculated urgency can be erroneously positive. See the example given in #2732 for more details.

The root of the issue is that when calculating inherited urgency, the algorithm chooses the maximum of `FLT_MIN` and the urgency of its blocked tasks. `FLT_MIN` is is the minimum _positive_ float value, so `-FLT_MAX` should be used instead. Thanks to @smemsh for diagnosing the issue in the comments of the initial bug report.