### PR TITLE
Add a Recurring status to TaskChampion

### DIFF
--- a/src/tc/Task.h
+++ b/src/tc/Task.h
@@ -40,6 +40,7 @@ namespace tc {
     Pending = tc::ffi::TC_STATUS_PENDING,
     Completed = tc::ffi::TC_STATUS_COMPLETED,
     Deleted = tc::ffi::TC_STATUS_DELETED,
+    Recurring = tc::ffi::TC_STATUS_RECURRING,
     Unknown = tc::ffi::TC_STATUS_UNKNOWN,
   };
 

--- a/taskchampion/docs/src/tasks.md
+++ b/taskchampion/docs/src/tasks.md
@@ -33,7 +33,7 @@ Timestamps are stored as UNIX epoch timestamps, in the form of an integer.
 
 The following keys, and key formats, are defined:
 
-* `status` - one of `P` for a pending task (the default), `C` for completed or `D` for deleted
+* `status` - one of `P` for a pending task (the default), `C` for completed, `D` for deleted, or `R` for recurring
 * `description` - the one-line summary of the task
 * `modified` - the time of the last modification of this task
 * `start` - the most recent time at which this task was started (a task with no `start` key is not active)
@@ -43,9 +43,7 @@ The following keys, and key formats, are defined:
 * `entry` - the time at which the task was created
 * `annotation_<timestamp>` - value is an annotation created at the given time
 
-The following are not yet implemented:
-
-* `dep_<uuid>` - indicates this task depends on `<uuid>` (value is an empty string)
+Note that while TaskChampion recognizes "recurring" as a status, it does not implement recurrence directly.
 
 ### UDAs
 

--- a/taskchampion/lib/src/status.rs
+++ b/taskchampion/lib/src/status.rs
@@ -8,6 +8,7 @@ pub enum TCStatus {
     Pending,
     Completed,
     Deleted,
+    Recurring,
     /// Unknown signifies a status in the task DB that was not
     /// recognized.
     Unknown,
@@ -19,6 +20,7 @@ impl From<TCStatus> for Status {
             TCStatus::Pending => Status::Pending,
             TCStatus::Completed => Status::Completed,
             TCStatus::Deleted => Status::Deleted,
+            TCStatus::Recurring => Status::Recurring,
             TCStatus::Unknown => Status::Unknown("unknown".to_string()),
         }
     }
@@ -30,6 +32,7 @@ impl From<Status> for TCStatus {
             Status::Pending => TCStatus::Pending,
             Status::Completed => TCStatus::Completed,
             Status::Deleted => TCStatus::Deleted,
+            Status::Recurring => TCStatus::Recurring,
             Status::Unknown(_) => TCStatus::Unknown,
         }
     }

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -111,6 +111,7 @@ typedef enum TCStatus {
   TC_STATUS_PENDING,
   TC_STATUS_COMPLETED,
   TC_STATUS_DELETED,
+  TC_STATUS_RECURRING,
   /**
    * Unknown signifies a status in the task DB that was not
    * recognized.

--- a/taskchampion/taskchampion/src/task/status.rs
+++ b/taskchampion/taskchampion/src/task/status.rs
@@ -5,6 +5,7 @@ pub enum Status {
     Pending,
     Completed,
     Deleted,
+    Recurring,
     /// Unknown signifies a status in the task DB that was not
     /// recognized.  This supports forward-compatibility if a
     /// new status is added.  Tasks with unknown status should
@@ -20,6 +21,7 @@ impl Status {
             "pending" => Status::Pending,
             "completed" => Status::Completed,
             "deleted" => Status::Deleted,
+            "recurring" => Status::Recurring,
             v => Status::Unknown(v.to_string()),
         }
     }
@@ -30,6 +32,7 @@ impl Status {
             Status::Pending => "pending",
             Status::Completed => "completed",
             Status::Deleted => "deleted",
+            Status::Recurring => "recurring",
             Status::Unknown(v) => v.as_ref(),
         }
     }
@@ -45,6 +48,7 @@ mod test {
         assert_eq!(Status::Pending.to_taskmap(), "pending");
         assert_eq!(Status::Completed.to_taskmap(), "completed");
         assert_eq!(Status::Deleted.to_taskmap(), "deleted");
+        assert_eq!(Status::Recurring.to_taskmap(), "recurring");
         assert_eq!(Status::Unknown("wishful".into()).to_taskmap(), "wishful");
     }
 
@@ -53,6 +57,7 @@ mod test {
         assert_eq!(Status::from_taskmap("pending"), Status::Pending);
         assert_eq!(Status::from_taskmap("completed"), Status::Completed);
         assert_eq!(Status::from_taskmap("deleted"), Status::Deleted);
+        assert_eq!(Status::from_taskmap("recurring"), Status::Recurring);
         assert_eq!(
             Status::from_taskmap("something-else"),
             Status::Unknown("something-else".into())
@@ -64,6 +69,7 @@ mod test {
         assert_eq!(format!("{}", Status::Pending), "Pending");
         assert_eq!(format!("{}", Status::Completed), "Completed");
         assert_eq!(format!("{}", Status::Deleted), "Deleted");
+        assert_eq!(format!("{}", Status::Recurring), "Recurring");
         assert_eq!(format!("{}", Status::Unknown("wishful".into())), "Unknown");
     }
 }


### PR DESCRIPTION
#### Description

TaskChampion uses an enum to define statuses, so this adds "recurring" as one of the options.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [x] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
