### PR TITLE
Use GNUInstallDirs to determine installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set (HAVE_CMAKE true)
 
 project (task)
 include (CXXSniffer)
+include (GNUInstallDirs)
 
 set (PROJECT_VERSION "2.6.2")
 
@@ -48,16 +49,7 @@ set (PACKAGE_TARNAME "${PACKAGE}")
 set (PACKAGE_VERSION "${VERSION}")
 set (PACKAGE_STRING "${PACKAGE} ${VERSION}")
 
-if (FREEBSD OR DRAGONFLY)
-SET (TASK_MAN1DIR man/man1 CACHE STRING "Installation directory for man pages, section 1")
-SET (TASK_MAN5DIR man/man5 CACHE STRING "Installation directory for man pages, section 5")
-else (FREEBSD OR DRAGONFLY)
-SET (TASK_MAN1DIR share/man/man1 CACHE STRING "Installation directory for man pages, section 1")
-SET (TASK_MAN5DIR share/man/man5 CACHE STRING "Installation directory for man pages, section 5")
-endif (FREEBSD OR DRAGONFLY)
-SET (TASK_DOCDIR  share/doc/task CACHE STRING "Installation directory for doc files")
-SET (TASK_RCDIR "${TASK_DOCDIR}/rc" CACHE STRING "Installation directory for configuration files")
-SET (TASK_BINDIR  bin            CACHE STRING "Installation directory for the binary")
+SET (TASK_RCDIR "${CMAKE_INSTALL_DOCDIR}/rc" CACHE STRING "Installation directory for configuration files")
 
 # rust libs require these
 set (TASK_LIBRARIES dl pthread)
@@ -146,7 +138,7 @@ endif (EXISTS performance)
 
 set (doc_FILES NEWS ChangeLog README.md INSTALL AUTHORS COPYING LICENSE)
 foreach (doc_FILE ${doc_FILES})
-  install (FILES ${doc_FILE}  DESTINATION ${TASK_DOCDIR})
+  install (FILES ${doc_FILE}  DESTINATION ${CMAKE_INSTALL_DOCDIR})
 endforeach (doc_FILE)
 
 add_custom_command(OUTPUT run-review

--- a/INSTALL
+++ b/INSTALL
@@ -71,21 +71,18 @@ cmake configuration variables are applied with the -D option and consist of a
 Four more variables can customize the installation process. The following table
 lists them and their defaults plus the CMAKE_INSTALL_PREFIX:
 
-  CMAKE_INSTALL_PREFIX  /usr/local
-  TASK_BINDIR           bin
-  TASK_DOCDIR           share/doc/task
-  TASK_RCDIR            share/doc/task/rc
-  TASK_MAN1DIR          share/man/man1
-  TASK_MAN5DIR          share/man/man5
+  CMAKE_INSTALL_PREFIX      /usr/local
+  CMAKE_INSTALL_BINDIR      bin
+  CMAKE_INSTALL_DATAROOTDIR share
+  CMAKE_INSTALL_DOCDIR      ${CMAKE_INSTALL_DATAROOTDIR}/doc/task
+  CMAKE_INSTALL_MANDIR      man
+  TASK_RCDIR                ${CMAKE_INSTALL_DOCDIR}/rc
 
-The corresponding TASK_* variables will be combined with CMAKE_INSTALL_PREFIX to
-get absolute installation directories:
+The corresponding TASK_* variables can also be absolute paths. Relative paths
+will be combined with CMAKE_INSTALL_PREFIX to get absolute installation
+directories:
 
-  CMAKE_INSTALL_PREFIX/TASK_BINDIR   /usr/local/bin
-  CMAKE_INSTALL_PREFIX/TASK_DOCDIR   /usr/local/share/doc/task
   CMAKE_INSTALL_PREFIX/TASK_RCDIR    /usr/local/share/doc/task/rc
-  CMAKE_INSTALL_PREFIX/TASK_MAN1DIR  /usr/local/share/man/man1
-  CMAKE_INSTALL_PREFIX/TASK_MAN5DIR  /usr/local/share/man/man5
 
 
 Uninstallation

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -7,10 +7,10 @@ foreach (man_FILE ${man_FILES})
     man/${man_FILE})
 endforeach (man_FILE)
 
-install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man/   DESTINATION ${TASK_MAN1DIR}
+install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man/   DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
                                                       FILES_MATCHING PATTERN "*.1")
-install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man/   DESTINATION ${TASK_MAN5DIR}
+install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man/   DESTINATION ${CMAKE_INSTALL_MANDIR}/man5
                                                       FILES_MATCHING PATTERN "*.5")
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rc/    DESTINATION ${TASK_RCDIR})
 
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/ref/task-ref.pdf DESTINATION ${TASK_DOCDIR})
+install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/ref/task-ref.pdf DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required (VERSION 3.0)
 install (DIRECTORY bash fish vim hooks
-         DESTINATION ${TASK_DOCDIR}/scripts)
+         DESTINATION ${CMAKE_INSTALL_DOCDIR}/scripts)
 install (FILES zsh/_task
          DESTINATION share/zsh/site-functions)
 install (DIRECTORY add-ons
-         DESTINATION ${TASK_DOCDIR}/scripts
+         DESTINATION ${CMAKE_INSTALL_DOCDIR}/scripts
          FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                           GROUP_READ             GROUP_EXECUTE
                           WORLD_READ             WORLD_EXECUTE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ endif (DARWIN)
 
 set_property (TARGET task_executable PROPERTY OUTPUT_NAME "task")
 
-install (TARGETS task_executable DESTINATION ${TASK_BINDIR})
+install (TARGETS task_executable DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 set_property (TARGET calc_executable PROPERTY OUTPUT_NAME "calc")
 set_property (TARGET lex_executable PROPERTY OUTPUT_NAME "lex")


### PR DESCRIPTION
#### Description

I replaced the path-guessing system with GNUInstallDirs which provides override-able sane defaults.  To override, pass them in, e.g. `-DCMAKE_INSTALL_LIBDIR=foo`.

GNUInstallDirs sets `CMAKE_INSTALL_BINDIR=bin` as well as `CMAKE_INSTALL_MANDIR=share/man`. No guessing based on the system and architecture, that's all handled by GNUInstallDirs.

`CMAKE_INSTALL_FULL_*` is the full path equivalent to the prefixed version without `FULL`, e.g. `CMAKE_INSTALL_BINDIR=bin`, then `CMAKE_INSTALL_FULL_BINDIR=/usr/bin`.

This removes the old options `TASK_*`.

More information about GNUInstallDirs: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

#### Additional information...

- [x] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

```
./problems
Failed:
delete.t                            1
recurrence.t                        1

Unexpected successes:

Skipped:
datetime-negative.t                 9
dependencies.t                      1
diag.t                              1
export.t                            1
feature.default.project.t           3
filter.t                            1
hooks.on-modify.t                   1
import.t                            1
nag.t                               5
recurrence.t                        1
wait.t                              1

Expected failures:
dependencies.t                      2
filter.t                            3
lexer.t                             4
quotes.t                            1
tw-2124.t                           1
tw-2514.t                           1
undo.t                              2
```


- [ ] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.

<details><summary>Lots of output here</summary>

```
... lots of output from installing packages (omitted) ...
   Compiling taskchampion-sync-server v0.4.1 (/root/taskwarrior/taskchampion/sync-server)
    Finished test [unoptimized + debuginfo] target(s) in 30.11s
     Running unittests src/lib.rs (target/debug/deps/integration_tests-99451c572772a828)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/bindings.rs (target/debug/deps/bindings-c75c659aa4492f4a)

running 4 tests
test replica_tests ... ok
test string_tests ... ok
test task_tests ... ok
test uuid_tests ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s

     Running tests/cross-sync.rs (target/debug/deps/cross_sync-66ca12a0b0fa5f1d)

running 1 test
test cross_sync ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.60s

     Running tests/snapshots.rs (target/debug/deps/snapshots-2bad8a87cc532861)

running 1 test
test sync_with_snapshots ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.65s

     Running tests/update-and-delete-sync.rs (target/debug/deps/update_and_delete_sync-07a322d948b57740)

running 2 tests
test update_and_delete_sync_delete_first ... ok
test update_and_delete_sync_update_first ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s

     Running unittests src/lib.rs (target/debug/deps/taskchampion-6ec9a40ba7542674)

running 151 tests
test depmap::test::dependencies ... ok
test depmap::test::dependents ... ok
test replica::tests::get_does_not_exist ... ok
test replica::tests::delete_task ... ok
test replica::tests::new_pending_adds_to_working_set ... ok
test server::crypto::test::envelope_bad_version ... ok
test replica::tests::new_recurring_adds_to_working_set ... ok
test server::crypto::test::envelope_round_trip ... ok
test server::crypto::test::envelope_too_short ... ok
test replica::tests::get_and_modify ... ok
test replica::tests::modify_task ... ok
test replica::tests::new_task ... ok
test replica::tests::rebuild_working_set_includes_recurring ... ok
test server::op::test::test_json_delete ... ok
test replica::tests::expire ... ok
test server::op::test::test_json_update ... ok
test server::op::test::test_json_create ... ok
test server::op::test::test_related_updates_different_props ... ok
test replica::tests::dependency_map ... ok
test storage::inmemory::test::add_to_working_set ... ok
test storage::op::test::test_into_sync_create ... ok
test storage::op::test::test_into_sync_delete ... ok
test server::op::test::test_related_updates_same_prop ... ok
test server::op::test::test_json_update_none ... ok
test storage::inmemory::test::clear_working_set ... ok
test server::op::test::test_unrelated_create ... ok
test server::op::test::test_related_updates_same_prop_same_time ... ok
test storage::inmemory::test::get_working_set_empty ... ok
test storage::op::test::test_into_sync_undo_point ... ok
test storage::op::test::test_into_sync_update ... ok
test storage::op::test::test_json_create ... ok
test storage::op::test::test_json_delete ... ok
test storage::op::test::test_json_update ... ok
test storage::op::test::test_reverse_create ... ok
test storage::op::test::test_json_update_none ... ok
test storage::op::test::test_reverse_undo_point ... ok
test storage::op::test::test_reverse_delete ... ok
test storage::op::test::test_reverse_update ... ok
test server::local::test::test_empty ... ok
test server::local::test::test_add_nonzero_base_forbidden ... ok
test storage::sqlite::test::get_working_set_empty ... ok
test storage::sqlite::test::test_all_tasks_empty ... ok
test server::local::test::test_add_nonzero_base ... ok
test server::local::test::test_add_zero_base ... ok
test storage::sqlite::test::test_base_version_default ... ok
test server::op::test::transform_invariant_holds ... ok
test storage::sqlite::test::add_to_working_set ... ok
test task::status::test::display ... ok
test task::status::test::from_taskmap ... ok
test task::status::test::to_taskmap ... ok
test task::tag::test::test_tag_try_into_err::case_1_empty ... ok
test task::tag::test::test_tag_try_into_err::case_2_colon_infix ... ok
test task::tag::test::test_tag_try_into_err::case_3_digits ... ok
test task::tag::test::test_tag_try_into_err::case_4_bangs ... ok
test task::tag::test::test_tag_try_into_err::case_5_no_such_synthetic ... ok
test task::tag::test::test_tag_try_into_success::case_1_simple ... ok
test task::tag::test::test_tag_try_into_success::case_2_colon_prefix ... ok
test task::tag::test::test_tag_try_into_success::case_3_letters_and_numbers ... ok
test task::tag::test::test_tag_try_into_success::case_4_synthetic ... ok
test task::task::test::dependencies_tags ... ok
test task::task::test::set_value_modified ... ok
test task::task::test::test_add_annotation ... ok
test task::task::test::test_add_tags ... ok
test task::task::test::test_delete ... ok
test task::task::test::test_dependencies ... ok
test task::task::test::test_done ... ok
test task::task::test::test_entry_not_set ... ok
test task::task::test::test_entry_set ... ok
test task::task::test::test_get_annotations ... ok
test task::task::test::test_get_legacy_uda ... ok
test task::task::test::test_get_priority_default ... ok
test task::task::test::test_get_tags ... ok
test task::task::test::test_get_tags_invalid_tags ... ok
test task::task::test::test_get_uda ... ok
test task::task::test::test_get_udas ... ok
test task::task::test::test_has_tag ... ok
test task::task::test::test_is_active_active ... ok
test task::task::test::test_is_active_inactive ... ok
test task::task::test::test_is_active_never_started ... ok
test task::task::test::test_remove_annotation ... ok
test task::task::test::test_remove_legacy_uda ... ok
test task::task::test::test_remove_tags ... ok
test task::task::test::test_remove_uda ... ok
test task::task::test::test_remove_uda_invalid ... ok
test task::task::test::test_set_get_priority ... ok
test task::task::test::test_set_get_value ... ok
test task::task::test::test_set_legacy_uda ... ok
test task::task::test::test_set_status_completed ... ok
test task::task::test::test_set_status_deleted ... ok
test task::task::test::test_set_status_pending ... ok
test task::task::test::test_set_status_recurring ... ok
test task::task::test::test_set_uda ... ok
test storage::sqlite::test::test_base_version_setting ... ok
test task::task::test::test_set_uda_invalid ... ok
test task::task::test::test_start ... ok
test task::task::test::test_wait_in_future ... ok
test task::task::test::test_wait_in_past ... ok
test task::task::test::test_stop ... ok
test task::task::test::test_wait_not_set ... ok
test taskdb::apply::tests::test_apply_create ... ok
test taskdb::apply::tests::test_apply_create_delete ... ok
test taskdb::apply::tests::test_apply_create_exists ... ok
test taskdb::apply::tests::test_apply_create_update ... ok
test taskdb::apply::tests::test_apply_delete_not_present ... ok
test taskdb::apply::tests::test_apply_create_update_delete_prop ... ok
test taskdb::apply::tests::test_apply_update_does_not_exist ... ok
test taskdb::snapshot::test::test_serialize_empty ... ok
test taskdb::snapshot::test::test_serialize_tasks ... ok
test taskdb::sync::test::test_sync ... ok
test taskdb::snapshot::test::test_round_trip ... ok
test taskdb::sync::test::test_sync_avoids_snapshot ... ok
test taskdb::sync::test::test_sync_create_delete ... ok
test taskdb::tests::test_add_undo_point ... ok
test taskdb::tests::test_apply ... ok
test taskdb::tests::test_num_operations ... ok
test taskdb::tests::test_num_undo_points ... ok
test taskdb::sync::test::test_sync_add_snapshot_start_with_snapshot ... ok
test taskdb::undo::tests::test_apply_create ... ok
test taskdb::working_set::test::rebuild_working_set_no_renumber ... ok
test taskdb::working_set::test::rebuild_working_set_renumber ... ok
test utils::test::test_from_bytes ... ok
test utils::test::test_from_bytes_bad_len - should panic ... ok
test workingset::test::test_by_index ... ok
test workingset::test::test_by_uuid ... ok
test workingset::test::test_iter ... ok
test workingset::test::test_largest_index ... ok
test workingset::test::test_len_and_is_empty ... ok
test workingset::test::test_new ... ok
test storage::sqlite::test::drop_transaction ... ok
test storage::sqlite::test::test_all_tasks_and_uuids ... ok
test server::crypto::test::externally_valid::bad_version_id ... ok
test server::crypto::test::externally_valid::bad_app_id ... ok
test server::crypto::test::externally_valid::good ... ok
test server::crypto::test::externally_valid::bad_client_id ... ok
test server::crypto::test::externally_valid::bad_version ... ok
test server::crypto::test::round_trip ... ok
test storage::sqlite::test::clear_working_set ... ok
test storage::sqlite::test::set_working_set_item ... ok
test storage::sqlite::test::test_create ... ok
test storage::sqlite::test::test_delete_task_missing ... ok
test storage::sqlite::test::test_get_missing ... ok
test server::crypto::test::externally_valid::bad_secret ... ok
test storage::sqlite::test::test_empty_dir ... ok
test storage::sqlite::test::test_create_exists ... ok
test storage::sqlite::test::test_delete_task_exists ... ok
test taskdb::tests::transform_sequences_of_operations ... ok
test storage::sqlite::test::test_set_task ... ok
test storage::sqlite::test::test_operations ... ok
test server::crypto::test::round_trip_bad_version ... ok
test server::crypto::test::round_trip_bad_key ... ok
test server::crypto::test::round_trip_bad_client_id ... ok

test result: ok. 151 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.68s

     Running unittests src/lib.rs (target/debug/deps/taskchampion_lib-b235ff372a608406)

running 28 tests
test annotation::test::empty_list_has_non_null_pointer ... ok
test kv::test::empty_list_has_non_null_pointer ... ok
test annotation::test::free_sets_null_pointer ... ok
test kv::test::free_sets_null_pointer ... ok
test string::test::bytes_string_to_cstring ... ok
test string::test::cstr_as_bytes ... ok
test string::test::cstr_as_str ... ok
test string::test::cstr_string_to_cstring ... ok
test string::test::cstring_as_bytes ... ok
test string::test::cstring_as_str ... ok
test string::test::cstring_string_to_cstring ... ok
test string::test::empty_list_has_non_null_pointer ... ok
test string::test::free_sets_null_pointer ... ok
test string::test::invalid_bytes_as_bytes ... ok
test string::test::invalid_bytes_as_str ... ok
test string::test::string_as_bytes ... ok
test string::test::string_as_str ... ok
test string::test::string_string_to_cstring ... ok
test string::test::string_with_nul_as_bytes ... ok
test string::test::string_with_nul_as_str ... ok
test string::test::string_with_nul_string_to_cstring ... ok
test task::test::empty_list_has_non_null_pointer ... ok
test string::test::valid_bytes_as_str ... ok
test task::test::free_sets_null_pointer ... ok
test uda::test::empty_list_has_non_null_pointer ... ok
test uda::test::free_sets_null_pointer ... ok
test uuid::test::empty_list_has_non_null_pointer ... ok
test uuid::test::free_sets_null_pointer ... ok

test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/taskchampion_sync_server-96461b6179dc9311)

running 47 tests
test server::test::add_snapshot_fails_nil_version ... ok
test server::test::add_snapshot_fails_newer_exists ... ok
test server::test::add_snapshot_fails_no_such ... ok
test server::test::add_snapshot_success_latest ... ok
test server::test::add_snapshot_fails_too_old ... ok
test server::test::add_snapshot_success_older ... ok
test server::test::add_version_conflict ... ok
test server::test::add_version_success_recent_snapshot ... ok
test server::test::add_version_success_aged_snapshot ... ok
test server::test::add_version_with_existing_history ... ok
test server::test::get_child_version_gone ... ok
test server::test::get_child_version_gone_initial ... ok
test server::test::get_child_version_not_found_initial ... ok
test server::test::add_version_with_no_history ... ok
test server::test::get_snapshot_found ... ok
test server::test::snapshot_urgency_for_versions_since ... ok
test server::test::get_snapshot_not_found ... ok
test server::test::get_child_version_not_found_up_to_date ... ok
test storage::inmemory::test::test_add_version_and_get_version ... ok
test storage::inmemory::test::test_get_client_empty ... ok
test server::test::snapshot_urgency_for_days ... ok
test storage::inmemory::test::test_client_storage ... ok
test server::test::snapshot_urgency_max ... ok
test server::test::get_child_version_found ... ok
test storage::inmemory::test::test_gvbp_empty ... ok
test server::test::add_version_success_snapshot_many_versions_ago ... ok
test storage::inmemory::test::test_snapshots ... ok
test api::add_version::test::test_success ... ok
test api::get_child_version::test::test_client_not_found ... ok
test api::add_snapshot::test::test_success ... ok
test api::get_snapshot::test::test_not_found ... ok
test api::add_version::test::test_conflict ... ok
test api::get_child_version::test::test_version_not_found_and_gone ... ok
test api::add_snapshot::test::test_not_added_200 ... ok
test api::get_snapshot::test::test_success ... ok
test api::add_version::test::test_empty_body ... ok
test api::add_version::test::test_bad_content_type ... ok
test api::add_snapshot::test::test_bad_content_type ... ok
test api::get_child_version::test::test_success ... ok
test api::add_snapshot::test::test_empty_body ... ok
test test::test_cache_control ... ok
test storage::sqlite::test::test_gvbp_empty ... ok
test storage::sqlite::test::test_emtpy_dir ... ok
test storage::sqlite::test::test_get_client_empty ... ok
test storage::sqlite::test::test_add_version_and_get_version ... ok
test storage::sqlite::test::test_client_storage ... ok
test storage::sqlite::test::test_snapshots ... ok

test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s

     Running unittests src/bin/taskchampion-sync-server.rs (target/debug/deps/taskchampion_sync_server-a8bce7079259b1dc)

running 1 test
test test::test_index_get ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/xtask-d6bbf2f9f64a8448)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests integration-tests

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests taskchampion

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests taskchampion-lib

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests taskchampion-sync-server

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```
</details>
