### PR TITLE
Add Replica::num_undo_points and exclude undo points from num_operations

### DIFF
--- a/taskchampion/integration-tests/src/bindings_tests/replica.c
+++ b/taskchampion/integration-tests/src/bindings_tests/replica.c
@@ -109,7 +109,7 @@ static void test_replica_working_set(void) {
 
     tc_working_set_free(ws);
 
-    TEST_ASSERT_EQUAL(19, tc_replica_num_local_operations(rep));
+    TEST_ASSERT_EQUAL(18, tc_replica_num_local_operations(rep));
 
     tc_replica_free(rep);
 }

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -360,13 +360,27 @@ pub unsafe extern "C" fn tc_replica_undo(rep: *mut TCReplica, undone_out: *mut i
     )
 }
 
-/// Get the number of local, un-synchronized operations, or -1 on error
+/// Get the number of local, un-synchronized operations (not including undo points), or -1 on
+/// error.
 #[no_mangle]
 pub unsafe extern "C" fn tc_replica_num_local_operations(rep: *mut TCReplica) -> i64 {
     wrap(
         rep,
         |rep| {
             let count = rep.num_local_operations()? as i64;
+            Ok(count)
+        },
+        -1,
+    )
+}
+
+/// Get the number of undo points (number of undo calls possible), or -1 on error.
+#[no_mangle]
+pub unsafe extern "C" fn tc_replica_num_undo_points(rep: *mut TCReplica) -> i64 {
+    wrap(
+        rep,
+        |rep| {
+            let count = rep.num_undo_points()? as i64;
             Ok(count)
         },
         -1,

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -558,9 +558,15 @@ TCResult tc_replica_sync(struct TCReplica *rep, struct TCServer *server, bool av
 TCResult tc_replica_undo(struct TCReplica *rep, int32_t *undone_out);
 
 /**
- * Get the number of local, un-synchronized operations, or -1 on error
+ * Get the number of local, un-synchronized operations (not including undo points), or -1 on
+ * error.
  */
 int64_t tc_replica_num_local_operations(struct TCReplica *rep);
+
+/**
+ * Get the number of undo points (number of undo calls possible), or -1 on error.
+ */
+int64_t tc_replica_num_undo_points(struct TCReplica *rep);
 
 /**
  * Add an UndoPoint, if one has not already been added by this Replica.  This occurs automatically

--- a/taskchampion/taskchampion/src/replica.rs
+++ b/taskchampion/taskchampion/src/replica.rs
@@ -259,6 +259,11 @@ impl Replica {
     pub fn num_local_operations(&mut self) -> anyhow::Result<usize> {
         self.taskdb.num_operations()
     }
+
+    /// Get the number of undo points available (number of times `undo` will succeed).
+    pub fn num_undo_points(&mut self) -> anyhow::Result<usize> {
+        self.taskdb.num_undo_points()
+    }
 }
 
 #[cfg(test)]
@@ -405,7 +410,11 @@ mod tests {
             ]
         );
 
-        assert_eq!(rep.num_local_operations().unwrap(), 10);
+        // num_local_operations includes all but the undo point
+        assert_eq!(rep.num_local_operations().unwrap(), 9);
+
+        // num_undo_points includes only the undo point
+        assert_eq!(rep.num_undo_points().unwrap(), 1);
     }
 
     #[test]

--- a/taskchampion/taskchampion/src/storage/op.rs
+++ b/taskchampion/taskchampion/src/storage/op.rs
@@ -59,6 +59,11 @@ impl ReplicaOp {
         }
     }
 
+    /// Determine whether this is an undo point.
+    pub fn is_undo_point(&self) -> bool {
+        self == &Self::UndoPoint
+    }
+
     /// Generate a sequence of SyncOp's to reverse the effects of this ReplicaOp.
     pub fn reverse_ops(self) -> Vec<SyncOp> {
         match self {


### PR DESCRIPTION
#### Description

Taskwarrior's stats include a number of available undo's.  In the TC data model, these are UndoPoint operations, so make a function to count those.

Also, those aren't real "operations" in the sense that they won't be synchronized to the server, so don't count them in num_operations.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [x] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
