### PR TITLE
Add workflow for Taskwarrior Docker image

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,53 @@
+name: Taskwarrior Docker image
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [tests]
+    branches:
+      - develop
+      - stable
+    types:
+      - completed
+
+env:
+  REGISTRY: "ghcr.io"
+
+jobs:
+  build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2.8.1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Taskwarrior Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          file: "./docker/task.dockerfile"
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.actor }}/task:${{ github.ref_name }}
+
+      - name: Sign the published Docker image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign ${{ env.REGISTRY }}/${{ github.actor }}/task@${{ steps.build-and-push.outputs.digest }}

--- a/docker/task.dockerfile
+++ b/docker/task.dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:22.04 AS base
+
+FROM base AS builder
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+            build-essential \
+            cmake \
+            curl \
+            git \
+            libgnutls28-dev \
+            uuid-dev
+
+# Setup language environment
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Add source directory
+ADD .. /root/code/
+WORKDIR /root/code/
+
+# Setup Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh && \
+    sh rustup.sh -y --profile minimal --default-toolchain stable --component rust-docs
+
+# Build Taskwarrior
+RUN git clean -dfx && \
+    git submodule init && \
+    git submodule update && \
+    cmake -DCMAKE_BUILD_TYPE=release . && \
+    make -j8
+
+FROM base AS runner
+
+# Install Taskwarrior
+COPY --from=builder /root/code/src/task /usr/local/bin
+
+# Initialize Taskwarrior
+RUN ( echo "yes" | task ) || true


### PR DESCRIPTION
#### Description
Add workflow for Taskwarrior Docker image

The workflow is triggered by a successful run of the test suite and creates a Docker image with a Taskwarrior installation of the current branch (restricted to develop/stable)

The main intention is to have a base image to test the on-modify hook for Timewarrior (see [here](https://github.com/lauft/task-on-modify-hook)), but it may also be useful for other extension – or just to try out Taskwarrior.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  No changes to present code or build infrastructure

- [ ] I changed Rust code or build infrastructure.
  No changes to present code or build infrastructure
