### PR TITLE
Fix repository name in audit check

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,6 @@ jobs:
     name: "Audit Rust Dependencies"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@master
+      - uses: rustsec/audit-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,6 @@ jobs:
     name: "Audit Rust Dependencies"
     steps:
       - uses: actions/checkout@v2
-      - uses: rust-rs/audit-check@master
+      - uses: actions-rs/audit-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Description

I forgot this doesn't run on PRs, so my confidence that it's using .cargo/audit.toml may have been misplaced.
