### PR TITLE
taskchampion: Add time.utc_timestamp function.

### DIFF
--- a/taskchampion/lib/src/atomic.rs
+++ b/taskchampion/lib/src/atomic.rs
@@ -1,7 +1,8 @@
 //! Trait implementations for a few atomic types
 
 use crate::traits::*;
-use taskchampion::chrono::{offset::LocalResult, prelude::*};
+use taskchampion::chrono::{DateTime, Utc};
+use taskchampion::utc_timestamp;
 
 impl PassByValue for usize {
     type RustType = usize;
@@ -21,9 +22,7 @@ impl PassByValue for libc::time_t {
 
     unsafe fn from_ctype(self) -> Option<DateTime<Utc>> {
         if self != 0 {
-            if let LocalResult::Single(ts) = Utc.timestamp_opt(self, 0) {
-                return Some(ts);
-            }
+            return Some(utc_timestamp(self));
         }
         None
     }

--- a/taskchampion/lib/src/task.rs
+++ b/taskchampion/lib/src/task.rs
@@ -5,8 +5,7 @@ use std::convert::TryFrom;
 use std::ops::Deref;
 use std::ptr::NonNull;
 use std::str::FromStr;
-use taskchampion::chrono::{offset::LocalResult, TimeZone, Utc};
-use taskchampion::{Annotation, Tag, Task, TaskMut, Uuid};
+use taskchampion::{utc_timestamp, Annotation, Tag, Task, TaskMut, Uuid};
 
 /// A task, as publicly exposed by this library.
 ///
@@ -760,9 +759,7 @@ pub unsafe extern "C" fn tc_task_remove_annotation(task: *mut TCTask, entry: i64
     wrap_mut(
         task,
         |task| {
-            if let LocalResult::Single(ts) = Utc.timestamp_opt(entry, 0) {
-                task.remove_annotation(ts)?;
-            }
+            task.remove_annotation(utc_timestamp(entry))?;
             Ok(TCResult::Ok)
         },
         TCResult::Error,

--- a/taskchampion/taskchampion/src/lib.rs
+++ b/taskchampion/taskchampion/src/lib.rs
@@ -63,7 +63,7 @@ pub use errors::Error;
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
 pub use storage::StorageConfig;
-pub use task::{Annotation, Status, Tag, Task, TaskMut};
+pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskMut};
 pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.

--- a/taskchampion/taskchampion/src/task/mod.rs
+++ b/taskchampion/taskchampion/src/task/mod.rs
@@ -1,14 +1,12 @@
 #![allow(clippy::module_inception)]
-use chrono::prelude::*;
-
 mod annotation;
 mod status;
 mod tag;
 mod task;
+mod time;
 
 pub use annotation::Annotation;
 pub use status::Status;
 pub use tag::Tag;
 pub use task::{Task, TaskMut};
-
-pub type Timestamp = DateTime<Utc>;
+pub use time::{utc_timestamp, Timestamp};

--- a/taskchampion/taskchampion/src/task/time.rs
+++ b/taskchampion/taskchampion/src/task/time.rs
@@ -1,0 +1,11 @@
+use chrono::{offset::LocalResult, DateTime, TimeZone, Utc};
+
+pub type Timestamp = DateTime<Utc>;
+
+pub fn utc_timestamp(secs: i64) -> Timestamp {
+    match Utc.timestamp_opt(secs, 0) {
+        LocalResult::Single(tz) => tz,
+        // The other two variants are None and Ambiguous, which both are caused by DST.
+        _ => unreachable!("We're requesting UTC so daylight saving time isn't a factor."),
+    }
+}


### PR DESCRIPTION
Per discussion in #3019.

Something I hadn't realized in that discussion was that, by my reading of the docs, `None` is also only returned due to daylight saving time issues, so that should also be unreachable.

Additional considerations for potential further improvement:

1. Would it be more appropriate to make our own `Timestamp` than to use it as an alias for `DateTime<Utc>`? Reading https://lurklurk.org/effective-rust/re-export.html:

> As an aside, think carefully before using another crate's types in your API: it intimately ties your crate to that of the dependency.

I think the point may be overstated, but perhaps a consideration. As an additional benefit we could use the `From` trait so we would only have to pass around `Timestamp` and not an additional function.

2. If we're going to keep `Timestamp` as an alias, would it be better to define a new trait (e.g. `FromSecs`) than to pass around this helper function?

#### Description

Add a function that returns a Timestamp from an i64. One advantage is improved readability since this function is guaranteed to return a `LocalResult::Single`. Anther advantage is that it will panic if something other than a LocalResult::Single is returned by chrono, which shouldn't be possible for UTC timestamps which can't have DST ambiguity.
#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [X] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
