### PR TITLE
add write-all permission to the audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    permissions: write-all
     name: "Audit Dependencies"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#### Description

Per https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac I think this will at least get a better error message
