### PR TITLE
bump ffizz-header to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "ffizz-header"
-version = "0.3.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b3ae8dccc2b5edfc7805a0c26cc776ae521fd5f6fdd693520e130abcdce06"
+checksum = "8a1a52e9f00aa4c639059d977e1289a13963117d8e60ccb25e86cca2aab98538"
 dependencies = [
  "ffizz-macros",
  "itertools",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "ffizz-macros"
-version = "0.3.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56603703fdb7bcae099f7212b9afb83f0d057236e42d87c894ba6b34ad77ac18"
+checksum = "af208cea557bab3ec4f05fb0c26460f1c61fdb204f3738f471b6b1ecd58d7a04"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cc = "1.0.73"
 chrono = { version = "^0.4.22", features = ["serde"] }
 clap = { version = "^4.3.0", features = ["string"] }
 env_logger = "^0.10.0"
-ffizz-header = "0.3"
+ffizz-header = "0.5"
 flate2 = "1"
 futures = "^0.3.25"
 lazy_static = "1"


### PR DESCRIPTION
#### Description

Replaces https://github.com/GothenburgBitFactory/taskwarrior/pull/3122
