### PR TITLE
Make TDB2.backlog non-public

### DIFF
--- a/src/DOM.cpp
+++ b/src/DOM.cpp
@@ -90,13 +90,8 @@ bool getDOM (const std::string& name, Variant& value)
     if (name == "tw.syncneeded")
     {
       value = Variant (0);
-      for (const auto& line : Context::getContext ().tdb2.backlog.get_lines ())
-      {
-        if (line[0] == '{')
-        {
-          value = Variant (1);
-          break;
-        }
+      if (Context::getContext ().tdb2.num_local_changes () > 0) {
+        value = Variant (1);
       }
 
       return true;

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -1260,6 +1260,19 @@ bool TDB2::read_only ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+int TDB2::num_local_changes ()
+{
+  std::vector <std::string> lines = backlog.get_lines ();
+  return std::count_if(lines.begin(), lines.end(), [](const auto& line){ return line.front() == '{'; });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+size_t TDB2::data_size ()
+{
+  return pending._file.size () + completed._file.size () + undo._file.size () + backlog._file.size ();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 void TDB2::clear ()
 {
   pending.clear ();

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -135,6 +135,9 @@ public:
   // Read-only mode.
   bool read_only ();
 
+  int num_local_changes ();
+  size_t data_size ();
+
   void clear ();
   void dump ();
 
@@ -152,6 +155,9 @@ public:
   TF2 pending;
   TF2 completed;
   TF2 undo;
+
+protected:
+  friend class CmdSync; // CmdSync accesses the backlog directly
   TF2 backlog;
 
 private:

--- a/src/commands/CmdStats.cpp
+++ b/src/commands/CmdStats.cpp
@@ -63,18 +63,14 @@ int CmdStats::execute (std::string& output)
   std::string dateformat = Context::getContext ().config.get ("dateformat");
 
   // Go get the file sizes.
-  size_t dataSize = Context::getContext ().tdb2.pending._file.size ()
-                  + Context::getContext ().tdb2.completed._file.size ()
-                  + Context::getContext ().tdb2.undo._file.size ()
-                  + Context::getContext ().tdb2.backlog._file.size ();
+  size_t dataSize = Context::getContext ().tdb2.data_size ();
 
   // Count the undo transactions.
   std::vector <std::string> undoTxns = Context::getContext ().tdb2.undo.get_lines ();
   int undoCount = std::count(undoTxns.begin(), undoTxns.end(), "---");
 
   // Count the backlog transactions.
-  std::vector <std::string> backlogTxns = Context::getContext ().tdb2.backlog.get_lines ();
-  int backlogCount = std::count_if(backlogTxns.begin(), backlogTxns.end(), [](const auto& tx){ return tx.front() == '{'; });
+  int numLocalChanges = Context::getContext ().tdb2.num_local_changes ();
 
   // Get all the tasks.
   Filter filter;
@@ -207,7 +203,7 @@ int CmdStats::execute (std::string& output)
 
   row = view.addRow ();
   view.set (row, 0, "Sync backlog transactions");
-  view.set (row, 1, backlogCount);
+  view.set (row, 1, numLocalChanges);
 
   if (totalT)
   {

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -210,8 +210,7 @@ void feedback_backlog ()
   if (Context::getContext ().config.get ("taskd.server") != "" &&
       Context::getContext ().verbose ("sync"))
   {
-    std::vector <std::string> lines = Context::getContext ().tdb2.backlog.get_lines ();
-    int count = std::count_if(lines.begin(), lines.end(), [](const auto& line){ return line.front() == '{'; });
+    int count = Context::getContext ().tdb2.num_local_changes ();
     if (count)
       Context::getContext ().footnote (format (count > 1 ?  "There are {1} local changes.  Sync required."
                                                          : "There is {1} local change.  Sync required.", count));

--- a/test/tdb2.t.cpp
+++ b/test/tdb2.t.cpp
@@ -61,39 +61,39 @@ int main (int, char**)
     std::vector <Task> pending          = context.tdb2.pending.get_tasks ();
     std::vector <Task> completed        = context.tdb2.completed.get_tasks ();
     std::vector <std::string> undo      = context.tdb2.undo.get_lines ();
-    std::vector <std::string> backlog   = context.tdb2.backlog.get_lines ();
+    int num_local_changes               = context.tdb2.num_local_changes ();
 
     t.is ((int) pending.size (),   0, "TDB2 Read empty pending");
     t.is ((int) completed.size (), 0, "TDB2 Read empty completed");
     t.is ((int) undo.size (),      0, "TDB2 Read empty undo");
-    t.is ((int) backlog.size (),   0, "TDB2 Read empty backlog");
+    t.is ((int) num_local_changes, 0, "TDB2 Read empty backlog");
 
     // Add a task.
     Task task (R"([description:"description" name:"value"])");
     context.tdb2.add (task);
 
-    pending   = context.tdb2.pending.get_tasks ();
-    completed = context.tdb2.completed.get_tasks ();
-    undo      = context.tdb2.undo.get_lines ();
-    backlog   = context.tdb2.backlog.get_lines ();
+    pending           = context.tdb2.pending.get_tasks ();
+    completed         = context.tdb2.completed.get_tasks ();
+    undo              = context.tdb2.undo.get_lines ();
+    num_local_changes = context.tdb2.num_local_changes ();
 
     t.is ((int) pending.size (),   1, "TDB2 after add, 1 pending task");
     t.is ((int) completed.size (), 0, "TDB2 after add, 0 completed tasks");
     t.is ((int) undo.size (),      3, "TDB2 after add, 3 undo lines");
-    t.is ((int) backlog.size (),   1, "TDB2 after add, 1 backlog task");
+    t.is ((int) num_local_changes, 1, "TDB2 after add, 1 backlog task");
 
     task.set ("description", "This is a test");
     context.tdb2.modify (task);
 
-    pending   = context.tdb2.pending.get_tasks ();
-    completed = context.tdb2.completed.get_tasks ();
-    undo      = context.tdb2.undo.get_lines ();
-    backlog   = context.tdb2.backlog.get_lines ();
+    pending           = context.tdb2.pending.get_tasks ();
+    completed         = context.tdb2.completed.get_tasks ();
+    undo              = context.tdb2.undo.get_lines ();
+    num_local_changes = context.tdb2.num_local_changes ();
 
     t.is ((int) pending.size (),   1, "TDB2 after add, 1 pending task");
     t.is ((int) completed.size (), 0, "TDB2 after add, 0 completed tasks");
     t.is ((int) undo.size (),      7, "TDB2 after add, 7 undo lines");
-    t.is ((int) backlog.size (),   2, "TDB2 after add, 2 backlog task");
+    t.is ((int) num_local_changes, 2, "TDB2 after add, 2 backlog task");
 
     context.tdb2.commit ();
 


### PR DESCRIPTION
The stats command gets this information from an API that will also work
for TaskChampion.  The sync command still accesses the field directly,
as the command must be completely rewritten for TaskChampion.

This is one small part of a general effort to make the interface to TDB2 more abstract, so that it can eventually be implemented with a Replica. (#2801)

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.
