### PR TITLE
review-dockerfile: Adjust for recent buildchain changes

### DIFF
--- a/scripts/review-dockerfile
+++ b/scripts/review-dockerfile
@@ -17,6 +17,10 @@ RUN echo warrior ALL=NOPASSWD:ALL > /etc/sudoers.d/warrior
 USER warrior
 WORKDIR /home/warrior/
 
+# Setup Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh && \
+    sh rustup.sh -y --profile minimal --default-toolchain stable --component rust-docs
+
 # Setup taskwarrior
 # The purpose is to speed up subsequent re-installs due to Docker layer caching
 RUN git clone https://github.com/GothenburgBitFactory/taskwarrior.git

--- a/scripts/review-dockerfile
+++ b/scripts/review-dockerfile
@@ -3,6 +3,10 @@
 
 FROM centos:8
 
+# Workaround to the location of the repos
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN dnf update -y
 RUN yum install epel-release -y
 RUN dnf install python38 git gcc gcc-c++ cmake make gnutls-devel libuuid-devel libfaketime sudo man -y


### PR DESCRIPTION
#### Description

The review dockerfile (`scripts/review-dockerfile`) needed two fixes in order to recover its ability to build Taskwarrior pull requests:
* Location of upstream CentOS repos has changed
* Rust build toolchain needed to be setup

#### How to test

Run the `review` target with make, referencing an arbitrary recent PR, i.e.:

```
make PR=2993 review
```