### PR TITLE
Fix issue with filter not applied correctly during `task _tags` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ src/commands/libcommands.a
 src/columns/libcolumns.a
 *~
 .*.swp
+Session.vim
 package-config/osx/binary/task
+/build/
 CMakeFiles
 CMakeCache.txt
 cmake_install.cmake

--- a/src/commands/CmdTags.cpp
+++ b/src/commands/CmdTags.cpp
@@ -166,7 +166,7 @@ int CmdCompletionTags::execute (std::string& output)
   // Apply filter.
   Filter filter;
   std::vector <Task> filtered;
-  filter.subset (filtered);
+  filter.subset (tasks, filtered);
 
   // Scan all the tasks for their tags, building a map using tag
   // names as keys.


### PR DESCRIPTION
#### Description

Closes #2823

Filter was not applied correctly and as a result all the found tasks were used
when determining the tags.

Also includes:

* Add cmake build directory + Session.vim files to .gitignore list


#### Additional information

- [X] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```
$ ./problems

Failed:

Unexpected successes:

Skipped:

Expected failures:
lexer.t                             4
```