### PR TITLE
Put Rust deps at the root of the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,34 @@ members = [
 
 # src/tc/rust is just part of the TW build and not a public crate
 exclude = [ "src/tc/rust" ]
+
+# All Rust dependencies are defined here, and then referenced by the
+# Cargo.toml's in the members with `foo.workspace = true`.
+[workspace.dependencies]
+actix-rt = "2"
+actix-web = "^4.3.1"
+anyhow = "1.0"
+byteorder = "1.0"
+cc = "1.0.73"
+chrono = { version = "^0.4.22", features = ["serde"] }
+clap = { version = "^4.3.0", features = ["string"] }
+env_logger = "^0.10.0"
+ffizz-header = "0.3"
+flate2 = "1"
+futures = "^0.3.25"
+lazy_static = "1"
+libc = "0.2.136"
+log = "^0.4.17"
+pretty_assertions = "1"
+proptest = "^1.2.0"
+ring = "0.16"
+rstest = "0.17"
+rusqlite = { version = "0.29", features = ["bundled"] }
+serde_json = "^1.0"
+serde = { version = "^1.0.147", features = ["derive"] }
+strum = "0.25"
+strum_macros = "0.25"
+tempfile = "3"
+thiserror = "1.0"
+ureq = "^2.7.0"
+uuid = { version = "^1.3.0", features = ["serde", "v4"] }

--- a/taskchampion/integration-tests/Cargo.toml
+++ b/taskchampion/integration-tests/Cargo.toml
@@ -12,14 +12,14 @@ taskchampion-lib = { path = "../lib" }
 taskchampion-sync-server = { path = "../sync-server" }
 
 [dev-dependencies]
-anyhow = "1.0"
-actix-web = "^4.3.1"
-actix-rt = "2"
-tempfile = "3"
-pretty_assertions = "1"
-log = "^0.4.17"
-env_logger = "^0.10.0"
-lazy_static = "1"
+anyhow.workspace = true
+actix-web.workspace = true
+actix-rt.workspace = true
+tempfile.workspace = true
+pretty_assertions.workspace = true
+log.workspace = true
+env_logger.workspace = true
+lazy_static.workspace = true
 
 [build-dependencies]
-cc = "1.0.73"
+cc.workspace = true

--- a/taskchampion/lib/Cargo.toml
+++ b/taskchampion/lib/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-libc = "0.2.136"
+libc.workspace = true
+anyhow.workspace = true
+ffizz-header.workspace = true
+
 taskchampion = { path = "../taskchampion" }
-anyhow = "1.0"
-ffizz-header = "0.3"
 
 [dev-dependencies]
-pretty_assertions = "1"
+pretty_assertions.workspace = true

--- a/taskchampion/sync-server/Cargo.toml
+++ b/taskchampion/sync-server/Cargo.toml
@@ -8,20 +8,20 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { version = "^1.3.0", features = ["serde", "v4"] }
-actix-web = "^4.3.1"
-anyhow = "1.0"
-thiserror = "1.0"
-futures = "^0.3.25"
-serde = "^1.0.147"
-serde_json = "^1.0"
-clap = { version = "^4.3.0", features = ["string"] }
-log = "^0.4.17"
-env_logger = "^0.10.0"
-rusqlite = { version = "0.29", features = ["bundled"] }
-chrono = { version = "^0.4.22", features = ["serde"] }
+uuid.workspace = true
+actix-web.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+clap.workspace = true
+log.workspace = true
+env_logger.workspace = true
+rusqlite.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
-actix-rt = "2"
-tempfile = "3"
-pretty_assertions = "1"
+actix-rt.workspace = true
+tempfile.workspace = true
+pretty_assertions.workspace = true

--- a/taskchampion/taskchampion/Cargo.toml
+++ b/taskchampion/taskchampion/Cargo.toml
@@ -11,23 +11,23 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-uuid = { version = "^1.3.0", features = ["serde", "v4"] }
-serde = { version = "^1.0.147", features = ["derive"] }
-serde_json = "^1.0"
-chrono = { version = "^0.4.22", features = ["serde"] }
-anyhow = "1.0"
-thiserror = "1.0"
-ureq = "^2.7.0"
-log = "^0.4.17"
-rusqlite = { version = "0.29", features = ["bundled"] }
-strum = "0.25"
-strum_macros = "0.25"
-flate2 = "1"
-byteorder = "1.0"
-ring = "0.16"
+uuid.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+ureq.workspace = true
+log.workspace = true
+rusqlite.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
+flate2.workspace = true
+byteorder.workspace = true
+ring.workspace = true
 
 [dev-dependencies]
-proptest = "^1.2.0"
-tempfile = "3"
-rstest = "0.17"
-pretty_assertions = "1"
+proptest.workspace = true
+tempfile.workspace = true
+rstest.workspace = true
+pretty_assertions.workspace = true

--- a/taskchampion/xtask/Cargo.toml
+++ b/taskchampion/xtask/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.4.1"
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
+
 taskchampion-lib = { path = "../lib" }


### PR DESCRIPTION
This allows us to be consistent about the required versions for each of the member packages.

Fixes #3088.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [x] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
