### PR TITLE
taskchampion: use taskchampion::Error

### DIFF
--- a/taskchampion/taskchampion/src/errors.rs
+++ b/taskchampion/taskchampion/src/errors.rs
@@ -19,20 +19,25 @@ pub enum Error {
     /// A usage error
     #[error("User Error: {0}")]
     Usage(String),
-
-    /// Error conversions.
-    #[error(transparent)]
-    Http(#[from] ureq::Error),
-    #[error(transparent)]
-    Io(#[from] io::Error),
-    #[error(transparent)]
-    Json(#[from] serde_json::Error),
+    /// A general error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
-    #[error("Third Party Sqlite Error")]
-    Rusqlite(#[from] rusqlite::Error),
-    #[error(transparent)]
-    Sqlite(#[from] crate::storage::sqlite::SqliteError),
 }
+
+/// Convert private and third party errors into Error::Other.
+macro_rules! convert_error {
+    ( $error:ty ) => {
+        impl From<$error> for Error {
+            fn from(err: $error) -> Self {
+                Self::Other(err.into())
+            }
+        }
+    };
+}
+convert_error!(ureq::Error);
+convert_error!(io::Error);
+convert_error!(serde_json::Error);
+convert_error!(rusqlite::Error);
+convert_error!(crate::storage::sqlite::SqliteError);
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/taskchampion/taskchampion/src/errors.rs
+++ b/taskchampion/taskchampion/src/errors.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 pub enum Error {
     /// A crypto-related error
     #[error("Crypto Error: {0}")]
-    Crypto(String),
+    Server(String),
     /// A task-database-related error
     #[error("Task Database Error: {0}")]
     Database(String),
@@ -18,7 +18,7 @@ pub enum Error {
     OutOfSync,
     /// A usage error
     #[error("User Error: {0}")]
-    UserError(String),
+    Usage(String),
 
     /// Error conversions.
     #[error(transparent)]
@@ -35,4 +35,4 @@ pub enum Error {
     Sqlite(#[from] crate::storage::sqlite::SqliteError),
 }
 
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/taskchampion/taskchampion/src/errors.rs
+++ b/taskchampion/taskchampion/src/errors.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 #[non_exhaustive]
 /// Errors returned from taskchampion operations
 pub enum Error {
-    /// A crypto-related error
-    #[error("Crypto Error: {0}")]
+    /// A server-related error
+    #[error("Server Error: {0}")]
     Server(String),
     /// A task-database-related error
     #[error("Task Database Error: {0}")]
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("Local replica is out of sync with the server")]
     OutOfSync,
     /// A usage error
-    #[error("User Error: {0}")]
+    #[error("Usage Error: {0}")]
     Usage(String),
     /// A general error.
     #[error(transparent)]
@@ -25,7 +25,7 @@ pub enum Error {
 }
 
 /// Convert private and third party errors into Error::Other.
-macro_rules! convert_error {
+macro_rules! other_error {
     ( $error:ty ) => {
         impl From<$error> for Error {
             fn from(err: $error) -> Self {
@@ -34,10 +34,10 @@ macro_rules! convert_error {
         }
     };
 }
-convert_error!(ureq::Error);
-convert_error!(io::Error);
-convert_error!(serde_json::Error);
-convert_error!(rusqlite::Error);
-convert_error!(crate::storage::sqlite::SqliteError);
+other_error!(ureq::Error);
+other_error!(io::Error);
+other_error!(serde_json::Error);
+other_error!(rusqlite::Error);
+other_error!(crate::storage::sqlite::SqliteError);
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/taskchampion/taskchampion/src/errors.rs
+++ b/taskchampion/taskchampion/src/errors.rs
@@ -1,9 +1,13 @@
+use std::io;
 use thiserror::Error;
 
-#[derive(Debug, Error, Eq, PartialEq, Clone)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 /// Errors returned from taskchampion operations
 pub enum Error {
+    /// A crypto-related error
+    #[error("Crypto Error: {0}")]
+    Crypto(String),
     /// A task-database-related error
     #[error("Task Database Error: {0}")]
     Database(String),
@@ -12,4 +16,23 @@ pub enum Error {
     /// other irrecoverable error.
     #[error("Local replica is out of sync with the server")]
     OutOfSync,
+    /// A usage error
+    #[error("User Error: {0}")]
+    UserError(String),
+
+    /// Error conversions.
+    #[error(transparent)]
+    Http(#[from] ureq::Error),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+    #[error("Third Party Sqlite Error")]
+    Rusqlite(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Sqlite(#[from] crate::storage::sqlite::SqliteError),
 }
+
+pub type Result<T> = core::result::Result<T, Error>;

--- a/taskchampion/taskchampion/src/replica.rs
+++ b/taskchampion/taskchampion/src/replica.rs
@@ -1,4 +1,5 @@
 use crate::depmap::DependencyMap;
+use crate::errors::Result;
 use crate::server::{Server, SyncOp};
 use crate::storage::{Storage, TaskMap};
 use crate::task::{Status, Task};
@@ -63,7 +64,7 @@ impl Replica {
         uuid: Uuid,
         property: S1,
         value: Option<S2>,
-    ) -> anyhow::Result<TaskMap>
+    ) -> Result<TaskMap>
     where
         S1: Into<String>,
         S2: Into<String>,
@@ -78,12 +79,12 @@ impl Replica {
     }
 
     /// Add the given uuid to the working set, returning its index.
-    pub(crate) fn add_to_working_set(&mut self, uuid: Uuid) -> anyhow::Result<usize> {
+    pub(crate) fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize> {
         self.taskdb.add_to_working_set(uuid)
     }
 
     /// Get all tasks represented as a map keyed by UUID
-    pub fn all_tasks(&mut self) -> anyhow::Result<HashMap<Uuid, Task>> {
+    pub fn all_tasks(&mut self) -> Result<HashMap<Uuid, Task>> {
         let depmap = self.dependency_map(false)?;
         let mut res = HashMap::new();
         for (uuid, tm) in self.taskdb.all_tasks()?.drain(..) {
@@ -93,13 +94,13 @@ impl Replica {
     }
 
     /// Get the UUIDs of all tasks
-    pub fn all_task_uuids(&mut self) -> anyhow::Result<Vec<Uuid>> {
+    pub fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
         self.taskdb.all_task_uuids()
     }
 
     /// Get the "working set" for this replica.  This is a snapshot of the current state,
     /// and it is up to the caller to decide how long to store this value.
-    pub fn working_set(&mut self) -> anyhow::Result<WorkingSet> {
+    pub fn working_set(&mut self) -> Result<WorkingSet> {
         Ok(WorkingSet::new(self.taskdb.working_set()?))
     }
 
@@ -111,7 +112,7 @@ impl Replica {
     ///
     /// If `force` is true, then the result is re-calculated from the current state of the replica,
     /// although previously-returned dependency maps are not updated.
-    pub fn dependency_map(&mut self, force: bool) -> anyhow::Result<Rc<DependencyMap>> {
+    pub fn dependency_map(&mut self, force: bool) -> Result<Rc<DependencyMap>> {
         if force || self.depmap.is_none() {
             let mut dm = DependencyMap::new();
             let ws = self.working_set()?;
@@ -138,7 +139,7 @@ impl Replica {
     }
 
     /// Get an existing task by its UUID
-    pub fn get_task(&mut self, uuid: Uuid) -> anyhow::Result<Option<Task>> {
+    pub fn get_task(&mut self, uuid: Uuid) -> Result<Option<Task>> {
         let depmap = self.dependency_map(false)?;
         Ok(self
             .taskdb
@@ -147,7 +148,7 @@ impl Replica {
     }
 
     /// Create a new task.
-    pub fn new_task(&mut self, status: Status, description: String) -> anyhow::Result<Task> {
+    pub fn new_task(&mut self, status: Status, description: String) -> Result<Task> {
         let uuid = Uuid::new_v4();
         self.add_undo_point(false)?;
         let taskmap = self.taskdb.apply(SyncOp::Create { uuid })?;
@@ -163,7 +164,7 @@ impl Replica {
     /// Create a new, empty task with the given UUID.  This is useful for importing tasks, but
     /// otherwise should be avoided in favor of `new_task`.  If the task already exists, this
     /// does nothing and returns the existing task.
-    pub fn import_task_with_uuid(&mut self, uuid: Uuid) -> anyhow::Result<Task> {
+    pub fn import_task_with_uuid(&mut self, uuid: Uuid) -> Result<Task> {
         self.add_undo_point(false)?;
         let taskmap = self.taskdb.apply(SyncOp::Create { uuid })?;
         let depmap = self.dependency_map(false)?;
@@ -173,7 +174,7 @@ impl Replica {
     /// Delete a task.  The task must exist.  Note that this is different from setting status to
     /// Deleted; this is the final purge of the task.  This is not a public method as deletion
     /// should only occur through expiration.
-    fn delete_task(&mut self, uuid: Uuid) -> anyhow::Result<()> {
+    fn delete_task(&mut self, uuid: Uuid) -> Result<()> {
         self.add_undo_point(false)?;
         self.taskdb.apply(SyncOp::Delete { uuid })?;
         trace!("task {} deleted", uuid);
@@ -190,11 +191,7 @@ impl Replica {
     ///
     /// Set this to true on systems more constrained in CPU, memory, or bandwidth than a typical desktop
     /// system
-    pub fn sync(
-        &mut self,
-        server: &mut Box<dyn Server>,
-        avoid_snapshots: bool,
-    ) -> anyhow::Result<()> {
+    pub fn sync(&mut self, server: &mut Box<dyn Server>, avoid_snapshots: bool) -> Result<()> {
         self.taskdb
             .sync(server, avoid_snapshots)
             .context("Failed to synchronize with server")?;
@@ -205,7 +202,7 @@ impl Replica {
 
     /// Undo local operations until the most recent UndoPoint, returning false if there are no
     /// local operations to undo.
-    pub fn undo(&mut self) -> anyhow::Result<bool> {
+    pub fn undo(&mut self) -> Result<bool> {
         self.taskdb.undo()
     }
 
@@ -213,7 +210,7 @@ impl Replica {
     /// `renumber` is true, then existing tasks may be moved to new working-set indices; in any
     /// case, on completion all pending and recurring tasks are in the working set and all tasks
     /// with other statuses are not.
-    pub fn rebuild_working_set(&mut self, renumber: bool) -> anyhow::Result<()> {
+    pub fn rebuild_working_set(&mut self, renumber: bool) -> Result<()> {
         let pending = String::from(Status::Pending.to_taskmap());
         let recurring = String::from(Status::Recurring.to_taskmap());
         self.taskdb.rebuild_working_set(
@@ -236,7 +233,7 @@ impl Replica {
     ///
     /// Tasks are eligible for expiration when they have status Deleted and have not been modified
     /// for 180 days (about six months). Note that completed tasks are not eligible.
-    pub fn expire_tasks(&mut self) -> anyhow::Result<()> {
+    pub fn expire_tasks(&mut self) -> Result<()> {
         let six_mos_ago = Utc::now() - Duration::days(180);
         self.all_tasks()?
             .iter()
@@ -256,7 +253,7 @@ impl Replica {
     /// automatically when a change is made.  The `force` flag allows forcing a new UndoPoint
     /// even if one has already been created by this Replica, and may be useful when a Replica
     /// instance is held for a long time and used to apply more than one user-visible change.
-    pub fn add_undo_point(&mut self, force: bool) -> anyhow::Result<()> {
+    pub fn add_undo_point(&mut self, force: bool) -> Result<()> {
         if force || !self.added_undo_point {
             self.taskdb.add_undo_point()?;
             self.added_undo_point = true;
@@ -265,12 +262,12 @@ impl Replica {
     }
 
     /// Get the number of operations local to this replica and not yet synchronized to the server.
-    pub fn num_local_operations(&mut self) -> anyhow::Result<usize> {
+    pub fn num_local_operations(&mut self) -> Result<usize> {
         self.taskdb.num_operations()
     }
 
     /// Get the number of undo points available (number of times `undo` will succeed).
-    pub fn num_undo_points(&mut self) -> anyhow::Result<usize> {
+    pub fn num_undo_points(&mut self) -> Result<usize> {
         self.taskdb.num_undo_points()
     }
 }

--- a/taskchampion/taskchampion/src/server/config.rs
+++ b/taskchampion/taskchampion/src/server/config.rs
@@ -1,5 +1,6 @@
 use super::types::Server;
 use super::{LocalServer, RemoteServer};
+use crate::errors::Result;
 use std::path::PathBuf;
 use uuid::Uuid;
 
@@ -26,7 +27,7 @@ pub enum ServerConfig {
 
 impl ServerConfig {
     /// Get a server based on this configuration
-    pub fn into_server(self) -> anyhow::Result<Box<dyn Server>> {
+    pub fn into_server(self) -> Result<Box<dyn Server>> {
         Ok(match self {
             ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
             ServerConfig::Remote {

--- a/taskchampion/taskchampion/src/server/crypto.rs
+++ b/taskchampion/taskchampion/src/server/crypto.rs
@@ -136,12 +136,12 @@ struct Envelope<'a> {
 impl<'a> Envelope<'a> {
     fn from_bytes(buf: &'a [u8]) -> Result<Envelope<'a>> {
         if buf.len() <= 1 + aead::NONCE_LEN {
-            return Err(Error::Crypto(String::from("envelope is too small")));
+            return Err(Error::Server(String::from("envelope is too small")));
         }
 
         let version = buf[0];
         if version != ENVELOPE_VERSION {
-            return Err(Error::Crypto(format!(
+            return Err(Error::Server(format!(
                 "unrecognized encryption envelope version {}",
                 version
             )));
@@ -191,7 +191,7 @@ impl Sealed {
                 payload,
             })
         } else {
-            Err(Error::Crypto(String::from(
+            Err(Error::Server(String::from(
                 "Response did not have expected content-type",
             )))
         }

--- a/taskchampion/taskchampion/src/server/local.rs
+++ b/taskchampion/taskchampion/src/server/local.rs
@@ -1,3 +1,4 @@
+use crate::errors::Result;
 use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, Snapshot, SnapshotUrgency,
     VersionId, NIL_VERSION_ID,
@@ -22,13 +23,13 @@ pub struct LocalServer {
 }
 
 impl LocalServer {
-    fn txn(&mut self) -> anyhow::Result<rusqlite::Transaction> {
+    fn txn(&mut self) -> Result<rusqlite::Transaction> {
         let txn = self.con.transaction()?;
         Ok(txn)
     }
 
     /// A server which has no notion of clients, signatures, encryption, etc.
-    pub fn new<P: AsRef<Path>>(directory: P) -> anyhow::Result<LocalServer> {
+    pub fn new<P: AsRef<Path>>(directory: P) -> Result<LocalServer> {
         let db_file = directory
             .as_ref()
             .join("taskchampion-local-sync-server.sqlite3");
@@ -45,7 +46,7 @@ impl LocalServer {
         Ok(LocalServer { con })
     }
 
-    fn get_latest_version_id(&mut self) -> anyhow::Result<VersionId> {
+    fn get_latest_version_id(&mut self) -> Result<VersionId> {
         let t = self.txn()?;
         let result: Option<StoredUuid> = t
             .query_row(
@@ -57,7 +58,7 @@ impl LocalServer {
         Ok(result.map(|x| x.0).unwrap_or(NIL_VERSION_ID))
     }
 
-    fn set_latest_version_id(&mut self, version_id: VersionId) -> anyhow::Result<()> {
+    fn set_latest_version_id(&mut self, version_id: VersionId) -> Result<()> {
         let t = self.txn()?;
         t.execute(
             "INSERT OR REPLACE INTO data (key, value) VALUES ('latest_version_id', ?)",
@@ -71,7 +72,7 @@ impl LocalServer {
     fn get_version_by_parent_version_id(
         &mut self,
         parent_version_id: VersionId,
-    ) -> anyhow::Result<Option<Version>> {
+    ) -> Result<Option<Version>> {
         let t = self.txn()?;
         let r = t.query_row(
             "SELECT version_id, parent_version_id, data FROM versions WHERE parent_version_id = ?",
@@ -92,7 +93,7 @@ impl LocalServer {
         Ok(r)
     }
 
-    fn add_version_by_parent_version_id(&mut self, version: Version) -> anyhow::Result<()> {
+    fn add_version_by_parent_version_id(&mut self, version: Version) -> Result<()> {
         let t = self.txn()?;
         t.execute(
             "INSERT INTO versions (version_id, parent_version_id, data) VALUES (?, ?, ?)",
@@ -115,7 +116,7 @@ impl Server for LocalServer {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> anyhow::Result<(AddVersionResult, SnapshotUrgency)> {
+    ) -> Result<(AddVersionResult, SnapshotUrgency)> {
         // no client lookup
         // no signature validation
 
@@ -141,10 +142,7 @@ impl Server for LocalServer {
         Ok((AddVersionResult::Ok(version_id), SnapshotUrgency::None))
     }
 
-    fn get_child_version(
-        &mut self,
-        parent_version_id: VersionId,
-    ) -> anyhow::Result<GetVersionResult> {
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult> {
         if let Some(version) = self.get_version_by_parent_version_id(parent_version_id)? {
             Ok(GetVersionResult::Version {
                 version_id: version.version_id,
@@ -156,12 +154,12 @@ impl Server for LocalServer {
         }
     }
 
-    fn add_snapshot(&mut self, _version_id: VersionId, _snapshot: Snapshot) -> anyhow::Result<()> {
+    fn add_snapshot(&mut self, _version_id: VersionId, _snapshot: Snapshot) -> Result<()> {
         // the local server never requests a snapshot, so it should never get one
         unreachable!()
     }
 
-    fn get_snapshot(&mut self) -> anyhow::Result<Option<(VersionId, Snapshot)>> {
+    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
         Ok(None)
     }
 }
@@ -173,7 +171,7 @@ mod test {
     use tempfile::TempDir;
 
     #[test]
-    fn test_empty() -> anyhow::Result<()> {
+    fn test_empty() -> Result<()> {
         let tmp_dir = TempDir::new()?;
         let mut server = LocalServer::new(tmp_dir.path())?;
         let child_version = server.get_child_version(NIL_VERSION_ID)?;
@@ -182,7 +180,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_zero_base() -> anyhow::Result<()> {
+    fn test_add_zero_base() -> Result<()> {
         let tmp_dir = TempDir::new()?;
         let mut server = LocalServer::new(tmp_dir.path())?;
         let history = b"1234".to_vec();
@@ -207,7 +205,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_nonzero_base() -> anyhow::Result<()> {
+    fn test_add_nonzero_base() -> Result<()> {
         let tmp_dir = TempDir::new()?;
         let mut server = LocalServer::new(tmp_dir.path())?;
         let history = b"1234".to_vec();
@@ -235,7 +233,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_nonzero_base_forbidden() -> anyhow::Result<()> {
+    fn test_add_nonzero_base_forbidden() -> Result<()> {
         let tmp_dir = TempDir::new()?;
         let mut server = LocalServer::new(tmp_dir.path())?;
         let history = b"1234".to_vec();

--- a/taskchampion/taskchampion/src/server/op.rs
+++ b/taskchampion/taskchampion/src/server/op.rs
@@ -123,6 +123,7 @@ impl SyncOp {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::errors::Result;
     use crate::storage::InMemoryStorage;
     use crate::taskdb::TaskDb;
     use chrono::{Duration, Utc};
@@ -130,7 +131,7 @@ mod test {
     use proptest::prelude::*;
 
     #[test]
-    fn test_json_create() -> anyhow::Result<()> {
+    fn test_json_create() -> Result<()> {
         let uuid = Uuid::new_v4();
         let op = Create { uuid };
         let json = serde_json::to_string(&op)?;
@@ -141,7 +142,7 @@ mod test {
     }
 
     #[test]
-    fn test_json_delete() -> anyhow::Result<()> {
+    fn test_json_delete() -> Result<()> {
         let uuid = Uuid::new_v4();
         let op = Delete { uuid };
         let json = serde_json::to_string(&op)?;
@@ -152,7 +153,7 @@ mod test {
     }
 
     #[test]
-    fn test_json_update() -> anyhow::Result<()> {
+    fn test_json_update() -> Result<()> {
         let uuid = Uuid::new_v4();
         let timestamp = Utc::now();
 
@@ -177,7 +178,7 @@ mod test {
     }
 
     #[test]
-    fn test_json_update_none() -> anyhow::Result<()> {
+    fn test_json_update_none() -> Result<()> {
         let uuid = Uuid::new_v4();
         let timestamp = Utc::now();
 

--- a/taskchampion/taskchampion/src/server/remote/mod.rs
+++ b/taskchampion/taskchampion/src/server/remote/mod.rs
@@ -1,3 +1,4 @@
+use crate::errors::Result;
 use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, Snapshot, SnapshotUrgency,
     VersionId,
@@ -31,7 +32,7 @@ impl RemoteServer {
         origin: String,
         client_key: Uuid,
         encryption_secret: Vec<u8>,
-    ) -> anyhow::Result<RemoteServer> {
+    ) -> Result<RemoteServer> {
         Ok(RemoteServer {
             origin,
             client_key,
@@ -45,7 +46,7 @@ impl RemoteServer {
 }
 
 /// Read a UUID-bearing header or fail trying
-fn get_uuid_header(resp: &ureq::Response, name: &str) -> anyhow::Result<Uuid> {
+fn get_uuid_header(resp: &ureq::Response, name: &str) -> Result<Uuid> {
     let value = resp
         .header(name)
         .ok_or_else(|| anyhow::anyhow!("Response does not have {} header", name))?;
@@ -71,7 +72,7 @@ impl Server for RemoteServer {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> anyhow::Result<(AddVersionResult, SnapshotUrgency)> {
+    ) -> Result<(AddVersionResult, SnapshotUrgency)> {
         let url = format!(
             "{}/v1/client/add-version/{}",
             self.origin, parent_version_id
@@ -106,10 +107,7 @@ impl Server for RemoteServer {
         }
     }
 
-    fn get_child_version(
-        &mut self,
-        parent_version_id: VersionId,
-    ) -> anyhow::Result<GetVersionResult> {
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult> {
         let url = format!(
             "{}/v1/client/get-child-version/{}",
             self.origin, parent_version_id
@@ -139,7 +137,7 @@ impl Server for RemoteServer {
         }
     }
 
-    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> anyhow::Result<()> {
+    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
         let url = format!("{}/v1/client/add-snapshot/{}", self.origin, version_id);
         let unsealed = Unsealed {
             version_id,
@@ -155,7 +153,7 @@ impl Server for RemoteServer {
             .map(|_| ())?)
     }
 
-    fn get_snapshot(&mut self) -> anyhow::Result<Option<(VersionId, Snapshot)>> {
+    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
         let url = format!("{}/v1/client/snapshot", self.origin);
         match self
             .agent

--- a/taskchampion/taskchampion/src/server/test.rs
+++ b/taskchampion/taskchampion/src/server/test.rs
@@ -1,3 +1,4 @@
+use crate::errors::Result;
 use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, Snapshot, SnapshotUrgency,
     VersionId, NIL_VERSION_ID,
@@ -66,7 +67,7 @@ impl Server for TestServer {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> anyhow::Result<(AddVersionResult, SnapshotUrgency)> {
+    ) -> Result<(AddVersionResult, SnapshotUrgency)> {
         let mut inner = self.0.lock().unwrap();
 
         // no client lookup
@@ -101,10 +102,7 @@ impl Server for TestServer {
     }
 
     /// Get a vector of all versions after `since_version`
-    fn get_child_version(
-        &mut self,
-        parent_version_id: VersionId,
-    ) -> anyhow::Result<GetVersionResult> {
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult> {
         let inner = self.0.lock().unwrap();
 
         if let Some(version) = inner.versions.get(&parent_version_id) {
@@ -118,7 +116,7 @@ impl Server for TestServer {
         }
     }
 
-    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> anyhow::Result<()> {
+    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
         let mut inner = self.0.lock().unwrap();
 
         // test implementation -- does not perform any validation
@@ -126,7 +124,7 @@ impl Server for TestServer {
         Ok(())
     }
 
-    fn get_snapshot(&mut self) -> anyhow::Result<Option<(VersionId, Snapshot)>> {
+    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
         let inner = self.0.lock().unwrap();
         Ok(inner.snapshot.clone())
     }

--- a/taskchampion/taskchampion/src/server/types.rs
+++ b/taskchampion/taskchampion/src/server/types.rs
@@ -1,3 +1,4 @@
+use crate::errors::Result;
 use uuid::Uuid;
 
 /// Versions are referred to with sha2 hashes.
@@ -55,16 +56,13 @@ pub trait Server {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> anyhow::Result<(AddVersionResult, SnapshotUrgency)>;
+    ) -> Result<(AddVersionResult, SnapshotUrgency)>;
 
     /// Get the version with the given parent VersionId
-    fn get_child_version(
-        &mut self,
-        parent_version_id: VersionId,
-    ) -> anyhow::Result<GetVersionResult>;
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult>;
 
     /// Add a snapshot on the server
-    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> anyhow::Result<()>;
+    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()>;
 
-    fn get_snapshot(&mut self) -> anyhow::Result<Option<(VersionId, Snapshot)>>;
+    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>>;
 }

--- a/taskchampion/taskchampion/src/storage/config.rs
+++ b/taskchampion/taskchampion/src/storage/config.rs
@@ -1,4 +1,5 @@
 use super::{InMemoryStorage, SqliteStorage, Storage};
+use crate::errors::Result;
 use std::path::PathBuf;
 
 /// The configuration required for a replica's storage.
@@ -16,7 +17,7 @@ pub enum StorageConfig {
 }
 
 impl StorageConfig {
-    pub fn into_storage(self) -> anyhow::Result<Box<dyn Storage>> {
+    pub fn into_storage(self) -> Result<Box<dyn Storage>> {
         Ok(match self {
             StorageConfig::OnDisk {
                 taskdb_dir,

--- a/taskchampion/taskchampion/src/storage/mod.rs
+++ b/taskchampion/taskchampion/src/storage/mod.rs
@@ -5,7 +5,7 @@ It defines a [trait](crate::storage::Storage) for storage implementations, and p
 Typical uses of this crate do not interact directly with this module; [`StorageConfig`](crate::StorageConfig) is sufficient.
 However, users who wish to implement their own storage backends can implement the traits defined here and pass the result to [`Replica`](crate::Replica).
 */
-use anyhow::Result;
+use crate::errors::Result;
 use std::collections::HashMap;
 use uuid::Uuid;
 

--- a/taskchampion/taskchampion/src/storage/op.rs
+++ b/taskchampion/taskchampion/src/storage/op.rs
@@ -103,6 +103,7 @@ impl ReplicaOp {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::errors::Result;
     use crate::storage::taskmap_with;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
@@ -110,7 +111,7 @@ mod test {
     use ReplicaOp::*;
 
     #[test]
-    fn test_json_create() -> anyhow::Result<()> {
+    fn test_json_create() -> Result<()> {
         let uuid = Uuid::new_v4();
         let op = Create { uuid };
         let json = serde_json::to_string(&op)?;
@@ -121,7 +122,7 @@ mod test {
     }
 
     #[test]
-    fn test_json_delete() -> anyhow::Result<()> {
+    fn test_json_delete() -> Result<()> {
         let uuid = Uuid::new_v4();
         let old_task = vec![("foo".into(), "bar".into())].drain(..).collect();
         let op = Delete { uuid, old_task };
@@ -139,7 +140,7 @@ mod test {
     }
 
     #[test]
-    fn test_json_update() -> anyhow::Result<()> {
+    fn test_json_update() -> Result<()> {
         let uuid = Uuid::new_v4();
         let timestamp = Utc::now();
 
@@ -165,7 +166,7 @@ mod test {
     }
 
     #[test]
-    fn test_json_update_none() -> anyhow::Result<()> {
+    fn test_json_update_none() -> Result<()> {
         let uuid = Uuid::new_v4();
         let timestamp = Utc::now();
 

--- a/taskchampion/taskchampion/src/storage/sqlite.rs
+++ b/taskchampion/taskchampion/src/storage/sqlite.rs
@@ -113,7 +113,7 @@ struct Txn<'t> {
 }
 
 impl<'t> Txn<'t> {
-    fn get_txn(&self) -> core::result::Result<&rusqlite::Transaction<'t>, SqliteError> {
+    fn get_txn(&self) -> std::result::Result<&rusqlite::Transaction<'t>, SqliteError> {
         self.txn
             .as_ref()
             .ok_or(SqliteError::TransactionAlreadyCommitted)
@@ -305,7 +305,7 @@ impl<'t> StorageTxn for Txn<'t> {
             })
             .context("Get working set query")?;
 
-        let rows: Vec<core::result::Result<(usize, Uuid), _>> = rows.collect();
+        let rows: Vec<std::result::Result<(usize, Uuid), _>> = rows.collect();
         let mut res = Vec::with_capacity(rows.len());
         for _ in 0..self
             .get_next_working_set_number()

--- a/taskchampion/taskchampion/src/task/task.rs
+++ b/taskchampion/taskchampion/src/task/task.rs
@@ -418,7 +418,7 @@ impl<'r> TaskMut<'r> {
     /// Add a tag to this task.  Does nothing if the tag is already present.
     pub fn add_tag(&mut self, tag: &Tag) -> Result<()> {
         if tag.is_synthetic() {
-            return Err(Error::UserError(String::from(
+            return Err(Error::Usage(String::from(
                 "Synthetic tags cannot be modified",
             )));
         }
@@ -428,7 +428,7 @@ impl<'r> TaskMut<'r> {
     /// Remove a tag from this task.  Does nothing if the tag is not present.
     pub fn remove_tag(&mut self, tag: &Tag) -> Result<()> {
         if tag.is_synthetic() {
-            return Err(Error::UserError(String::from(
+            return Err(Error::Usage(String::from(
                 "Synthetic tags cannot be modified",
             )));
         }
@@ -476,7 +476,7 @@ impl<'r> TaskMut<'r> {
     ) -> Result<()> {
         let key = key.into();
         if Task::is_known_key(&key) {
-            return Err(Error::UserError(format!(
+            return Err(Error::Usage(format!(
                 "Property name {} as special meaning in a task and cannot be used as a UDA",
                 key
             )));
@@ -488,7 +488,7 @@ impl<'r> TaskMut<'r> {
     pub fn remove_legacy_uda(&mut self, key: impl Into<String>) -> Result<()> {
         let key = key.into();
         if Task::is_known_key(&key) {
-            return Err(Error::UserError(format!(
+            return Err(Error::Usage(format!(
                 "Property name {} as special meaning in a task and cannot be used as a UDA",
                 key
             )));

--- a/taskchampion/taskchampion/src/taskdb/snapshot.rs
+++ b/taskchampion/taskchampion/src/taskdb/snapshot.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 pub(super) struct SnapshotTasks(Vec<(Uuid, TaskMap)>);
 
 impl Serialize for SnapshotTasks {
-    fn serialize<'a, S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+    fn serialize<'a, S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -31,7 +31,7 @@ impl<'de> Visitor<'de> for TaskDbVisitor {
         formatter.write_str("a map representing a task snapshot")
     }
 
-    fn visit_map<M>(self, mut access: M) -> core::result::Result<Self::Value, M::Error>
+    fn visit_map<M>(self, mut access: M) -> std::result::Result<Self::Value, M::Error>
     where
         M: MapAccess<'de>,
     {
@@ -46,7 +46,7 @@ impl<'de> Visitor<'de> for TaskDbVisitor {
 }
 
 impl<'de> Deserialize<'de> for SnapshotTasks {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/taskchampion/taskchampion/src/taskdb/snapshot.rs
+++ b/taskchampion/taskchampion/src/taskdb/snapshot.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 pub(super) struct SnapshotTasks(Vec<(Uuid, TaskMap)>);
 
 impl Serialize for SnapshotTasks {
-    fn serialize<'a, S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/taskchampion/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/taskchampion/src/taskdb/undo.rs
@@ -1,9 +1,10 @@
 use super::apply;
+use crate::errors::Result;
 use crate::storage::{ReplicaOp, StorageTxn};
 use log::{debug, trace};
 
 /// Undo local operations until an UndoPoint.
-pub(super) fn undo(txn: &mut dyn StorageTxn) -> anyhow::Result<bool> {
+pub(super) fn undo(txn: &mut dyn StorageTxn) -> Result<bool> {
     let mut applied = false;
     let mut popped = false;
     let mut local_ops = txn.operations()?;
@@ -40,7 +41,7 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
-    fn test_apply_create() -> anyhow::Result<()> {
+    fn test_apply_create() -> Result<()> {
         let mut db = TaskDb::new_inmemory();
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();

--- a/taskchampion/taskchampion/src/taskdb/working_set.rs
+++ b/taskchampion/taskchampion/src/taskdb/working_set.rs
@@ -1,3 +1,4 @@
+use crate::errors::Result;
 use crate::storage::{StorageTxn, TaskMap};
 use std::collections::HashSet;
 
@@ -5,7 +6,7 @@ use std::collections::HashSet;
 /// renumbers the existing working-set tasks to eliminate gaps, and also adds any tasks that
 /// are not already in the working set but should be.  The rebuild occurs in a single
 /// trasnsaction against the storage backend.
-pub fn rebuild<F>(txn: &mut dyn StorageTxn, in_working_set: F, renumber: bool) -> anyhow::Result<()>
+pub fn rebuild<F>(txn: &mut dyn StorageTxn, in_working_set: F, renumber: bool) -> Result<()>
 where
     F: Fn(&TaskMap) -> bool,
 {
@@ -69,16 +70,16 @@ mod test {
     use uuid::Uuid;
 
     #[test]
-    fn rebuild_working_set_renumber() -> anyhow::Result<()> {
+    fn rebuild_working_set_renumber() -> Result<()> {
         rebuild_working_set(true)
     }
 
     #[test]
-    fn rebuild_working_set_no_renumber() -> anyhow::Result<()> {
+    fn rebuild_working_set_no_renumber() -> Result<()> {
         rebuild_working_set(false)
     }
 
-    fn rebuild_working_set(renumber: bool) -> anyhow::Result<()> {
+    fn rebuild_working_set(renumber: bool) -> Result<()> {
         let mut db = TaskDb::new_inmemory();
         let mut uuids = vec![];
         uuids.push(Uuid::new_v4());


### PR DESCRIPTION
Resolve #2878

Let me know if I completely missed the mark on what you were going for in that issue. I'm just trying to learn Rust at this point so I'm sure there are some anti-patterns here as well.

#### Description

Return the `taskchampion::Error` type from the public API.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [X] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
