### PR TITLE
Enable version updates for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
+  # Enable version updates for GitHub actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # Enable updates for Rust packages
   - package-ecosystem: "cargo"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
#### Description

This PR adds version updates for GitHub actions. Analog to Rust package updates, dependabot is configured to check and update GitHub actions on weekly schedule.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  No changes to present C++ code or build infrastructure

- [ ] I changed Rust code or build infrastructure.
  No changes to present Rust code or build infrastructure
