### PR TITLE
TW-2763: added hooks.location to show command

### DIFF
--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -165,6 +165,7 @@ int CmdShow::execute (std::string& output)
     " fontunderline"
     " gc"
     " hooks"
+    " hooks.location"
     " hyphenate"
     " indent.annotation"
     " indent.report"


### PR DESCRIPTION
#### Description

Resolves #2763
Added `hooks.location` to show command

#### Additional information...

- [x] Have you run the test suite?
  Many changes need to be tested. Please run the test suite
  and include the output of ```cd test && ./problems```.

```Failed:                        
calendar.t                          2

Unexpected successes:          

Skipped:                       
dependencies.t                      1
diag.t                              1
export.t                            1
feature.default.project.t           4
filter.t                            1
hooks.on-modify.t                   1
import.t                            1
nag.t                               5
recurrence.t                        1
tw-1999.t                           2
wait.t                              1

Expected failures:             
dependencies.t                      2
filter.t                            3
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
```

The failed calendar tests have been there before ...
