### PR TITLE
Remove redundant comments

### DIFF
--- a/taskchampion/lib/src/annotation.rs
+++ b/taskchampion/lib/src/annotation.rs
@@ -32,9 +32,7 @@ use taskchampion::chrono::prelude::*;
 /// ```
 #[repr(C)]
 pub struct TCAnnotation {
-    /// Time the annotation was made.  Must be nonzero.
     pub entry: libc::time_t,
-    /// Content of the annotation.  Must not be NULL.
     pub description: TCString,
 }
 
@@ -96,14 +94,9 @@ impl Default for TCAnnotation {
 /// ```
 #[repr(C)]
 pub struct TCAnnotationList {
-    /// number of annotations in items
     len: libc::size_t,
-
     /// total size of items (internal use only)
     capacity: libc::size_t,
-
-    /// Array of annotations. These remain owned by the TCAnnotationList instance and will be freed by
-    /// tc_annotation_list_free.  This pointer is never NULL for a valid TCAnnotationList.
     items: *mut TCAnnotation,
 }
 

--- a/taskchampion/lib/src/kv.rs
+++ b/taskchampion/lib/src/kv.rs
@@ -69,14 +69,9 @@ impl PassByValue for TCKV {
 /// ```
 #[repr(C)]
 pub struct TCKVList {
-    /// number of key/value pairs in items
     len: libc::size_t,
-
     /// total size of items (internal use only)
     _capacity: libc::size_t,
-
-    /// Array of TCKV's. These remain owned by the TCKVList instance and will be freed by
-    /// tc_kv_list_free.  This pointer is never NULL for a valid TCKVList.
     items: *mut TCKV,
 }
 

--- a/taskchampion/lib/src/string.rs
+++ b/taskchampion/lib/src/string.rs
@@ -394,15 +394,9 @@ where
 /// ```
 #[repr(C)]
 pub struct TCStringList {
-    /// number of strings in items
     len: libc::size_t,
-
     /// total size of items (internal use only)
     capacity: libc::size_t,
-
-    /// Array of strings. These remain owned by the TCStringList instance and will be freed by
-    /// tc_string_list_free.  This pointer is never NULL for a valid TCStringList, and the
-    /// *TCStringList at indexes 0..len-1 are not NULL.
     items: *mut TCString,
 }
 

--- a/taskchampion/lib/src/uda.rs
+++ b/taskchampion/lib/src/uda.rs
@@ -20,11 +20,8 @@ use crate::types::*;
 #[repr(C)]
 #[derive(Default)]
 pub struct TCUda {
-    /// Namespace of the UDA.  For legacy UDAs, this may have a NULL ptr field.
     pub ns: TCString,
-    /// UDA key.  Must not be NULL.
     pub key: TCString,
-    /// Content of the UDA.  Must not be NULL.
     pub value: TCString,
 }
 

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -672,12 +672,14 @@ EXTERN_C bool tc_task_is_waiting(struct TCTask *task);
 // until this task is made immutable again.  This implies that it is not allowed for more than one
 // task associated with a replica to be mutable at any time.
 //
-// Typical mutation of tasks is bracketed with `tc_task_to_mut` and `tc_task_to_immut`:
+// Typically mutation of tasks is bracketed with `tc_task_to_mut` and `tc_task_to_immut`:
 //
+// ```text
 //     tc_task_to_mut(task, rep);
 //     success = tc_task_done(task);
 //     tc_task_to_immut(task, rep);
 //     if (!success) { ... }
+// ```
 EXTERN_C void tc_task_to_mut(struct TCTask *task, struct TCReplica *tcreplica);
 
 // Add an annotation to a mutable task.  This call takes ownership of the


### PR DESCRIPTION
There's no need to repeat comments on the fields of a struct within taskchampion-lib.

See https://github.com/djmitche/ffizz/issues/43 for more discussion.

/cc @ryneeverett 