### PR TITLE
Make showing the task id in reverse order possible

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -117,6 +117,7 @@ std::string configurationDefaults =
   "json.array=1                                   # Enclose JSON output in [ ]\n"
   "abbreviation.minimum=2                         # Shortest allowed abbreviation\n"
   "news.version=                                  # Latest version highlights read by the user\n"
+  "reverse_id=false                               # Show the task IDs in reverse order\n"
   "\n"
   "# Dates\n"
   "dateformat=Y-M-D                               # Preferred input and display date format\n"

--- a/test/README
+++ b/test/README
@@ -41,8 +41,9 @@ There are three varieties of tests:
     line, hooks and syncing. There is an example, 'template.t', that shows how
     to perform various high level tests.
 
-  * Bash unit tests, one test per file, using the bash_tap_tw.sh script. These
-    tests are small, quick tests, not intended to be permanent.
+  * Bash unit tests, one test per file, using the bash_tap_tw.sh script (must be
+    sourced at the start of the script). These tests are small, quick tests,
+    not intended to be permanent.
 
 All tests are named with the pattern '*.t', and any other forms are not run by
 the test harness. Additionally a test must be set executable (chmod +x) for it

--- a/test/reverse-id.t
+++ b/test/reverse-id.t
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+. bash_tap_tw.sh
+
+task add First task
+first_uuid="$(task _get 1.uuid)"
+
+task add Second task
+second_uuid="$(task _get 2.uuid)"
+
+# Check that the order isn't messed up on normal settings
+[[ "$(task _get "${first_uuid}".id )" == 1  ]]
+[[ "$(task _get "${second_uuid}".id )" == 2  ]]
+
+
+# Check that the order is reversed
+[[ "$(task rc.reverse_id:true _get "${first_uuid}".id )" == 2  ]]
+[[ "$(task rc.reverse_id:true _get "${second_uuid}".id )" == 1  ]]
+
+# Check that modifying a task doesn't change it
+task "${first_uuid}" modify "modified title"
+
+[[ "$(task _get "${first_uuid}".id )" == 1  ]]
+[[ "$(task _get "${second_uuid}".id )" == 2  ]]
+[[ "$(task rc.reverse_id:true _get "${first_uuid}".id )" == 2  ]]
+[[ "$(task rc.reverse_id:true _get "${second_uuid}".id )" == 1  ]]
+
+task add Third task
+[[ "$(task _get "${first_uuid}".id )" == 1  ]]
+[[ "$(task _get "${second_uuid}".id )" == 2  ]]
+[[ "$(task rc.reverse_id:true _get "${first_uuid}".id )" == 3  ]]
+[[ "$(task rc.reverse_id:true _get "${second_uuid}".id )" == 2  ]]


### PR DESCRIPTION
#### Description

With the current behaviour, tasks ID go from 1 (oldest task) to X (being the number of pending tasks if the GC is enabled). This change adds a new boolean configuration option `reverse_id` to make the ID go from X (oldest task) to 1 (newest task). It should only affect the place where we load the tasks and where we add them, no behavioural change elsewhere.

#### Additional information...

- [X] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

I also added a test case for this change, and slightly updated the documentation for running bash tests (it wasn't fully clear to me that the script had to be _sourced_)

```sh
taskwarrior/Build/test $ ./problems
Failed:

Unexpected successes:

Skipped:

Expected failures:
lexer.t                             4
```