### PR TITLE
simpletap: simplify to use parent `run` method

### DIFF
--- a/test/simpletap/__init__.py
+++ b/test/simpletap/__init__.py
@@ -30,7 +30,6 @@
 import os
 import sys
 import unittest
-import warnings
 import traceback
 import inspect
 
@@ -226,37 +225,7 @@ class TAPTestRunner(unittest.runner.TextTestRunner):
     """
     resultclass = TAPTestResult
 
-    def run(self, test):
-        result = self._makeResult()
-        unittest.signals.registerResult(result)
-        result.failfast = self.failfast
-
-        # TAP requires output is on STDOUT.
-        # TODO: Define this at __init__ time
-        result.stream = unittest.runner._WritelnDecorator(sys.stdout)
-
-        with warnings.catch_warnings():
-            if getattr(self, "warnings", None):
-                # if self.warnings is set, use it to filter all the warnings
-                warnings.simplefilter(self.warnings)
-                # if the filter is 'default' or 'always', special-case the
-                # warnings from the deprecated unittest methods to show them
-                # no more than once per module, because they can be fairly
-                # noisy.  The -Wd and -Wa flags can be used to bypass this
-                # only when self.warnings is None.
-                if self.warnings in ['default', 'always']:
-                    warnings.filterwarnings(
-                        'module',
-                        category=DeprecationWarning,
-                        message='Please use assert\w+ instead.')
-            startTestRun = getattr(result, 'startTestRun', None)
-            if startTestRun is not None:
-                startTestRun(test.countTestCases())
-            try:
-                test(result)
-            finally:
-                stopTestRun = getattr(result, 'stopTestRun', None)
-                if stopTestRun is not None:
-                    stopTestRun()
-
-        return result
+    def __init__(self, stream=sys.stdout, *args, **kwargs):
+        if stream != sys.stdout:
+            raise ValueError("TAP requires output is on STDOUT.")
+        super().__init__(stream=stream, *args, **kwargs)

--- a/test/tw-2189.t
+++ b/test/tw-2189.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . bash_tap_tw.sh
 
 task add "foo \' bar"


### PR DESCRIPTION
#### Description

Per the TODO, use `__init__` to override the stream. There don't seem to be any other substantial changes to the `run` method needed for TAP and I'm assuming the additional code in the upstream `run` has been added since this class was written.

My primary motivation was to set `result.buffer = self.buffer` in the `run` method, which fixes the runner enough to be able to use `breakpoint()`. (But this is taken care of by the parent class when we remove `run`.)

In addition, I updated the shebang in `tw-2189.t` for portability.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [ ] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
