### PR TITLE
CmdInfo: Fix leading spaces before urgency value

### DIFF
--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -37,6 +37,7 @@
 #include <shared.h>
 #include <format.h>
 #include <util.h>
+#include <Lexer.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 CmdInfo::CmdInfo ()
@@ -373,7 +374,7 @@ int CmdInfo::execute (std::string& output)
     // Task::urgency
     row = view.addRow ();
     view.set (row, 0, "Urgency");
-    view.set (row, 1, format (task.urgency (), 4, 4));
+    view.set (row, 1, Lexer::trimLeft (format (task.urgency (), 4, 4)));
 
     // Show any UDAs
     auto all = task.all ();


### PR DESCRIPTION
#### Description

When showing a task (`task info`), the minimal width for the urgency value is set to 4, so when the decimal value is shorter and can't be expanded to 4 characters, it gets prefixed with spaces instead, breaking the flow of the table.

This PR trims the string with the value. (It looks like the trim was already there before - although back then, it was from `text.h`, not `Lexer.h` - but for some reason it got removed, see commit ec919a8677e79d04f0008439690c11e99e7d0425.)
#### Reproduction of the bug

```

Name          Value                               
ID            4                                   
Description   Shorty McUrges
Status        Pending                             
Entered       2022-04-13 04:10:10 (54s)
Last modified 2022-04-13 04:10:10 (54s)           
Virtual tags  PENDING READY UNBLOCKED
UUID          3e083087-ca52-48b5-940d-6976cb99bc42
Urgency          0


Name          Value                                       
ID            5                                           
Description   Urgie McShorts                              
Status        Pending                                     
Entered       2022-04-13 04:10:29 (35s)
Last modified 2022-04-13 04:10:29 (35s)                   
Virtual tags  LATEST PENDING PRIORITY READY UDA UNBLOCKED
UUID          295de772-d91d-4c1b-9281-5b2b48e3d396        
Urgency        1.8
Priority      L                                           

    UDA priority.L      1 *  1.8 =    1.8
                                   ------
                                      1.8

```

#### Additional information...

- [x] Have you run the test suite?
