### PR TITLE
update MSRV to 1.52

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         rust:
           # MSRV; most not be higher than the clippy rust version in checks.yml
-          - "1.47"
+          - "1.51"
           - "stable"
         os:
           - ubuntu-latest

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         rust:
           # MSRV; most not be higher than the clippy rust version in checks.yml
-          - "1.51"
+          - "1.52"
           - "stable"
         os:
           - ubuntu-latest

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1,5 +1,4 @@
-// Not compatible with the MSRV
-// #![warn(unsafe_op_in_unsafe_fn)]
+#![warn(unsafe_op_in_unsafe_fn)]
 #![allow(unused_unsafe)]
 // Not working yet in stable - https://github.com/rust-lang/rust-clippy/issues/8020
 // #![warn(clippy::undocumented_unsafe_blocks)]

--- a/rust/taskchampion/src/lib.rs
+++ b/rust/taskchampion/src/lib.rs
@@ -41,7 +41,7 @@ for more information about the design and usage of the tool.
 
 # Minimum Supported Rust Version (MSRV)
 
-This crate supports Rust version 1.51 and higher.
+This crate supports Rust version 1.52 and higher.
 
  */
 

--- a/rust/taskchampion/src/lib.rs
+++ b/rust/taskchampion/src/lib.rs
@@ -39,9 +39,9 @@ Users can define their own server impelementations.
 See the [TaskChampion Book](http://taskchampion.github.com/taskchampion)
 for more information about the design and usage of the tool.
 
-# Minimum Supported Rust Version
+# Minimum Supported Rust Version (MSRV)
 
-This crate supports Rust version 1.47 and higher.
+This crate supports Rust version 1.51 and higher.
 
  */
 


### PR DESCRIPTION
#### Description

This updates the minumum Rust version to 1.51, which is required by some updated dependencies.  Since nothing depends on these Rust libraries yet, there's no reason not to bump it as necessary
