### PR TITLE
osx: Set LDFLAGS to search Foundation and Security

### DIFF
--- a/test/scripts/test_osx.sh
+++ b/test/scripts/test_osx.sh
@@ -1,5 +1,6 @@
 set -ex
 
+export LDFLAGS="-framework Foundation -framework Security"
 brew install gnutls
 brew install cmake
 brew install libfaketime


### PR DESCRIPTION
This is the minimum set of flags required for linking to work on Mac OS-X.