### PR TITLE
Fix inherited urgency when parent and child have the same urgency

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -2116,7 +2116,7 @@ float Task::urgency_c () const
 
     // This is a hackish way of making sure parent tasks are sorted above
     // child tasks.  For reports that hide blocked tasks, this is not needed.
-    if (prev < value)
+    if (prev <= value)
       value += 0.01;
   }
 #endif


### PR DESCRIPTION
#### Description

Fixes #2940.
Changing the comparison of the maximum child urgency and the parent urgency to `prev <= value` is fixing the wrong inheritance.

#### Additional information...

- [x] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.
  ```
  Failed:

  Unexpected successes:

  Skipped:
  dependencies.t                      1
  diag.t                              1
  export.t                            1
  feature.default.project.t           4
  filter.t                            1
  hooks.on-modify.t                   1
  import.t                            1
  nag.t                               5
  recurrence.t                        1
  tw-1999.t                           2
  wait.t                              1
  
  Expected failures:
  dependencies.t                      2
  filter.t                            3
  lexer.t                             4
  quotes.t                            1
  tw-2124.t                           1
  ```

- [ ] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
