### PR TITLE
add Cargo.* to Rust CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 rust/* @dbr @djmitche
+Cargo.toml @dbr @djmitche
+Cargo.lock @dbr @djmitche


### PR DESCRIPTION
This should help assign reviewers for dependabot.