### PR TITLE
Add a hint to 'make test' see test problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,11 @@ add_custom_command(OUTPUT run-reproduce
 )
 add_custom_target(reproduce DEPENDS run-reproduce)
 
+add_custom_command(OUTPUT show-problems
+    COMMAND cd test && ./problems
+)
+add_custom_target(problems DEPENDS show-problems)
+
 # ---
 
 set (CPACK_SOURCE_GENERATOR "TGZ")

--- a/test/problems
+++ b/test/problems
@@ -121,6 +121,7 @@ if __name__ == "__main__":
     expected_int = v.format(sum(expected.values()))
     runtime_str = "Runtime:" + pad(20)
     runtime_int = "{0:>8.2f} seconds".format(stop - start)
+    details_str = "For details run 'make problems'"
 
     if cmd_args.summary:
         print(color(passed_str, "green"), passed_int)
@@ -129,6 +130,7 @@ if __name__ == "__main__":
         print(color(skipped_str, "yellow"), skipped_int)
         print(color(expected_str, "yellow"), expected_int)
         print(runtime_str, runtime_int)
+        print(details_str)
 
     else:
         print(color(error_str, "red"))


### PR DESCRIPTION
#### Description

I keep forgetting how to see the problems in my test runs, so this will at least help me -- and hopefully some other people too!

#### Additional information...

- [x] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [ ] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
