### PR TITLE
Ignore the aarch64-apple-darwin directory

### DIFF
--- a/src/tc/rust/.gitignore
+++ b/src/tc/rust/.gitignore
@@ -1,3 +1,4 @@
 target
 x86_64-unknown-linux-gnu
+aarch64-apple-darwin
 .rustc_info.json


### PR DESCRIPTION
#### Description

This directory is generated instead of the x86_64-unknown-linux-gnu directory when building on an ARM64/AArch64 Mac, so this change adds that directory to the gitignore config.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [ ] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
