### PR TITLE
Fix escape character escaping as described in #1693

### DIFF
--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -443,7 +443,7 @@ void CLI2::lexArguments ()
 
       cursor = 0;
       std::string word;
-      if (Lexer::readWord (quote + escaped + quote, quote, cursor, word))
+      if (Lexer::extractWord (quote + escaped + quote, quote, cursor, word))
       {
         Lexer::dequote (word);
         A2 unknown (word, Lexer::Type::word);

--- a/src/CLI2.cpp
+++ b/src/CLI2.cpp
@@ -433,12 +433,31 @@ void CLI2::lexArguments ()
         std::string character = utf8_character (num);
         if (!nextEscaped && (character == "\\"))
           nextEscaped = true;
-        else {
-          if (character == quote && !nextEscaped)
-            escaped += "\\";
+
+        else if (character == quote)
+        {
+          escaped += "U+0027";
+
+          if (nextEscaped)
+            nextEscaped = false;
+        }
+
+        else if (character == "\"" && nextEscaped)
+        {
+          escaped += "U+0022";
           nextEscaped = false;
         }
+
+        else
+        {
+          if (nextEscaped)
+          {
+            escaped += '\\';
+            nextEscaped = false;
+          }
+
         escaped += character;
+        }
       }
 
       cursor = 0;

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -1420,6 +1420,12 @@ bool Lexer::isDOM (const std::string& text)
          type == Lexer::Type::dom;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Replaces escaped character escapes with their unicode characters.  Includes:
+//   "U+XXXX"
+//   "\uXXXX"
+//   '"'
+//   '\''
 void Lexer::handleEscapes(std::string &word,
 								  std::string::size_type cursor)
 {
@@ -1480,6 +1486,13 @@ void Lexer::handleEscapes(std::string &word,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Extracts a quoted word from a longer string starting from cursor.  Includes:
+//   '\''
+//   '"'
+//   "'"
+//   "\""
+//   'one two'
+// Result includes the quotes.
 bool Lexer::extractWord (
   const std::string& text,
   const std::string& quotes,
@@ -1522,6 +1535,17 @@ bool Lexer::extractWord (
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Extract an unquoted word from a longer string starting from cursor.
+// Includes:
+//   one\ two
+//   abcU+0020def
+//   abc\u0020def
+//   a\tb
+//
+// Ends at:
+//   Lexer::isEOS
+//   unicodeWhitespace
+//   Lexer::isHardBoundary
 bool Lexer::extractWord (
   const std::string& text,
   std::string::size_type& cursor,

--- a/src/Lexer.h
+++ b/src/Lexer.h
@@ -73,6 +73,9 @@ public:
   static bool isDOM                          (const std::string&);
   static void dequote                        (std::string&, const std::string& quotes = "'\"");
   static bool wasQuoted                      (const std::string&);
+  static void handleEscapes                  (std::string&, std::string::size_type);
+  static bool extractWord                    (const std::string&, const std::string&, std::string::size_type&, std::string&);
+  static bool extractWord                    (const std::string&, std::string::size_type&, std::string&);
   static bool readWord                       (const std::string&, const std::string&, std::string::size_type&, std::string&);
   static bool readWord                       (const std::string&, std::string::size_type&, std::string&);
   static bool decomposePair                  (const std::string&, std::string&, std::string&, std::string&, std::string&);

--- a/src/Lexer.h
+++ b/src/Lexer.h
@@ -74,6 +74,7 @@ public:
   static void dequote                        (std::string&, const std::string& quotes = "'\"");
   static bool wasQuoted                      (const std::string&);
   static void handleEscapes                  (std::string&, std::string::size_type);
+  static void handleUnicode                  (std::string&, std::string::size_type);
   static bool extractWord                    (const std::string&, const std::string&, std::string::size_type&, std::string&);
   static bool extractWord                    (const std::string&, std::string::size_type&, std::string&);
   static bool readWord                       (const std::string&, const std::string&, std::string::size_type&, std::string&);

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -26,6 +26,9 @@
 
 #include <cmake.h>
 #include <Task.h>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
 #include <sstream>
 #include <stdlib.h>
 #include <assert.h>
@@ -2411,7 +2414,17 @@ void Task::modify (modType type, bool text_required /* = false */)
   //  any.
   if (text != "")
   {
+
     Lexer::dequote (text);
+
+	 // For some reason, unicode escapes in the arguments were not processed yet.
+	 if (type == modReplace)
+	 {
+      std::string safe_text = '\'' + text + '\'';
+      Lexer::handleUnicode(safe_text, 0);
+      Lexer::dequote(safe_text);
+      text = safe_text;
+    }
 
     switch (type)
     {

--- a/test/tw-1669.t
+++ b/test/tw-1669.t
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Copyright 2006 - 2021, Tomas Babej, Paul Beckingham, Federico Hernandez.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# https://www.opensource.org/licenses/mit-license.php
+#
+###############################################################################
+
+import sys
+import os
+import unittest
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from basetest import Task, TestCase
+
+# Test methods available:
+#     self.assertEqual(a, b)
+#     self.assertNotEqual(a, b)
+#     self.assertTrue(x)
+#     self.assertFalse(x)
+#     self.assertIs(a, b)
+#     self.assertIsNot(a, b)
+#     self.assertIsNone(x)
+#     self.assertIsNotNone(x)
+#     self.assertIn(a, b)
+#     self.assertNotIn(a, b)
+#     self.assertIsInstance(a, b)
+#     self.assertNotIsInstance(a, b)
+#     self.assertRaises(e)
+#     self.assertRegex(t, r)
+#     self.assertNotRegex(t, r)
+#     self.tap("")
+
+class TestBugXXXX(TestCase):
+    def setUp(self):
+        self.t = Task()
+
+    def test_escaped_escape_char_in_annotation(self):
+        """Annotate a task using double backslashes
+        and check it displaying correctly."""
+        self.t("add test")
+        self.t("""annotate 1 'Lorem \\n ipsum \\\\n dolor \\\\\\n sit
+ amet'""")
+        code, out, err = self.t("_get 1.annotations.1.description")
+        self.tap(out)
+        self.tap(err)
+
+        expected = """Lorem 
+ ipsum \\n dolor \\
+ sit
+ amet
+"""
+
+        self.assertEqual(out, expected)
+
+if __name__ == "__main__":
+    from simpletap import TAPTestRunner
+    unittest.main(testRunner=TAPTestRunner())
+
+# vim: ai sts=4 et sw=4 ft=python


### PR DESCRIPTION
#### Description

The fix is achieved by splitting the `Lexer::readWord` function into multiple parts and calling only the necessary one in `CLI2.cpp`.

#### Additional information...

I was not completely sure about the naming of the new functions and would like to discuss that in this PR.
Since I am also still in the process of writing a new test for #1693, there is no test suite run attached.