### PR TITLE
CmdStart: Fix "make this task pending" note for completed tasks

### DIFF
--- a/src/commands/CmdStart.cpp
+++ b/src/commands/CmdStart.cpp
@@ -83,7 +83,6 @@ int CmdStart::execute (std::string&)
       std::string question = format ("Start task {1} '{2}'?",
                                      task.identifier (true),
                                      task.get ("description"));
-      task.modify (Task::modAnnotate);
       task.setAsNow ("start");
 
       Task::status status = task.getStatus ();
@@ -93,6 +92,7 @@ int CmdStart::execute (std::string&)
         task.setStatus (Task::pending);
       }
 
+      task.modify (Task::modAnnotate);
       if (Context::getContext ().config.getBoolean ("journal.time"))
         task.addAnnotation (Context::getContext ().config.get ("journal.time.start.annotation"));
 


### PR DESCRIPTION
#### Description

When trying to start a task that is already completed, the command first tries to modify the task with given arguments as an annotation. That raises a note about making the task pending, even though the task will be set as pending after the command finishes.
The fix preserves the warning for other changes that do not make the completed task pending.

#### Reproduction of the bug

```
$ task done 0f57ee11
Completed task 7 'Donald the Done'.
Completed 1 task.
You have more urgent tasks.
$ task start 0f57ee11
Starting task 7 'Donald the Done'.
Started 1 task.
Note: Modified task 0f57ee11 is completed. You may wish to make this task pending with: task 0f57ee11 modify status:pending
You have more urgent tasks.
$ task 0f57ee11

Name          Value                                 
ID            7                                     
Description   Donald the Done                       
Status        Pending                               
Entered       2022-04-23 02:33:34 (29s)
Start         2022-04-23 02:33:58                   
Last modified 2022-04-23 02:33:58 (5s)
Virtual tags  ACTIVE LATEST PENDING READY UNBLOCKED 
UUID          0f57ee11-8771-4bbf-b10f-93dc768c8245
Urgency       4                                     

    active      1 *    4 =      4
                           ------
                                4

Date                Modification                                 
2022-04-23 02:33:51 End set to '2022-04-23 02:33:51'.            
                    Status changed from 'pending' to 'completed'.
2022-04-23 02:33:58 End deleted.
                    Start set to '2022-04-23 02:33:58'.
                    Status changed from 'completed' to 'pending'.
```

#### Additional information...

- [x] Have you run the test suite?