### PR TITLE
man: Make frequency abbreviation more clear

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -1142,11 +1142,11 @@ task ... due:juhannus
 .SS FREQUENCIES
 Recurrence periods. Taskwarrior supports several ways of specifying the
 .I frequency
-of recurring tasks.
+of recurring tasks. Note that frequencies can be abbreviated.
 
 .RS
 .TP
-daily, day, 1da, 2da, ...
+daily, day, 1day, 1days, 2day, 2days, 1da, 2da, ...
 Every day or a number of days.
 
 .TP


### PR DESCRIPTION
Supersedes #2865 by clarifying the abbreviations in the man page section for frequencies.