### PR TITLE
Do not further update 'modified' if it's explicitly set

### DIFF
--- a/taskchampion/taskchampion/src/task/task.rs
+++ b/taskchampion/taskchampion/src/task/task.rs
@@ -1199,7 +1199,7 @@ mod test {
     }
 
     #[test]
-    fn set_value_modiifed() {
+    fn set_value_modified() {
         with_mut_task(|mut task| {
             // set the modified property to something in the past..
             task.set_value("modified", Some("1671820000".into()))

--- a/taskchampion/taskchampion/src/task/task.rs
+++ b/taskchampion/taskchampion/src/task/task.rs
@@ -372,8 +372,17 @@ impl<'r> TaskMut<'r> {
     }
 
     /// Set a tasks's property by name.
+    ///
+    /// This will not automatically update the `modified` timestamp or perform any other
+    /// "automatic" operations -- it simply sets the property. Howerver, if property is
+    /// "modified", then subsequent calls to other `set_..` methods will not update the
+    /// `modified` timestamp.
     pub fn set_value<S: Into<String>>(&mut self, property: S, value: Option<String>) -> Result<()> {
         let property = property.into();
+
+        if &property == "modified" {
+            self.updated_modified = true;
+        }
 
         if let Some(ref v) = value {
             trace!("task {}: set property {}={:?}", self.task.uuid, property, v);
@@ -524,7 +533,7 @@ impl<'r> TaskMut<'r> {
 
     fn set_string<S: Into<String>>(&mut self, property: S, value: Option<String>) -> Result<()> {
         let property = property.into();
-        // updated the modified timestamp unless we are setting it explicitly
+        // update the modified timestamp unless we are setting it explicitly
         if &property != "modified" {
             self.update_modified()?;
         }
@@ -1187,5 +1196,18 @@ mod test {
         assert!(!t2.has_tag(&stag(SyntheticTag::Blocked)));
         assert!(t2.has_tag(&stag(SyntheticTag::Unblocked)));
         assert!(t2.has_tag(&stag(SyntheticTag::Blocking)));
+    }
+
+    #[test]
+    fn set_value_modiifed() {
+        with_mut_task(|mut task| {
+            // set the modified property to something in the past..
+            task.set_value("modified", Some("1671820000".into()))
+                .unwrap();
+            // update another property
+            task.set_description("fun times".into()).unwrap();
+            // verify the modified property was not updated
+            assert_eq!(task.get_value("modified").unwrap(), "1671820000")
+        })
     }
 }


### PR DESCRIPTION
This is a minor correctness fix, but helps avoid inconsistencies when things like Taskwarrior call both `set_value` and other, higher-level `set_..` methods like `set_status`.