### PR TITLE
fix: typo

### DIFF
--- a/src/commands/CmdNews.cpp
+++ b/src/commands/CmdNews.cpp
@@ -257,7 +257,7 @@ void CmdNews::version2_6_0 (std::vector<NewsItem>& items) {
     "  The currently active context definition is now applied as default modifications\n"
     "  when creating new tasks using 'task add' and 'task log'.",
     "  \n"
-    "  Consider following example, using contex 'work' defined as 'project:Work' above:\n"
+    "  Consider following example, using context 'work' defined as 'project:Work' above:\n"
     "  \n"
     "    $ task context work\n"
     "    $ task add Talk to Jeff\n"


### PR DESCRIPTION
#### Description

Fixes a minor typo in the news output of changes in version 2.6.0.
