### PR TITLE
Fix typo in man page

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -1146,7 +1146,7 @@ of recurring tasks.
 
 .RS
 .TP
-daily, day, 1da, 2da, ...
+daily, day, 1day, 2day, ...
 Every day or a number of days.
 
 .TP


### PR DESCRIPTION
Frequency listing for number form of 'every day' or 'every other day' corrected to "1day, 2day" instead of "1da, 2da".

#### Description

Fixing minor typo in the man pages

#### Additional information...

- [ ] Have you run the test suite?
I have not run the test suite as this is just a one line typo correction. But if this is required I am happy to do so. 
