### PR TITLE
Draft: Custom virtual tag

### DIFF
--- a/src/Eval.cpp
+++ b/src/Eval.cpp
@@ -203,6 +203,12 @@ void Eval::debug (bool value)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+void Eval::ignoreTag(std::string tag)
+{
+  ignoreTags.push_back(tag);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Static.
 std::vector <std::string> Eval::getOperators ()
 {
@@ -316,7 +322,12 @@ void Eval::evaluatePostfixStack (
       else if (contextTask) {
              if (token.first == "~")        result = left.operator_match (right, *contextTask);
         else if (token.first == "!~")       result = left.operator_nomatch (right, *contextTask);
-        else if (token.first == "_hastag_") result = left.operator_hastag (right, *contextTask);
+        else if (token.first == "_hastag_") {
+          if (std::find (ignoreTags.begin (), ignoreTags.end (), right.get_string ()) == ignoreTags.end ())
+            result = left.operator_hastag (right, *contextTask);
+          else
+            result = true;
+        }
         else if (token.first == "_notag_")  result = left.operator_notag (right, *contextTask);
         else
           throw format ("Unsupported operator '{1}'.", token.first);

--- a/src/Eval.h
+++ b/src/Eval.h
@@ -45,10 +45,11 @@ public:
   void compileExpression (const std::vector <std::pair <std::string, Lexer::Type>>&);
   void evaluateCompiledExpression (Variant&);
   void debug (bool);
+  void ignoreTag (std::string);
 
   static std::vector <std::string> getOperators ();
   static std::vector <std::string> getBinaryOperators ();
-
+  
 private:
   void evaluatePostfixStack (const std::vector <std::pair <std::string, Lexer::Type>>&, Variant&) const;
   void infixToPostfix (std::vector <std::pair <std::string, Lexer::Type>>&) const;
@@ -71,6 +72,8 @@ private:
   std::vector <bool (*)(const std::string&, Variant&)> _sources {};
   bool _debug                                                   {false};
   std::vector <std::pair <std::string, Lexer::Type>> _compiled  {};
+  
+  std::vector <std::string> ignoreTags {};
 };
 
 #endif

--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -37,7 +37,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 // Take an input set of tasks and filter into a subset.
-void Filter::subset (const std::vector <Task>& input, std::vector <Task>& output)
+void Filter::subset (const std::vector <Task>& input, std::vector <Task>& output, std::vector <std::string> ignore)
 {
   Timer timer;
   _startCount = (int) input.size ();
@@ -53,11 +53,17 @@ void Filter::subset (const std::vector <Task>& input, std::vector <Task>& output
   {
     Eval eval;
     eval.addSource (domSource);
+    
+    for (auto tag : ignore)
+    {
+      eval.ignoreTag(tag);
+    }
 
     // Debug output from Eval during compilation is useful.  During evaluation
     // it is mostly noise.
     eval.debug (Context::getContext ().config.getInteger ("debug.parser") >= 3 ? true : false);
     eval.compileExpression (precompiled);
+    
 
     for (auto& task : input)
     {
@@ -69,6 +75,7 @@ void Filter::subset (const std::vector <Task>& input, std::vector <Task>& output
       if (var.get_bool ())
         output.push_back (task);
     }
+    
 
     eval.debug (false);
   }
@@ -82,11 +89,11 @@ void Filter::subset (const std::vector <Task>& input, std::vector <Task>& output
 
 ////////////////////////////////////////////////////////////////////////////////
 // Take the set of all tasks and filter into a subset.
-void Filter::subset (std::vector <Task>& output)
+void Filter::subset (std::vector <Task>& output, std::vector <std::string> ignore)
 {
   Timer timer;
   Context::getContext ().cli2.prepareFilter ();
-
+  
   std::vector <std::pair <std::string, Lexer::Type>> precompiled;
   for (auto& a : Context::getContext ().cli2._args)
     if (a.hasTag ("FILTER"))
@@ -104,6 +111,11 @@ void Filter::subset (std::vector <Task>& output)
 
     Eval eval;
     eval.addSource (domSource);
+    
+    for (auto tag : ignore)
+    {
+      eval.ignoreTag(tag);
+    }
 
     // Debug output from Eval during compilation is useful.  During evaluation
     // it is mostly noise.

--- a/src/Filter.h
+++ b/src/Filter.h
@@ -37,8 +37,8 @@ class Filter
 public:
   Filter () = default;
 
-  void subset (const std::vector <Task>&, std::vector <Task>&);
-  void subset (std::vector <Task>&);
+  void subset (const std::vector <Task>&, std::vector <Task>&, std::vector <std::string> = {});
+  void subset (std::vector <Task>&, std::vector <std::string> = {});
   bool hasFilter () const;
   bool pendingOnly () const;
   void safety () const;

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -32,7 +32,6 @@
 #include <string>
 #ifdef PRODUCT_TASKWARRIOR
 #include <math.h>
-#include <map>
 #include <ctype.h>
 #endif
 #include <cfloat>
@@ -1367,23 +1366,14 @@ int Task::getTagCount () const
 
 bool Task::customVirtualTagApplies (const std::string& tag) const
 {
-  
-  // if (custom_virtual_tag_processing.count (tag)) {
-  //   // custom_virtual_tag_processing.at(tag) = true;
-  //   auto it = custom_virtual_tag_processing.find (tag);
-  //   if (it != custom_virtual_tag_processing.end ())
-  //     it->second = true;
-  // } else {
-  //   custom_virtual_tag_processing.insert ({tag, true});
-  // }
 
   auto tagFilter = Context::getContext ().config.get("virtualtag." + tag + ".filter");
-  
+
   if (tagFilter != "")
     Context::getContext ().cli2.addFilter (tagFilter);
   else
     return false;
-  
+
   Filter filter;
   std::vector <Task> filtered;
   filter.subset (filtered, {tag});
@@ -1452,13 +1442,11 @@ bool Task::hasTag (const std::string& tag) const
 #endif
     if (tag == "PROJECT")   return has ("project");
     if (tag == "PRIORITY")  return has ("priority");
-    
-    // if (Context::getContext ().config.get("virtualtag." + tag + ".filter") != "")
-      // if (custom_virtual_tag_processing.count(tag) && custom_virtual_tag_processing.at(tag))
+
     if (customVirtualTagApplies (tag))
       return true;
   }
-  
+
   // Concrete tags.
   if (has (tag2Attr (tag)))
     return true;

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <cmake.h>
+#include <iostream>
 #include <Task.h>
 #include <sstream>
 #include <stdlib.h>
@@ -1363,26 +1364,62 @@ int Task::getTagCount () const
   return count;
 }
 
+bool Task::filterApplies (const std::string& filter, std::vector <std::string> ignore) const
+{
+  CLI2 localCli2;
+
+  // std::cout << "begin" << std::endl;
+  // Context* currentContext = &Context::getContext ();
+  // std::cout << "After copy" << std::endl;
+
+  // Context localContext;
+  // Context::setContext(&localContext);
+  // std::cout << "After setContext" << std::endl;
+  // // Context::getContext ();// .cli2.addFilter (filter);
+  // std::cout << "After addFilter" << std::endl;
+  
+  // Filter filter_obj;
+  // std::vector <Task> filtered;
+  // filter_obj.subset (filtered, ignore);
+  // std::cout << "After subset" << std::endl;
+
+  // Context::setContext(currentContext);
+  // std::cout << "After setContext currentContext" << std::endl;
+
+  // if (std::find (filtered.begin (), filtered.end (), *this) != filtered.end ()) {
+  //   return true;
+  // }
+
+  // return false;
+}
 
 bool Task::customVirtualTagApplies (const std::string& tag) const
 {
-
   auto tagFilter = Context::getContext ().config.get("virtualtag." + tag + ".filter");
+  
+  return filterApplies (tagFilter, {tag});
 
-  if (tagFilter != "")
-    Context::getContext ().cli2.addFilter (tagFilter);
-  else
-    return false;
+  // if (tagFilter != "")
+  //   Context::getContext ().cli2.addFilter (tagFilter);
+  // else if (tag == "SCHEDULEDSOON") {
+  //   std::cout << "(" << id << ") tagFilter is '': returning false" << std::endl;
+  //   return false;
+  // }
+  
+  // Filter filter;
+  // std::vector <Task> filtered;
+  // filter.subset (filtered, {tag});
 
-  Filter filter;
-  std::vector <Task> filtered;
-  filter.subset (filtered, {tag});
+  // if (std::find (filtered.begin (), filtered.end (), *this) != filtered.end ()) {
+  //   return true;
+  // }
 
-  if (std::find (filtered.begin (), filtered.end (), *this) != filtered.end ()) {
-    return true;
-  }
+  // for (auto arg : Context::getContext ().cli2._args) {
+  //   std::cout << "dump: " << arg.dump() << std::endl;
+  // }
 
-  return false;
+  // std::cout << "(" << id << ") Could not find this in filtered" << std::endl;
+  // return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1444,7 +1481,13 @@ bool Task::hasTag (const std::string& tag) const
     if (tag == "PRIORITY")  return has ("priority");
 
     if (customVirtualTagApplies (tag))
+    {
+      if (tag == "SCHEDULEDSOON")
+        std::cout << "(" << id << ") Virtual Tag applies: " << tag << std::endl;
       return true;
+    }
+    else if (tag == "SCHEDULEDSOON")
+      std::cout << "(" << id << ") Virtual tag does not apply: " << tag << std::endl;
   }
 
   // Concrete tags.
@@ -2094,6 +2137,8 @@ float Task::urgency_c () const
         {
           std::string tag = var.first.substr (17, end - 17);
 
+          if (tag == "SCHEDULEDSOON")
+            std::cout << "(" << id << ") Before hastag: " << tag << std::endl;
           if (hasTag (tag))
             value += var.second;
         }

--- a/src/Task.h
+++ b/src/Task.h
@@ -133,6 +133,7 @@ public:
 
   int getTagCount () const;
   bool hasTag (const std::string&) const;
+  bool filterApplies (const std::string&, std::vector <std::string> = {}) const;
   bool customVirtualTagApplies(const std::string&) const;
   void addTag (const std::string&);
   void setTags (const std::vector <std::string>&);

--- a/src/Task.h
+++ b/src/Task.h
@@ -133,6 +133,7 @@ public:
 
   int getTagCount () const;
   bool hasTag (const std::string&) const;
+  bool customVirtualTagApplies(const std::string&) const;
   void addTag (const std::string&);
   void setTags (const std::vector <std::string>&);
   std::vector <std::string> getTags () const;
@@ -195,6 +196,7 @@ private:
 
 protected:
   std::map <std::string, std::string> data {};
+  std::map <std::string, bool> custom_virtual_tag_processing {};
 
 public:
   float urgency_project     () const;
@@ -209,6 +211,7 @@ public:
   float urgency_blocking    () const;
   float urgency_age         () const;
 };
+
 
 #endif
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/Task.h
+++ b/src/Task.h
@@ -196,7 +196,6 @@ private:
 
 protected:
   std::map <std::string, std::string> data {};
-  std::map <std::string, bool> custom_virtual_tag_processing {};
 
 public:
   float urgency_project     () const;

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -358,6 +358,19 @@ int CmdInfo::execute (std::string& output)
       if (task.hasTag ("WEEK"))      virtualTags += "WEEK ";
       if (task.hasTag ("YEAR"))      virtualTags += "YEAR ";
       if (task.hasTag ("YESTERDAY")) virtualTags += "YESTERDAY ";
+      
+      for (auto i : Context::getContext ().config)
+      {
+        if (i.first.substr (0, 11) == "virtualtag.")
+        {
+          auto end = i.first.find (".filter");
+          if (end != std::string::npos)
+          {
+            const std::string tagname = i.first.substr (11, end - 11);
+            if (task.hasTag (tagname)) virtualTags += tagname + " ";
+          }
+        }
+      }
       // If you update the above list, update src/Task.cpp and src/commands/CmdTags.cpp as well.
 
       row = view.addRow ();

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -244,6 +244,7 @@ int CmdShow::execute (std::string& output)
           i.first.substr (0,  6) != "alias."                &&
           i.first.substr (0,  5) != "hook."                 &&
           i.first.substr (0,  4) != "uda."                  &&
+          i.first.substr (0, 11) != "virtualtag."           &&
           i.first.substr (0,  8) != "default."              &&
           i.first.substr (0, 21) != "urgency.user.project." &&
           i.first.substr (0, 17) != "urgency.user.tag."     &&

--- a/src/commands/CmdTags.cpp
+++ b/src/commands/CmdTags.cpp
@@ -212,6 +212,19 @@ int CmdCompletionTags::execute (std::string& output)
   unique["WEEK"]      = 0;
   unique["YEAR"]      = 0;
   unique["YESTERDAY"] = 0;
+  
+  for (auto i : Context::getContext ().config)
+  {
+    if (i.first.substr (0, 11) == "virtualtag.")
+    {
+      auto end = i.first.find (".filter");
+      if (end != std::string::npos)
+      {
+        const std::string tagname = i.first.substr (11, end - 11);
+        unique[tagname] = 0;
+      }
+    }
+  }
 
   // If you update the above list, update src/commands/CmdInfo.cpp and src/Task.cpp as well.
 

--- a/src/tc/rust/Cargo.lock
+++ b/src/tc/rust/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,15 +78,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -88,12 +99,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e599641dff337570f6aa9c304ecca92341d30bf72e1c50287869ed6a36615a6"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e2434bc22249c056e12d2e87db46380730da0f2648471edea3e8e11834a892"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3894ad0c6d517cb5a4ce8ec20b37cd0ea31b480fe582a104c5db67ae21270853"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fa7e395dc1c001083c7eed28c8f0f0b5a225610f3b6284675f444af6fab86b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -143,18 +214,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
  "hashbrown",
 ]
@@ -164,6 +235,30 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
 
 [[package]]
 name = "idna"
@@ -199,19 +294,28 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -228,12 +332,6 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
@@ -317,16 +415,15 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "memchr",
  "smallvec",
 ]
 
@@ -355,6 +452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,18 +469,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,6 +577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +646,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,9 +665,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
+checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
  "base64",
  "chunked_transfer",
@@ -576,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
  "serde",
@@ -700,6 +818,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"


### PR DESCRIPTION
This PR adds a new feature, custom virtual tags. They can be specified in the config like so:

```
virtualtag.FORTODAY.filter=planned.before:tomorrow
```

Then they can be used like any other virtual tag, and the filter will be applied, e.g. `task +FORTODAY` will do the exact same thing as `task planned.before:tomorrow`. This is especially useful because you can use these tags in urgency settings as well:

```
urgency.user.tag.FORTODAY.coefficient=2.0
```

In this way you can effectively give all tasks that match a filter a boost in urgency.

I believe this would satisfy https://github.com/GothenburgBitFactory/taskwarrior/issues/174, and possibly others.

I have not written documentation yet, I didn't want to put in that work before I knew whether this feature would even be accepted. This is also my first contribution, so I may need a little help in learning the lay of the land ;-).