### PR TITLE
tests: Fail OS-X test workflow on error in the build process

### DIFF
--- a/test/scripts/test_osx.sh
+++ b/test/scripts/test_osx.sh
@@ -1,4 +1,4 @@
-set -x
+set -ex
 
 brew install gnutls
 brew install cmake


### PR DESCRIPTION
This sets `set -e` to ensure any errors in the test script are propagated upwards and noticed by the Github workflow.

Prior to these changes failures in the build process of the tests would be ignored, and the success / failure would be determined purely by the return code of the `./problems` script.

Closes #3012 