### PR TITLE
show undo diff

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -214,9 +214,11 @@ void TDB2::revert ()
     return;
   }
   if (confirm_revert(undo_ops)) {
+    // Has the side-effect of freeing undo_ops.
     replica.commit_undo_ops(undo_ops, NULL);
+  } else {
+    replica.free_replica_ops(undo_ops);
   }
-  replica.free_replica_ops(undo_ops);
   replica.rebuild_working_set (false);
 }
 

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -207,10 +207,17 @@ void TDB2::get_changes (std::vector <Task>& changes)
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::revert ()
 {
-  replica.undo (NULL);
+  replica.undo (NULL, confirm_revert);
   replica.rebuild_working_set (false);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+bool TDB2::confirm_revert (struct tc::ffi::TCUndoDiff undo)
+{
+  show_diff (undo.current, undo.prior, undo.when);
+  return ! Context::getContext ().config.getBoolean ("confirmation") ||
+        confirm ("The undo command is not reversible.  Are you sure you want to revert to the previous state?");
+}
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::show_diff (
   const std::string& current,

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -211,6 +211,7 @@ void TDB2::revert ()
   if (confirm_revert(undo_ops)) {
     replica.commit_undo_ops(undo_ops, NULL);
   }
+  replica.free_replica_ops(undo_ops);
   replica.rebuild_working_set (false);
 }
 
@@ -237,9 +238,7 @@ bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
         throw std::string ("Can't undo UndoPoint.");
         break;
       default:
-        // XXX throw
-        opstr = format("NON-OPERATION: {1}", std::to_string(op.operation_type).c_str());
-        // throw std::string ("Can't undo non-operation.");
+        throw std::string ("Can't undo non-operation.");
         break;
     }
     std::cout << "- " << opstr << "\n";

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -217,6 +217,11 @@ void TDB2::revert ()
 ////////////////////////////////////////////////////////////////////////////////
 bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
 {
+  std::cout << "The following " << undo_ops.len << " operations would be reverted:\n";
+  for (size_t i = 0; i < undo_ops.len; i++) {
+    tc::ffi::TCReplicaOp op = undo_ops.items[i];
+    std::cout << "- " << op.operation_type << "\n";
+  }
   // TODO show_diff
   return ! Context::getContext ().config.getBoolean ("confirmation") ||
         confirm ("The undo command is not reversible.  Are you sure you want to revert to the previous state?");

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -207,14 +207,17 @@ void TDB2::get_changes (std::vector <Task>& changes)
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::revert ()
 {
-  replica.undo (NULL, confirm_revert);
+  auto undo_ops = replica.get_undo_ops();
+  if (confirm_revert(undo_ops)) {
+    replica.commit_undo_ops(undo_ops, NULL);
+  }
   replica.rebuild_working_set (false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-bool TDB2::confirm_revert (struct tc::ffi::TCUndoDiff undo)
+bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
 {
-  show_diff (undo.current, undo.prior, undo.when);
+  // TODO show_diff
   return ! Context::getContext ().config.getBoolean ("confirmation") ||
         confirm ("The undo command is not reversible.  Are you sure you want to revert to the previous state?");
 }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -208,6 +208,10 @@ void TDB2::get_changes (std::vector <Task>& changes)
 void TDB2::revert ()
 {
   auto undo_ops = replica.get_undo_ops();
+  if (undo_ops.len == 0) {
+    std::cout << "No operations to undo.";
+    return;
+  }
   if (confirm_revert(undo_ops)) {
     replica.commit_undo_ops(undo_ops, NULL);
   }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -217,12 +217,31 @@ void TDB2::revert ()
 ////////////////////////////////////////////////////////////////////////////////
 bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
 {
+  // TODO Use show_diff rather than this basic listing of operations, though
+  // this might be a worthy undo.style itself.
   std::cout << "The following " << undo_ops.len << " operations would be reverted:\n";
   for (size_t i = 0; i < undo_ops.len; i++) {
     tc::ffi::TCReplicaOp op = undo_ops.items[i];
-    std::cout << "- " << op.operation_type << "\n";
+    auto opstr = "";
+    switch(op.operation_type) {
+      case tc::ffi::TCReplicaOpType::Create:
+        opstr = "Create";
+        break;
+      case tc::ffi::TCReplicaOpType::Delete:
+        opstr = "Delete";
+        break;
+      case tc::ffi::TCReplicaOpType::Update:
+        opstr = "Update";
+        break;
+      case tc::ffi::TCReplicaOpType::UndoPoint:
+        throw std::string ("Can't undo UndoPoint.");
+        break;
+      default:
+        throw std::string ("Can't undo non-operation.");
+        break;
+    }
+    std::cout << "- " << opstr << "\n";
   }
-  // TODO show_diff
   return ! Context::getContext ().config.getBoolean ("confirmation") ||
         confirm ("The undo command is not reversible.  Are you sure you want to revert to the previous state?");
 }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -238,7 +238,7 @@ bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
         break;
       case tc::ffi::TCReplicaOpType::Update:
         std::cout << "Update " << replica.get_op_uuid(op) << "\n";
-        std::cout << "    " << replica.get_op_property(op) << ": " << replica.get_op_old_value(op) << " -> " << replica.get_op_value(op);
+        std::cout << "    " << replica.get_op_property(op) << ": " << option_string(replica.get_op_old_value(op)) << " -> " << option_string(replica.get_op_value(op));
         break;
       case tc::ffi::TCReplicaOpType::UndoPoint:
         throw std::string ("Can't undo UndoPoint.");
@@ -252,6 +252,12 @@ bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
   return ! Context::getContext ().config.getBoolean ("confirmation") ||
         confirm ("The undo command is not reversible.  Are you sure you want to revert to the previous state?");
 }
+
+////////////////////////////////////////////////////////////////////////////////
+std::string TDB2::option_string(std::string input) {
+  return input == "" ? "<empty>" : input;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::show_diff (
   const std::string& current,

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -227,50 +227,18 @@ bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
   // this might be a worthy undo.style itself.
   std::cout << "The following " << undo_ops.len << " operations would be reverted:\n";
   for (size_t i = 0; i < undo_ops.len; i++) {
-    tc::ffi::TCReplicaOp op = undo_ops.items[i];
     std::cout << "- ";
+    tc::ffi::TCReplicaOp op = undo_ops.items[i];
     switch(op.operation_type) {
       case tc::ffi::TCReplicaOpType::Create:
-        std::cout << "Create ";
-        {
-          tc::ffi::TCString uuid = tc_uuid_to_str(op.uuid);
-          std::cout << tc::tc2string_clone(uuid);
-        }
+        std::cout << "Create " << replica.get_op_uuid(op);
         break;
       case tc::ffi::TCReplicaOpType::Delete:
-        std::cout << "Delete ";
-        {
-          for (size_t i = 0; i < op.old_task.len; i++) {
-            tc::ffi::TCString key = op.old_task.items[i].key;
-            if (tc::tc2string_clone(key) == "description") {
-              tc::ffi::TCString description = op.old_task.items[i].value;
-              std::cout << tc::tc2string_clone(description);
-            }
-          }
-        }
+        std::cout << "Delete " << replica.get_op_old_task_description(op);
         break;
       case tc::ffi::TCReplicaOpType::Update:
-        std::cout << "Update ";
-        {
-          tc::ffi::TCString uuid = tc_uuid_to_str(op.uuid);
-          std::cout << tc::tc2string_clone(uuid);
-        }
-        std::cout << "\n    ";
-        {
-          std::cout << tc::tc2string_clone(op.property);
-        }
-        std::cout << ": ";
-        {
-          tc::ffi::TCString old_value = op.old_value;
-          std::string old_value_str = tc::tc2string_clone(old_value);
-          if (old_value_str == "") {
-            std::cout << "<empty>";
-          } else {
-            std::cout << old_value_str;
-          }
-        }
-        std::cout << " -> ";
-        std::cout << tc::tc2string_clone(op.value);
+        std::cout << "Update " << replica.get_op_uuid(op) << "\n";
+        std::cout << "    " << replica.get_op_property(op) << ": " << replica.get_op_old_value(op) << " -> " << replica.get_op_value(op);
         break;
       case tc::ffi::TCReplicaOpType::UndoPoint:
         throw std::string ("Can't undo UndoPoint.");

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -222,7 +222,7 @@ bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
   std::cout << "The following " << undo_ops.len << " operations would be reverted:\n";
   for (size_t i = 0; i < undo_ops.len; i++) {
     tc::ffi::TCReplicaOp op = undo_ops.items[i];
-    auto opstr = "";
+    std::string opstr = "";
     switch(op.operation_type) {
       case tc::ffi::TCReplicaOpType::Create:
         opstr = "Create";
@@ -237,7 +237,9 @@ bool TDB2::confirm_revert (struct tc::ffi::TCReplicaOpList undo_ops)
         throw std::string ("Can't undo UndoPoint.");
         break;
       default:
-        throw std::string ("Can't undo non-operation.");
+        // XXX throw
+        opstr = format("NON-OPERATION: {1}", std::to_string(op.operation_type).c_str());
+        // throw std::string ("Can't undo non-operation.");
         break;
     }
     std::cout << "- " << opstr << "\n";

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -78,7 +78,7 @@ public:
   void dump ();
 
   void sync (tc::Server server, bool avoid_snapshots);
-  static bool confirm_revert(struct tc::ffi::TCReplicaOpList);
+  bool confirm_revert(struct tc::ffi::TCReplicaOpList);
 
 private:
   tc::Replica replica;

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -85,6 +85,7 @@ private:
   std::optional<tc::WorkingSet> _working_set;
 
   const tc::WorkingSet &working_set ();
+  static std::string option_string (std::string input);
   static void show_diff (const std::string&, const std::string&, const std::string&);
 };
 

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -78,13 +78,14 @@ public:
   void dump ();
 
   void sync (tc::Server server, bool avoid_snapshots);
+  static bool confirm_revert(struct tc::ffi::TCUndoDiff);
 
 private:
   tc::Replica replica;
   std::optional<tc::WorkingSet> _working_set;
 
   const tc::WorkingSet &working_set ();
-  void show_diff (const std::string&, const std::string&, const std::string&);
+  static void show_diff (const std::string&, const std::string&, const std::string&);
 };
 
 #endif

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -78,7 +78,7 @@ public:
   void dump ();
 
   void sync (tc::Server server, bool avoid_snapshots);
-  static bool confirm_revert(struct tc::ffi::TCUndoDiff);
+  static bool confirm_revert(struct tc::ffi::TCReplicaOpList);
 
 private:
   tc::Replica replica;

--- a/src/tc/Replica.cpp
+++ b/src/tc/Replica.cpp
@@ -172,7 +172,7 @@ void tc::Replica::commit_undo_ops (TCReplicaOpList tc_undo_ops, int32_t *undone_
 ////////////////////////////////////////////////////////////////////////////////
 void tc::Replica::free_replica_ops (TCReplicaOpList tc_undo_ops)
 {
-  tc_replica_op_list_free(tc_undo_ops);
+  tc_replica_op_list_free(&tc_undo_ops);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/tc/Replica.cpp
+++ b/src/tc/Replica.cpp
@@ -169,6 +169,12 @@ void tc::Replica::commit_undo_ops (TCReplicaOpList tc_undo_ops, int32_t *undone_
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+void tc::Replica::free_replica_ops (TCReplicaOpList tc_undo_ops)
+{
+  tc_replica_op_list_free(tc_undo_ops);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 int64_t tc::Replica::num_local_operations ()
 {
   auto num = tc_replica_num_local_operations (&*inner);

--- a/src/tc/Replica.cpp
+++ b/src/tc/Replica.cpp
@@ -154,9 +154,15 @@ void tc::Replica::sync (Server server, bool avoid_snapshots)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void tc::Replica::undo (int32_t *undone_out, bool(*condition)(struct tc::ffi::TCUndoDiff))
+TCReplicaOpList tc::Replica::get_undo_ops ()
 {
-  auto res = tc_replica_undo (&*inner, undone_out, condition);
+  return tc_replica_get_undo_ops(&*inner);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void tc::Replica::commit_undo_ops (TCReplicaOpList tc_undo_ops, int32_t *undone_out)
+{
+  auto res = tc_replica_commit_undo_ops (&*inner, tc_undo_ops, undone_out);
   if (res != TC_RESULT_OK) {
     throw replica_error ();
   }

--- a/src/tc/Replica.cpp
+++ b/src/tc/Replica.cpp
@@ -154,9 +154,9 @@ void tc::Replica::sync (Server server, bool avoid_snapshots)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void tc::Replica::undo (int32_t *undone_out)
+void tc::Replica::undo (int32_t *undone_out, bool(*condition)(struct tc::ffi::TCUndoDiff))
 {
-  auto res = tc_replica_undo (&*inner, undone_out);
+  auto res = tc_replica_undo (&*inner, undone_out, condition);
   if (res != TC_RESULT_OK) {
     throw replica_error ();
   }

--- a/src/tc/Replica.cpp
+++ b/src/tc/Replica.cpp
@@ -31,6 +31,7 @@
 #include "tc/Server.h"
 #include "tc/WorkingSet.h"
 #include "tc/util.h"
+#include <iostream>
 
 using namespace tc::ffi;
 
@@ -172,6 +173,48 @@ void tc::Replica::commit_undo_ops (TCReplicaOpList tc_undo_ops, int32_t *undone_
 void tc::Replica::free_replica_ops (TCReplicaOpList tc_undo_ops)
 {
   tc_replica_op_list_free(tc_undo_ops);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string tc::Replica::get_op_uuid(TCReplicaOp &tc_replica_op) const
+{
+  TCString uuid = tc_replica_op_get_uuid(&tc_replica_op);
+  return tc2string(uuid);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string tc::Replica::get_op_property(TCReplicaOp &tc_replica_op) const
+{
+  TCString property = tc_replica_op_get_property(&tc_replica_op);
+  return tc2string(property);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string tc::Replica::get_op_value(TCReplicaOp &tc_replica_op) const
+{
+  TCString value = tc_replica_op_get_value(&tc_replica_op);
+  return tc2string(value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string tc::Replica::get_op_old_value(TCReplicaOp &tc_replica_op) const
+{
+  TCString old_value = tc_replica_op_get_old_value(&tc_replica_op);
+  return tc2string(old_value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string tc::Replica::get_op_timestamp(TCReplicaOp &tc_replica_op) const
+{
+  TCString timestamp = tc_replica_op_get_timestamp(&tc_replica_op);
+  return tc2string(timestamp);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string tc::Replica::get_op_old_task_description(TCReplicaOp &tc_replica_op) const
+{
+  TCString description = tc_replica_op_get_old_task_description(&tc_replica_op);
+  return tc2string(description);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/tc/Replica.h
+++ b/src/tc/Replica.h
@@ -95,6 +95,7 @@ namespace tc {
     void sync(Server server, bool avoid_snapshots);
     tc::ffi::TCReplicaOpList get_undo_ops ();
     void commit_undo_ops (tc::ffi::TCReplicaOpList tc_undo_ops, int32_t *undone_out);
+    void free_replica_ops (tc::ffi::TCReplicaOpList tc_undo_ops);
     int64_t num_local_operations ();
     int64_t num_undo_points ();
 // TODO: TCResult tc_replica_add_undo_point(struct TCReplica *rep, bool force);

--- a/src/tc/Replica.h
+++ b/src/tc/Replica.h
@@ -93,7 +93,8 @@ namespace tc {
     tc::Task import_task_with_uuid (const std::string &uuid);
 // TODO: struct TCTask *tc_replica_import_task_with_uuid(struct TCReplica *rep, struct TCUuid tcuuid);
     void sync(Server server, bool avoid_snapshots);
-    void undo (int32_t *undone_out, bool(*condition)(struct tc::ffi::TCUndoDiff));
+    tc::ffi::TCReplicaOpList get_undo_ops ();
+    void commit_undo_ops (tc::ffi::TCReplicaOpList tc_undo_ops, int32_t *undone_out);
     int64_t num_local_operations ();
     int64_t num_undo_points ();
 // TODO: TCResult tc_replica_add_undo_point(struct TCReplica *rep, bool force);

--- a/src/tc/Replica.h
+++ b/src/tc/Replica.h
@@ -93,7 +93,7 @@ namespace tc {
     tc::Task import_task_with_uuid (const std::string &uuid);
 // TODO: struct TCTask *tc_replica_import_task_with_uuid(struct TCReplica *rep, struct TCUuid tcuuid);
     void sync(Server server, bool avoid_snapshots);
-    void undo (int32_t *undone_out);
+    void undo (int32_t *undone_out, bool(*condition)(struct tc::ffi::TCUndoDiff));
     int64_t num_local_operations ();
     int64_t num_undo_points ();
 // TODO: TCResult tc_replica_add_undo_point(struct TCReplica *rep, bool force);

--- a/src/tc/Replica.h
+++ b/src/tc/Replica.h
@@ -96,6 +96,12 @@ namespace tc {
     tc::ffi::TCReplicaOpList get_undo_ops ();
     void commit_undo_ops (tc::ffi::TCReplicaOpList tc_undo_ops, int32_t *undone_out);
     void free_replica_ops (tc::ffi::TCReplicaOpList tc_undo_ops);
+    std::string get_op_uuid(tc::ffi::TCReplicaOp &tc_replica_op) const;
+    std::string get_op_property(tc::ffi::TCReplicaOp &tc_replica_op) const;
+    std::string get_op_value(tc::ffi::TCReplicaOp &tc_replica_op) const;
+    std::string get_op_old_value(tc::ffi::TCReplicaOp &tc_replica_op) const;
+    std::string get_op_timestamp(tc::ffi::TCReplicaOp &tc_replica_op) const;
+    std::string get_op_old_task_description(tc::ffi::TCReplicaOp &tc_replica_op) const;
     int64_t num_local_operations ();
     int64_t num_undo_points ();
 // TODO: TCResult tc_replica_add_undo_point(struct TCReplica *rep, bool force);

--- a/src/tc/rust/Cargo.lock
+++ b/src/tc/rust/Cargo.lock
@@ -1758,9 +1758,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
  "serde",

--- a/taskchampion/integration-tests/src/bindings_tests/replica.c
+++ b/taskchampion/integration-tests/src/bindings_tests/replica.c
@@ -20,12 +20,20 @@ static void test_replica_creation_disk(void) {
     tc_replica_free(rep);
 }
 
+static bool always_confirm(void* undo_ops_ptr , size_t undo_ops_len) {
+  // silence unused variable warnings
+  (void) undo_ops_ptr;
+  (void) undo_ops_len;
+
+  return true;
+}
+
 // undo on an empty in-memory TCReplica does nothing
 static void test_replica_undo_empty(void) {
     TCReplica *rep = tc_replica_new_in_memory();
     TEST_ASSERT_NULL(tc_replica_error(rep).ptr);
     int undone;
-    int rv = tc_replica_undo(rep, &undone);
+    int rv = tc_replica_undo(rep, &undone, always_confirm);
     TEST_ASSERT_EQUAL(TC_RESULT_OK, rv);
     TEST_ASSERT_EQUAL(0, undone);
     TEST_ASSERT_NULL(tc_replica_error(rep).ptr);
@@ -118,7 +126,7 @@ static void test_replica_working_set(void) {
 static void test_replica_undo_empty_null_undone_out(void) {
     TCReplica *rep = tc_replica_new_in_memory();
     TEST_ASSERT_NULL(tc_replica_error(rep).ptr);
-    int rv = tc_replica_undo(rep, NULL);
+    int rv = tc_replica_undo(rep, NULL, always_confirm);
     TEST_ASSERT_EQUAL(TC_RESULT_OK, rv);
     TEST_ASSERT_NULL(tc_replica_error(rep).ptr);
     tc_replica_free(rep);

--- a/taskchampion/lib/src/kv.rs
+++ b/taskchampion/lib/src/kv.rs
@@ -1,6 +1,6 @@
 use crate::traits::*;
 use crate::types::*;
-use std::ptr::null_mut;
+use crate::util::vec_into_raw_parts;
 use taskchampion::storage::TaskMap;
 
 #[ffizz_header::item]
@@ -122,10 +122,11 @@ impl CList for TCKVList {
 
 impl Default for TCKVList {
     fn default() -> Self {
+        let (ptr, len, capacity) = vec_into_raw_parts(Vec::default());
         Self {
-            len: libc::size_t::default(),
-            _capacity: libc::size_t::default(),
-            items: null_mut(),
+            items: ptr,
+            len,
+            _capacity: capacity,
         }
     }
 }

--- a/taskchampion/lib/src/kv.rs
+++ b/taskchampion/lib/src/kv.rs
@@ -1,7 +1,5 @@
 use crate::traits::*;
 use crate::types::*;
-use crate::util::vec_into_raw_parts;
-use taskchampion::storage::TaskMap;
 
 #[ffizz_header::item]
 #[ffizz(order = 600)]
@@ -77,22 +75,6 @@ pub struct TCKVList {
     /// total size of items (internal use only)
     pub _capacity: libc::size_t,
     pub items: *mut TCKV,
-}
-
-impl From<TaskMap> for TCKVList {
-    fn from(taskmap: TaskMap) -> TCKVList {
-        let vec = taskmap
-            .iter()
-            .map(|(k, v)| {
-                let key = RustString::from(k.as_ref());
-                let value = RustString::from(v.as_ref());
-                TCKV::as_ctype((key, value))
-            })
-            .collect();
-        // SAFETY:
-        //  - caller will free this list
-        unsafe { TCKVList::return_val(vec) }
-    }
 }
 
 impl CList for TCKVList {

--- a/taskchampion/lib/src/kv.rs
+++ b/taskchampion/lib/src/kv.rs
@@ -19,6 +19,7 @@ use taskchampion::storage::TaskMap;
 /// } TCKV;
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct TCKV {
     pub key: TCString,
     pub value: TCString,
@@ -70,6 +71,7 @@ impl PassByValue for TCKV {
 /// } TCKVList;
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct TCKVList {
     pub len: libc::size_t,
     /// total size of items (internal use only)

--- a/taskchampion/lib/src/kv.rs
+++ b/taskchampion/lib/src/kv.rs
@@ -122,12 +122,9 @@ impl CList for TCKVList {
 
 impl Default for TCKVList {
     fn default() -> Self {
-        let (ptr, len, capacity) = vec_into_raw_parts(Vec::default());
-        Self {
-            items: ptr,
-            len,
-            _capacity: capacity,
-        }
+        // SAFETY:
+        //  - caller will free this list
+        unsafe { TCKVList::return_val(Vec::new()) }
     }
 }
 

--- a/taskchampion/lib/src/kv.rs
+++ b/taskchampion/lib/src/kv.rs
@@ -1,5 +1,6 @@
 use crate::traits::*;
 use crate::types::*;
+use std::ptr::null_mut;
 use taskchampion::storage::TaskMap;
 
 #[ffizz_header::item]
@@ -114,6 +115,16 @@ impl CList for TCKVList {
 
     fn into_raw_parts(self) -> (*mut Self::Element, usize, usize) {
         (self.items, self.len, self._capacity)
+    }
+}
+
+impl Default for TCKVList {
+    fn default() -> Self {
+        Self {
+            len: libc::size_t::default(),
+            _capacity: libc::size_t::default(),
+            items: null_mut(),
+        }
     }
 }
 

--- a/taskchampion/lib/src/lib.rs
+++ b/taskchampion/lib/src/lib.rs
@@ -65,7 +65,7 @@ ffizz_header::snippet! {
 /// ## Pass by Pointer
 ///
 /// Several types such as TCReplica and TCString are "opaque" types and always handled as pointers
-/// in C. The bytes these pointers address are private to the Rust implemetation and must not be
+/// in C. The bytes these pointers address are private to the Rust implementation and must not be
 /// accessed from C.
 ///
 /// Pass-by-pointer values have exactly one owner, and that owner is responsible for freeing the

--- a/taskchampion/lib/src/lib.rs
+++ b/taskchampion/lib/src/lib.rs
@@ -154,7 +154,7 @@ pub use workingset::*;
 pub(crate) mod types {
     pub(crate) use crate::annotation::{TCAnnotation, TCAnnotationList};
     pub(crate) use crate::kv::{TCKVList, TCKV};
-    pub(crate) use crate::replica::TCReplica;
+    pub(crate) use crate::replica::{TCReplica, TCUndoDiff};
     pub(crate) use crate::result::TCResult;
     pub(crate) use crate::server::TCServer;
     pub(crate) use crate::status::TCStatus;

--- a/taskchampion/lib/src/lib.rs
+++ b/taskchampion/lib/src/lib.rs
@@ -153,8 +153,8 @@ pub use workingset::*;
 
 pub(crate) mod types {
     pub(crate) use crate::annotation::{TCAnnotation, TCAnnotationList};
-    pub(crate) use crate::kv::{TCKVList, TCKV};
-    pub(crate) use crate::replica::{TCReplica, TCUndoDiff};
+    pub(crate) use crate::kv::TCKVList;
+    pub(crate) use crate::replica::TCReplica;
     pub(crate) use crate::result::TCResult;
     pub(crate) use crate::server::TCServer;
     pub(crate) use crate::status::TCStatus;

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -141,7 +141,7 @@ where
 ///     Create,
 ///     Delete,
 ///     Update,
-///     Undopoint,
+///     UndoPoint,
 /// } TCReplicaOpType;
 /// ```
 #[derive(Default)]
@@ -407,7 +407,7 @@ impl From<TCReplicaOp> for ReplicaOp {
 ///
 /// ```c
 /// struct TCReplicaOpList {
-///     void* items;
+///     struct TCReplicaOp *items;
 ///     size_t len;
 ///     size_t capacity;
 /// };

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -237,7 +237,9 @@ pub unsafe extern "C" fn tc_replica_new_on_disk(
 
 impl From<TCKVList> for TaskMap {
     fn from(kvlist: TCKVList) -> TaskMap {
-        // TODO SAFETY:
+        // SAFETY:
+        //  - items, len, and capacity are the unmodified values returned by vec_into_raw_parts
+        //  (promised by caller)
         let vec = unsafe { Vec::from_raw_parts(kvlist.items, kvlist.len, kvlist._capacity) };
 
         let mut taskmap = TaskMap::new();
@@ -365,7 +367,9 @@ impl From<Vec<ReplicaOp>> for TCReplicaOpList {
 
 impl From<TCReplicaOpList> for Vec<ReplicaOp> {
     fn from(tc_replica_op_list: TCReplicaOpList) -> Vec<ReplicaOp> {
-        // TODO SAFETY:
+        // SAFETY:
+        //  - items, len, and capacity are the unmodified values returned by vec_into_raw_parts
+        //  (promised by caller)
         let tc_replica_op_vec = unsafe {
             Vec::from_raw_parts(
                 tc_replica_op_list.items,
@@ -804,7 +808,9 @@ pub unsafe extern "C" fn tc_replica_op_list_free(oplist: *mut TCReplicaOpList) {
     //  - capacity is not NULL
     //  - capacity is properly aligned (promised by caller)
     let capacity = unsafe { (*oplist).capacity };
-    // TODO SAFETY:
+    // SAFETY:
+    //  - items, len, and capacity are the unmodified values returned by vec_into_raw_parts
+    //  (promised by caller)
     unsafe { Vec::from_raw_parts(items, len, capacity) };
 }
 

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -373,6 +373,7 @@ impl From<TCReplicaOp> for ReplicaOp {
 ///
 /// typedef struct TCReplicaOpList TCReplicaOpList;
 /// ```
+#[repr(C)]
 pub struct TCReplicaOpList {
     ptr: *mut TCReplicaOp,
     len: usize,

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -822,17 +822,22 @@ pub unsafe extern "C" fn tc_replica_op_list_free(oplist: *mut TCReplicaOpList) {
 /// EXTERN_C struct TCString tc_replica_op_get_uuid(struct TCReplicaOp *op);
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn tc_replica_op_get_uuid(op: &TCReplicaOp) -> TCString {
+pub unsafe extern "C" fn tc_replica_op_get_uuid(op: *const TCReplicaOp) -> TCString {
+    // SAFETY:
+    //   - inner is not null
+    //   - inner is a living object
+    let rop: &ReplicaOp = unsafe { (*op).inner.as_ref() };
+
     if let ReplicaOp::Create { uuid }
     | ReplicaOp::Delete { uuid, .. }
-    | ReplicaOp::Update { uuid, .. } = *op.inner
+    | ReplicaOp::Update { uuid, .. } = rop
     {
         let uuid_rstr: RustString = uuid.to_string().into();
         // SAFETY:
         //  - caller promises to free this string
         unsafe { TCString::return_val(uuid_rstr) }
     } else {
-        panic!("Operation has no uuid: {:#?}", op);
+        panic!("Operation has no uuid: {:#?}", rop);
     }
 }
 
@@ -844,13 +849,18 @@ pub unsafe extern "C" fn tc_replica_op_get_uuid(op: &TCReplicaOp) -> TCString {
 /// EXTERN_C struct TCString tc_replica_op_get_property(struct TCReplicaOp *op);
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn tc_replica_op_get_property(op: &TCReplicaOp) -> TCString {
-    if let ReplicaOp::Update { property, .. } = *op.inner.clone() {
+pub unsafe extern "C" fn tc_replica_op_get_property(op: *const TCReplicaOp) -> TCString {
+    // SAFETY:
+    //   - inner is not null
+    //   - inner is a living object
+    let rop: &ReplicaOp = unsafe { (*op).inner.as_ref() };
+
+    if let ReplicaOp::Update { property, .. } = rop {
         // SAFETY:
         //  - caller promises to free this string
-        unsafe { TCString::return_val(property.into()) }
+        unsafe { TCString::return_val(property.clone().into()) }
     } else {
-        panic!("Operation has no property: {:#?}", op);
+        panic!("Operation has no property: {:#?}", rop);
     }
 }
 
@@ -862,14 +872,19 @@ pub unsafe extern "C" fn tc_replica_op_get_property(op: &TCReplicaOp) -> TCStrin
 /// EXTERN_C struct TCString tc_replica_op_get_value(struct TCReplicaOp *op);
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn tc_replica_op_get_value(op: &TCReplicaOp) -> TCString {
-    if let ReplicaOp::Update { value, .. } = *op.inner.clone() {
-        let value_rstr: RustString = value.unwrap_or(String::new()).into();
+pub unsafe extern "C" fn tc_replica_op_get_value(op: *const TCReplicaOp) -> TCString {
+    // SAFETY:
+    //   - inner is not null
+    //   - inner is a living object
+    let rop: &ReplicaOp = unsafe { (*op).inner.as_ref() };
+
+    if let ReplicaOp::Update { value, .. } = rop {
+        let value_rstr: RustString = value.clone().unwrap_or(String::new()).into();
         // SAFETY:
         //  - caller promises to free this string
         unsafe { TCString::return_val(value_rstr) }
     } else {
-        panic!("Operation has no value: {:#?}", op);
+        panic!("Operation has no value: {:#?}", rop);
     }
 }
 
@@ -881,14 +896,19 @@ pub unsafe extern "C" fn tc_replica_op_get_value(op: &TCReplicaOp) -> TCString {
 /// EXTERN_C struct TCString tc_replica_op_get_old_value(struct TCReplicaOp *op);
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn tc_replica_op_get_old_value(op: &TCReplicaOp) -> TCString {
-    if let ReplicaOp::Update { old_value, .. } = *op.inner.clone() {
-        let old_value_rstr: RustString = old_value.unwrap_or(String::new()).into();
+pub unsafe extern "C" fn tc_replica_op_get_old_value(op: *const TCReplicaOp) -> TCString {
+    // SAFETY:
+    //   - inner is not null
+    //   - inner is a living object
+    let rop: &ReplicaOp = unsafe { (*op).inner.as_ref() };
+
+    if let ReplicaOp::Update { old_value, .. } = rop {
+        let old_value_rstr: RustString = old_value.clone().unwrap_or(String::new()).into();
         // SAFETY:
         //  - caller promises to free this string
         unsafe { TCString::return_val(old_value_rstr) }
     } else {
-        panic!("Operation has no old value: {:#?}", op);
+        panic!("Operation has no old value: {:#?}", rop);
     }
 }
 
@@ -900,14 +920,19 @@ pub unsafe extern "C" fn tc_replica_op_get_old_value(op: &TCReplicaOp) -> TCStri
 /// EXTERN_C struct TCString tc_replica_op_get_timestamp(struct TCReplicaOp *op);
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn tc_replica_op_get_timestamp(op: &TCReplicaOp) -> TCString {
-    if let ReplicaOp::Update { timestamp, .. } = *op.inner {
+pub unsafe extern "C" fn tc_replica_op_get_timestamp(op: *const TCReplicaOp) -> TCString {
+    // SAFETY:
+    //   - inner is not null
+    //   - inner is a living object
+    let rop: &ReplicaOp = unsafe { (*op).inner.as_ref() };
+
+    if let ReplicaOp::Update { timestamp, .. } = rop {
         let timestamp_rstr: RustString = timestamp.to_string().into();
         // SAFETY:
         //  - caller promises to free this string
         unsafe { TCString::return_val(timestamp_rstr) }
     } else {
-        panic!("Operation has no timestamp: {:#?}", op);
+        panic!("Operation has no timestamp: {:#?}", rop);
     }
 }
 
@@ -919,13 +944,20 @@ pub unsafe extern "C" fn tc_replica_op_get_timestamp(op: &TCReplicaOp) -> TCStri
 /// EXTERN_C struct TCString tc_replica_op_get_old_task_description(struct TCReplicaOp *op);
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn tc_replica_op_get_old_task_description(op: &TCReplicaOp) -> TCString {
-    if let ReplicaOp::Delete { old_task, .. } = *op.inner.clone() {
+pub unsafe extern "C" fn tc_replica_op_get_old_task_description(
+    op: *const TCReplicaOp,
+) -> TCString {
+    // SAFETY:
+    //   - inner is not null
+    //   - inner is a living object
+    let rop: &ReplicaOp = unsafe { (*op).inner.as_ref() };
+
+    if let ReplicaOp::Delete { old_task, .. } = rop {
         let description_rstr: RustString = old_task["description"].clone().into();
         // SAFETY:
         //  - caller promises to free this string
         unsafe { TCString::return_val(description_rstr) }
     } else {
-        panic!("Operation has no timestamp: {:#?}", op);
+        panic!("Operation has no timestamp: {:#?}", rop);
     }
 }

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -792,7 +792,7 @@ pub unsafe extern "C" fn tc_replica_free(rep: *mut TCReplica) {
 /// more than once.
 ///
 /// ```c
-/// EXTERN_C void tc_replica_op_list_free(struct TCReplicaOpList oplist);
+/// EXTERN_C void tc_replica_op_list_free(struct TCReplicaOpList *oplist);
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn tc_replica_op_list_free(oplist: *mut TCReplicaOpList) {

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -137,24 +137,49 @@ where
 /// ***** TCReplicaOpType *****
 ///
 /// ```c
-/// typedef enum TCReplicaOpType {
-///     Create,
-///     Delete,
-///     Update,
-///     UndoPoint,
-/// } TCReplicaOpType;
+/// enum TCReplicaOpType
+/// #ifdef __cplusplus
+///   : uint32_t
+/// #endif // __cplusplus
+/// {
+///     Create = 0,
+///     Delete = 1,
+///     Update = 2,
+///     UndoPoint = 3,
+/// };
+/// #ifndef __cplusplus
+/// typedef uint32_t TCReplicaOpType;
+/// #endif // __cplusplus
 /// ```
 #[derive(Default)]
+#[repr(u32)]
 pub enum TCReplicaOpType {
-    Create,
-    Delete,
-    Update,
-    UndoPoint,
+    Create = 0,
+    Delete = 1,
+    Update = 2,
+    UndoPoint = 3,
     #[default]
-    Error,
+    Error = 4,
 }
 
-impl PassByPointer for TCReplicaOpType {}
+impl PassByValue for TCReplicaOpType {
+    type RustType = u32;
+
+    unsafe fn from_ctype(self) -> Self::RustType {
+        self as u32
+    }
+
+    fn as_ctype(arg: u32) -> Self {
+        match arg {
+            0 => TCReplicaOpType::Create,
+            1 => TCReplicaOpType::Delete,
+            2 => TCReplicaOpType::Update,
+            3 => TCReplicaOpType::UndoPoint,
+            _ => panic!("Bad TCReplicaOpType."),
+        }
+    }
+
+}
 
 #[ffizz_header::item]
 #[ffizz(order = 901)]
@@ -255,6 +280,7 @@ impl From<TCKVList> for TaskMap {
 /// typedef struct TCReplicaOp TCReplicaOp;
 /// ```
 #[derive(Default)]
+#[repr(C)]
 pub struct TCReplicaOp {
     operation_type: TCReplicaOpType,
     uuid: TCUuid,

--- a/taskchampion/lib/src/replica.rs
+++ b/taskchampion/lib/src/replica.rs
@@ -151,6 +151,7 @@ where
 /// typedef uint32_t TCReplicaOpType;
 /// #endif // __cplusplus
 /// ```
+#[derive(Debug)]
 #[derive(Default)]
 #[repr(u32)]
 pub enum TCReplicaOpType {
@@ -279,6 +280,7 @@ impl From<TCKVList> for TaskMap {
 ///
 /// typedef struct TCReplicaOp TCReplicaOp;
 /// ```
+#[derive(Debug)]
 #[derive(Default)]
 #[repr(C)]
 pub struct TCReplicaOp {
@@ -290,8 +292,6 @@ pub struct TCReplicaOp {
     value: TCString,
     timestamp: TCString,
 }
-
-impl PassByPointer for TCReplicaOp {}
 
 impl From<ReplicaOp> for TCReplicaOp {
     fn from(replica_op: ReplicaOp) -> TCReplicaOp {
@@ -474,10 +474,14 @@ impl CList for TCReplicaOpList {
 
 impl From<Vec<ReplicaOp>> for TCReplicaOpList {
     fn from(replica_op_list: Vec<ReplicaOp>) -> TCReplicaOpList {
+        // XXX Remove prints
+        println!("{:#?}", replica_op_list);
+        let tc_replica_op_list: Vec<TCReplicaOp> = replica_op_list.into_iter().map(|op| TCReplicaOp::from(op)).collect();
+        println!("{:#?}", tc_replica_op_list);
         TCReplicaOpList {
-            items: replica_op_list.as_ptr() as *mut TCReplicaOp,
-            len: replica_op_list.len(),
-            capacity: replica_op_list.capacity(),
+            items: tc_replica_op_list.as_ptr() as *mut TCReplicaOp,
+            len: tc_replica_op_list.len(),
+            capacity: tc_replica_op_list.capacity(),
         }
     }
 }

--- a/taskchampion/lib/src/string.rs
+++ b/taskchampion/lib/src/string.rs
@@ -55,6 +55,7 @@ use std::path::PathBuf;
 /// } TCString;
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 pub struct TCString {
     // defined based on the type
     ptr: *mut libc::c_void,

--- a/taskchampion/lib/src/task.rs
+++ b/taskchampion/lib/src/task.rs
@@ -1,6 +1,7 @@
 use crate::traits::*;
 use crate::types::*;
 use crate::util::err_to_ruststring;
+use crate::TCKV;
 use std::convert::TryFrom;
 use std::ops::Deref;
 use std::ptr::NonNull;

--- a/taskchampion/lib/src/uuid.rs
+++ b/taskchampion/lib/src/uuid.rs
@@ -16,6 +16,7 @@ use taskchampion::Uuid;
 /// } TCUuid;
 /// ```
 #[repr(C)]
+#[derive(Default)]
 pub struct TCUuid([u8; 16]);
 
 impl PassByValue for TCUuid {

--- a/taskchampion/lib/src/uuid.rs
+++ b/taskchampion/lib/src/uuid.rs
@@ -16,8 +16,7 @@ use taskchampion::Uuid;
 /// } TCUuid;
 /// ```
 #[repr(C)]
-#[derive(Debug)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct TCUuid([u8; 16]);
 
 impl PassByValue for TCUuid {

--- a/taskchampion/lib/src/uuid.rs
+++ b/taskchampion/lib/src/uuid.rs
@@ -16,6 +16,7 @@ use taskchampion::Uuid;
 /// } TCUuid;
 /// ```
 #[repr(C)]
+#[derive(Debug)]
 #[derive(Default)]
 pub struct TCUuid([u8; 16]);
 

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -33,7 +33,7 @@
 // ## Pass by Pointer
 //
 // Several types such as TCReplica and TCString are "opaque" types and always handled as pointers
-// in C. The bytes these pointers address are private to the Rust implemetation and must not be
+// in C. The bytes these pointers address are private to the Rust implementation and must not be
 // accessed from C.
 //
 // Pass-by-pointer values have exactly one owner, and that owner is responsible for freeing the
@@ -481,12 +481,19 @@ EXTERN_C void tc_server_free(struct TCServer *server);
 typedef struct TCReplica TCReplica;
 
 // ***** TCReplicaOpType *****
-typedef enum TCReplicaOpType {
-    Create,
-    Delete,
-    Update,
-    UndoPoint,
-} TCReplicaOpType;
+enum TCReplicaOpType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+{
+    Create = 0,
+    Delete = 1,
+    Update = 2,
+    UndoPoint = 3,
+};
+#ifndef __cplusplus
+typedef uint32_t TCReplicaOpType;
+#endif // __cplusplus
 
 // ***** TCReplicaOp *****
 struct TCReplicaOp {

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -485,7 +485,7 @@ typedef enum TCReplicaOpType {
     Create,
     Delete,
     Update,
-    Undopoint,
+    UndoPoint,
 } TCReplicaOpType;
 
 // ***** TCReplicaOp *****
@@ -503,7 +503,7 @@ typedef struct TCReplicaOp TCReplicaOp;
 
 // ***** TCReplicaOpList *****
 struct TCReplicaOpList {
-    void* items;
+    struct TCReplicaOp *items;
     size_t len;
     size_t capacity;
 };

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -605,6 +605,10 @@ EXTERN_C struct TCWorkingSet *tc_replica_working_set(struct TCReplica *rep);
 // more than once.
 EXTERN_C void tc_replica_free(struct TCReplica *rep);
 
+// Free a vector of ReplicaOp.  The vector may not be used after this function returns and must not be freed
+// more than once.
+EXTERN_C void tc_replica_op_list_free(struct TCReplicaOpList oplist);
+
 // ***** TCTask *****
 //
 // A task, as publicly exposed by this library.

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -503,7 +503,7 @@ typedef struct TCReplicaOp TCReplicaOp;
 
 // ***** TCReplicaOpList *****
 struct TCReplicaOpList {
-    void* ptr;
+    void* items;
     size_t len;
     size_t capacity;
 };

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -498,12 +498,7 @@ typedef uint32_t TCReplicaOpType;
 // ***** TCReplicaOp *****
 struct TCReplicaOp {
     TCReplicaOpType operation_type;
-    TCUuid uuid;
-    TCKVList old_task;
-    TCString property;
-    TCString old_value;
-    TCString value;
-    TCString timestamp;
+    void* inner;
 };
 
 typedef struct TCReplicaOp TCReplicaOp;
@@ -604,6 +599,24 @@ EXTERN_C struct TCWorkingSet *tc_replica_working_set(struct TCReplica *rep);
 // Free a replica.  The replica may not be used after this function returns and must not be freed
 // more than once.
 EXTERN_C void tc_replica_free(struct TCReplica *rep);
+
+// Return description field of old task field of ReplicaOp.
+EXTERN_C struct TCString tc_replica_op_get_old_task_description(struct TCReplicaOp *op);
+
+// Return old value field of ReplicaOp.
+EXTERN_C struct TCString tc_replica_op_get_old_value(struct TCReplicaOp *op);
+
+// Return property field of ReplicaOp.
+EXTERN_C struct TCString tc_replica_op_get_property(struct TCReplicaOp *op);
+
+// Return timestamp field of ReplicaOp.
+EXTERN_C struct TCString tc_replica_op_get_timestamp(struct TCReplicaOp *op);
+
+// Return uuid field of ReplicaOp.
+EXTERN_C struct TCString tc_replica_op_get_uuid(struct TCReplicaOp *op);
+
+// Return value field of ReplicaOp.
+EXTERN_C struct TCString tc_replica_op_get_value(struct TCReplicaOp *op);
 
 // Free a vector of ReplicaOp.  The vector may not be used after this function returns and must not be freed
 // more than once.

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -480,6 +480,15 @@ EXTERN_C void tc_server_free(struct TCServer *server);
 // TCReplicas are not threadsafe.
 typedef struct TCReplica TCReplica;
 
+// ***** TCUndoDiff *****
+struct TCUndoDiff {
+    char *current;
+    char *prior;
+    char *when;
+};
+
+typedef struct TCUndoDiff TCUndoDiff;
+
 // Create a new TCReplica with an in-memory database.  The contents of the database will be
 // lost when it is freed with tc_replica_free.
 EXTERN_C struct TCReplica *tc_replica_new_in_memory(void);
@@ -553,7 +562,7 @@ EXTERN_C TCResult tc_replica_sync(struct TCReplica *rep, struct TCServer *server
 //
 // If undone_out is not NULL, then on success it is set to 1 if operations were undone, or 0 if
 // there are no operations that can be done.
-EXTERN_C TCResult tc_replica_undo(struct TCReplica *rep, int32_t *undone_out);
+EXTERN_C TCResult tc_replica_undo(struct TCReplica *rep, int32_t *undone_out, bool(*condition)(struct TCUndoDiff));
 
 // Get the current working set for this replica.  The resulting value must be freed
 // with tc_working_set_free.

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -620,7 +620,7 @@ EXTERN_C struct TCString tc_replica_op_get_value(struct TCReplicaOp *op);
 
 // Free a vector of ReplicaOp.  The vector may not be used after this function returns and must not be freed
 // more than once.
-EXTERN_C void tc_replica_op_list_free(struct TCReplicaOpList oplist);
+EXTERN_C void tc_replica_op_list_free(struct TCReplicaOpList *oplist);
 
 // ***** TCTask *****
 //

--- a/taskchampion/lib/taskchampion.h
+++ b/taskchampion/lib/taskchampion.h
@@ -480,28 +480,33 @@ EXTERN_C void tc_server_free(struct TCServer *server);
 // TCReplicas are not threadsafe.
 typedef struct TCReplica TCReplica;
 
+// ***** TCReplicaOpType *****
+typedef enum TCReplicaOpType {
+    Create,
+    Delete,
+    Update,
+    Undopoint,
+} TCReplicaOpType;
+
 // ***** TCReplicaOp *****
-enum TCReplicaOp {
-   Create { struct TCUuid uuid },
-   Delete { struct TCUuid uuid, TCKVList old_task },
-   Update {
-       struct TCUuid uuid,
-       struct TCString property,
-       struct TCString old_value,
-       struct TCString value,
-       struct TCString timestamp,
-   },
-   UndoPoint,
-}
+struct TCReplicaOp {
+    TCReplicaOpType operation_type;
+    TCUuid uuid;
+    TCKVList old_task;
+    TCString property;
+    TCString old_value;
+    TCString value;
+    TCString timestamp;
+};
 
 typedef struct TCReplicaOp TCReplicaOp;
 
 // ***** TCReplicaOpList *****
 struct TCReplicaOpList {
-    void* ptr
-    size_t len
-    size_t capacity
-}
+    void* ptr;
+    size_t len;
+    size_t capacity;
+};
 
 typedef struct TCReplicaOpList TCReplicaOpList;
 

--- a/taskchampion/taskchampion/src/lib.rs
+++ b/taskchampion/taskchampion/src/lib.rs
@@ -63,7 +63,7 @@ mod replica;
 pub mod server;
 pub mod storage;
 mod task;
-pub mod taskdb;
+mod taskdb;
 mod utils;
 mod workingset;
 

--- a/taskchampion/taskchampion/src/lib.rs
+++ b/taskchampion/taskchampion/src/lib.rs
@@ -63,7 +63,7 @@ mod replica;
 pub mod server;
 pub mod storage;
 mod task;
-mod taskdb;
+pub mod taskdb;
 mod utils;
 mod workingset;
 

--- a/taskchampion/taskchampion/src/replica.rs
+++ b/taskchampion/taskchampion/src/replica.rs
@@ -3,6 +3,7 @@ use crate::errors::Result;
 use crate::server::{Server, SyncOp};
 use crate::storage::{Storage, TaskMap};
 use crate::task::{Status, Task};
+use crate::taskdb::undo;
 use crate::taskdb::TaskDb;
 use crate::workingset::WorkingSet;
 use anyhow::Context;
@@ -238,8 +239,11 @@ impl Replica {
 
     /// Undo local operations until the most recent UndoPoint, returning false if there are no
     /// local operations to undo.
-    pub fn undo(&mut self) -> Result<bool> {
-        self.taskdb.undo()
+    pub fn undo<F>(&mut self, condition: F) -> Result<bool>
+    where
+        F: Fn(undo::UndoDiff) -> bool,
+    {
+        self.taskdb.undo(condition)
     }
 
     /// Rebuild this replica's working set, based on whether tasks are pending or not.  If

--- a/taskchampion/taskchampion/src/replica.rs
+++ b/taskchampion/taskchampion/src/replica.rs
@@ -242,7 +242,7 @@ impl Replica {
         self.taskdb.get_undo_ops()
     }
 
-    /// Undo local operations in storage.
+    /// Undo local operations in storage, returning a boolean indicating success.
     pub fn commit_undo_ops(&mut self, undo_ops: Vec<ReplicaOp>) -> Result<bool> {
         self.taskdb.commit_undo_ops(undo_ops)
     }

--- a/taskchampion/taskchampion/src/replica.rs
+++ b/taskchampion/taskchampion/src/replica.rs
@@ -236,7 +236,7 @@ impl Replica {
         Ok(())
     }
 
-    /// Return undo local operations until the most recent UndoPoint, returning false if there are no
+    /// Return undo local operations until the most recent UndoPoint, returning an empty Vec if there are no
     /// local operations to undo.
     pub fn get_undo_ops(&mut self) -> Result<Vec<ReplicaOp>> {
         self.taskdb.get_undo_ops()

--- a/taskchampion/taskchampion/src/storage/mod.rs
+++ b/taskchampion/taskchampion/src/storage/mod.rs
@@ -1,3 +1,4 @@
+use crate::errors::Result;
 /**
 This module defines the backend storage used by [`Replica`](crate::Replica).
 It defines a [trait](crate::storage::Storage) for storage implementations, and provides a default on-disk implementation as well as an in-memory implementation for testing.
@@ -5,7 +6,6 @@ It defines a [trait](crate::storage::Storage) for storage implementations, and p
 Typical uses of this crate do not interact directly with this module; [`StorageConfig`](crate::StorageConfig) is sufficient.
 However, users who wish to implement their own storage backends can implement the traits defined here and pass the result to [`Replica`](crate::Replica).
 */
-use crate::errors::Result;
 use std::collections::HashMap;
 use uuid::Uuid;
 

--- a/taskchampion/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/taskchampion/src/taskdb/mod.rs
@@ -114,14 +114,17 @@ impl TaskDb {
         sync::sync(server, txn.as_mut(), avoid_snapshots)
     }
 
-    /// Undo local operations until the most recent UndoPoint, returning false if there are no
+    /// Return undo local operations until the most recent UndoPoint, returning false if there are no
     /// local operations to undo.
-    pub fn undo<F>(&mut self, condition: F) -> Result<bool>
-    where
-        F: Fn(undo::UndoDiff) -> bool,
-    {
+    pub fn get_undo_ops(&mut self) -> Result<Vec<ReplicaOp>> {
         let mut txn = self.storage.txn()?;
-        undo::undo(txn.as_mut(), condition)
+        undo::get_undo_ops(txn.as_mut())
+    }
+
+    /// Undo local operations in storage.
+    pub fn commit_undo_ops(&mut self, undo_ops: Vec<ReplicaOp>) -> Result<bool> {
+        let mut txn = self.storage.txn()?;
+        undo::commit_undo_ops(txn.as_mut(), undo_ops)
     }
 
     /// Get the number of un-synchronized operations in storage, excluding undo

--- a/taskchampion/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/taskchampion/src/taskdb/mod.rs
@@ -121,7 +121,7 @@ impl TaskDb {
         undo::get_undo_ops(txn.as_mut())
     }
 
-    /// Undo local operations in storage.
+    /// Undo local operations in storage, returning a boolean indicating success.
     pub fn commit_undo_ops(&mut self, undo_ops: Vec<ReplicaOp>) -> Result<bool> {
         let mut txn = self.storage.txn()?;
         undo::commit_undo_ops(txn.as_mut(), undo_ops)

--- a/taskchampion/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/taskchampion/src/taskdb/mod.rs
@@ -114,7 +114,7 @@ impl TaskDb {
         sync::sync(server, txn.as_mut(), avoid_snapshots)
     }
 
-    /// Return undo local operations until the most recent UndoPoint, returning false if there are no
+    /// Return undo local operations until the most recent UndoPoint, returning an empty Vec if there are no
     /// local operations to undo.
     pub fn get_undo_ops(&mut self) -> Result<Vec<ReplicaOp>> {
         let mut txn = self.storage.txn()?;

--- a/taskchampion/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/taskchampion/src/taskdb/mod.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 mod apply;
 mod snapshot;
 mod sync;
-mod undo;
+pub mod undo;
 mod working_set;
 
 /// A TaskDb is the backend for a replica.  It manages the storage, operations, synchronization,
@@ -116,9 +116,12 @@ impl TaskDb {
 
     /// Undo local operations until the most recent UndoPoint, returning false if there are no
     /// local operations to undo.
-    pub fn undo(&mut self) -> Result<bool> {
+    pub fn undo<F>(&mut self, condition: F) -> Result<bool>
+    where
+        F: Fn(undo::UndoDiff) -> bool,
+    {
         let mut txn = self.storage.txn()?;
-        undo::undo(txn.as_mut())
+        undo::undo(txn.as_mut(), condition)
     }
 
     /// Get the number of un-synchronized operations in storage, excluding undo

--- a/taskchampion/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/taskchampion/src/taskdb/undo.rs
@@ -113,29 +113,29 @@ mod tests {
 
         assert_eq!(db.operations().len(), 9);
 
-        {
-            let mut txn = db.storage.txn()?;
-            assert!(undo(txn.as_mut())?);
-        }
+        let undo_ops = get_undo_ops(db.storage.txn()?.as_mut())?;
+        assert_eq!(undo_ops.len(), 4);
+
+        assert!(commit_undo_ops(db.storage.txn()?.as_mut(), undo_ops)?);
 
         // undo took db back to the snapshot
         assert_eq!(db.operations().len(), 5);
         assert_eq!(db.sorted_tasks(), db_state);
 
-        {
-            let mut txn = db.storage.txn()?;
-            assert!(undo(txn.as_mut())?);
-        }
+        let undo_ops = get_undo_ops(db.storage.txn()?.as_mut())?;
+        assert_eq!(undo_ops.len(), 5);
+
+        assert!(commit_undo_ops(db.storage.txn()?.as_mut(), undo_ops)?);
 
         // empty db
         assert_eq!(db.operations().len(), 0);
         assert_eq!(db.sorted_tasks(), vec![]);
 
-        {
-            let mut txn = db.storage.txn()?;
-            // nothing left to undo, so undo() returns false
-            assert!(!undo(txn.as_mut())?);
-        }
+        let undo_ops = get_undo_ops(db.storage.txn()?.as_mut())?;
+        assert_eq!(undo_ops.len(), 0);
+
+        // nothing left to undo, so commit_undo_ops() returns false
+        assert!(commit_undo_ops(db.storage.txn()?.as_mut(), undo_ops)?);
 
         Ok(())
     }

--- a/taskchampion/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/taskchampion/src/taskdb/undo.rs
@@ -114,16 +114,17 @@ mod tests {
         assert_eq!(db.operations().len(), 9);
 
         let undo_ops = get_undo_ops(db.storage.txn()?.as_mut())?;
-        assert_eq!(undo_ops.len(), 4);
+        assert_eq!(undo_ops.len(), 3);
 
         assert!(commit_undo_ops(db.storage.txn()?.as_mut(), undo_ops)?);
 
         // undo took db back to the snapshot
+        // note that we've subtracted the length of undo_ops plus one for the UndoPoint
         assert_eq!(db.operations().len(), 5);
         assert_eq!(db.sorted_tasks(), db_state);
 
         let undo_ops = get_undo_ops(db.storage.txn()?.as_mut())?;
-        assert_eq!(undo_ops.len(), 5);
+        assert_eq!(undo_ops.len(), 4);
 
         assert!(commit_undo_ops(db.storage.txn()?.as_mut(), undo_ops)?);
 

--- a/taskchampion/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/taskchampion/src/taskdb/undo.rs
@@ -1,147 +1,55 @@
 use super::apply;
 use crate::errors::Result;
-use crate::server::SyncOp;
-use crate::storage::{ReplicaOp, StorageTxn, TaskMap};
-use chrono::{DateTime, Utc};
-use log::{debug, trace};
+use crate::storage::{ReplicaOp, StorageTxn};
+use log::{debug, info, trace};
 
-/// A representation of the current set of operations which has been split on the UndoPoint, with the newest operations assigned to undo_ops and the remainder of the set assigned to reverted_ops.
-/// Undo instances should be short-lived because hold ownership, which is effectively a lock, on the TaskDb. This is a feature though, because if we wrote another change to the database and then applied our reverted_ops, those other changes would be clobbered.
-struct Undo<'a> {
-    /// The transaction with which to execute the undo.
-    txn: &'a mut dyn StorageTxn,
+/// Local operations until the most recent UndoPoint.
+pub fn get_undo_ops(txn: &mut dyn StorageTxn) -> Result<Vec<ReplicaOp>> {
+    let mut local_ops = txn.operations().unwrap();
+    let mut undo_ops: Vec<ReplicaOp> = Vec::new();
 
-    /// The operations which would be reversed by an undo.
-    undo_ops: Vec<ReplicaOp>,
-
-    /// The reverse operations to be applied.
-    rev_ops: Vec<SyncOp>,
-
-    /// The set of operations after reversing undo_ops.
-    reverted_ops: Vec<ReplicaOp>,
-}
-
-/// Undo local operations until the most recent UndoPoint, returning false if there are no
-/// local operations to undo.
-impl Undo<'_> {
-    pub fn new(txn: &mut dyn StorageTxn) -> Undo {
-        let mut local_ops = txn.operations().unwrap();
-        let mut undo_ops: Vec<ReplicaOp> = Vec::new();
-        let mut rev_ops: Vec<SyncOp> = Vec::new();
-
-        while let Some(op) = local_ops.pop() {
-            if op == ReplicaOp::UndoPoint {
-                break;
-            }
-            undo_ops.push(op);
+    while let Some(op) = local_ops.pop() {
+        if op == ReplicaOp::UndoPoint {
+            break;
         }
-
-        for op in &undo_ops {
-            debug!("Reversing operation {:?}", op);
-            rev_ops.append(&mut op.clone().reverse_ops());
-        }
-
-        Undo {
-            txn,
-            undo_ops,
-            rev_ops,
-            reverted_ops: local_ops,
-        }
+        undo_ops.push(op);
     }
 
-    /// Commit to storage.
-    pub fn commit(self) -> Result<bool> {
-        let mut applied = false;
+    Ok(undo_ops)
+}
 
-        for op in self.rev_ops {
+/// Commit operations to storage.
+pub fn commit_undo_ops(txn: &mut dyn StorageTxn, mut undo_ops: Vec<ReplicaOp>) -> Result<bool> {
+    let mut applied = false;
+    let mut local_ops = txn.operations().unwrap();
+
+    // Drop undo_ops iff they're the latest operations.
+    // TODO Support concurrent undo by adding the reverse of undo_ops rather than popping from operations.
+    let old_len = local_ops.len();
+    let undo_len = undo_ops.len();
+    let new_len = old_len - undo_len;
+    let local_undo_ops = &local_ops[new_len..old_len];
+    undo_ops.reverse();
+    if local_undo_ops != undo_ops {
+        info!("Undo failed: concurrent changes to the database occurred.");
+        return Ok(applied);
+    }
+    undo_ops.reverse();
+    local_ops.truncate(new_len);
+
+    for op in undo_ops {
+        debug!("Reversing operation {:?}", op);
+        let rev_ops = op.reverse_ops();
+        for op in rev_ops {
             trace!("Applying reversed operation {:?}", op);
-            apply::apply_op(&mut *self.txn, &op)?;
+            apply::apply_op(txn, &op)?;
             applied = true;
         }
-
-        if !self.undo_ops.is_empty() {
-            self.txn.set_operations(self.reverted_ops)?;
-            self.txn.commit()?;
-        }
-
-        Ok(applied)
-    }
-}
-
-#[repr(C)]
-pub struct UndoDiff {
-    current: TaskMap,
-    prior: TaskMap,
-    when: DateTime<Utc>,
-}
-
-impl UndoDiff {
-    fn new(undo: &Undo) -> UndoDiff {
-        let mut current = TaskMap::new();
-        let mut prior = TaskMap::new();
-        let mut when: Option<DateTime<Utc>> = None;
-
-        for op in &undo.undo_ops {
-            let sync_op = op.clone().into_sync().unwrap();
-            let timestamp = UndoDiff::apply_op(&mut current, &sync_op);
-            if when == None {
-                when = timestamp;
-            }
-        }
-
-        for sync_op in &undo.rev_ops {
-            UndoDiff::apply_op(&mut prior, sync_op);
-        }
-
-        UndoDiff {
-            current,
-            prior,
-            when: when.unwrap(),
-        }
     }
 
-    fn apply_op(task: &mut TaskMap, op: &SyncOp) -> Option<DateTime<Utc>> {
-        match op {
-            SyncOp::Create { uuid } => {
-                task.insert("uuid".to_string(), uuid.to_string());
-                None
-            }
-            SyncOp::Delete { .. } => {
-                task.clear();
-                None
-            }
-            SyncOp::Update {
-                property,
-                value: Some(value),
-                timestamp,
-                ..
-            } => {
-                task.insert(property.to_string(), value.to_string());
-                Some(*timestamp)
-            }
-            SyncOp::Update {
-                property,
-                value: None,
-                timestamp,
-                ..
-            } => {
-                task.remove(property);
-                Some(*timestamp)
-            }
-        }
-    }
-}
-
-pub fn undo<F>(txn: &mut dyn StorageTxn, condition: F) -> Result<bool>
-where
-    F: Fn(UndoDiff) -> bool,
-{
-    let mut applied = false;
-    let proposed_undo = Undo::new(txn);
-    let undo_diff = UndoDiff::new(&proposed_undo);
-
-    if condition(undo_diff) {
-        applied = proposed_undo.commit()?;
+    if undo_len != 0 {
+        txn.set_operations(local_ops)?;
+        txn.commit()?;
     }
 
     Ok(applied)

--- a/taskchampion/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/taskchampion/src/taskdb/undo.rs
@@ -1,12 +1,7 @@
 use super::apply;
 use crate::errors::Result;
 use crate::storage::{ReplicaOp, StorageTxn};
-
-// Adapted from https://stackoverflow.com/a/67105052/1938621
-#[cfg(not(test))]
-use log::{debug, info, trace}; // Use log crate when building application
-#[cfg(test)]
-use std::{println as debug, println as info, println as trace}; // Workaround to use prinltn! for logs.
+use log::{debug, info, trace};
 
 /// Local operations until the most recent UndoPoint.
 pub fn get_undo_ops(txn: &mut dyn StorageTxn) -> Result<Vec<ReplicaOp>> {
@@ -23,7 +18,7 @@ pub fn get_undo_ops(txn: &mut dyn StorageTxn) -> Result<Vec<ReplicaOp>> {
     Ok(undo_ops)
 }
 
-/// Commit operations to storage.
+/// Commit operations to storage, returning a boolean indicating success.
 pub fn commit_undo_ops(txn: &mut dyn StorageTxn, mut undo_ops: Vec<ReplicaOp>) -> Result<bool> {
     let mut applied = false;
     let mut local_ops = txn.operations().unwrap();

--- a/test/undo.t
+++ b/test/undo.t
@@ -74,7 +74,6 @@ class TestUndoStyle(TestCase):
         self.t("add one project:foo priority:H")
         self.t("1 modify +tag project:bar priority:")
 
-    @unittest.expectedFailure  # undo diffs are not supported
     def test_undo_side_style(self):
         """Test that 'rc.undo.style:side' generates the right output"""
         self.t.config("undo.style", "side")
@@ -82,7 +81,6 @@ class TestUndoStyle(TestCase):
         self.assertNotRegex(out, "-tags:\s*\n\+tags:\s+tag")
         self.assertRegex(out, "tags\s+tag\s*")
 
-    @unittest.expectedFailure  # undo diffs are not supported
     def test_undo_diff_style(self):
         """Test that 'rc.undo.style:diff' generates the right output"""
         self.t.config("undo.style", "diff")

--- a/test/undo.t
+++ b/test/undo.t
@@ -97,7 +97,7 @@ class TestUndoStyle(TestCase):
         # fifth operation setting the `modified` property.
         self.assertRegex(out, "The following [4|5] operations would be reverted:")
 
-        self.assertIn("tags_tag: <empty> -> x", out)
+        self.assertIn("tag_tag: <empty> -> x", out)
         self.assertIn("tags: <empty> -> tag", out)
         self.assertIn("project: foo -> bar", out)
         self.assertIn("priority: H -> <empty>", out)

--- a/test/undo.t
+++ b/test/undo.t
@@ -90,6 +90,14 @@ class TestUndoStyle(TestCase):
         self.assertRegex(out, "-tags:\s*\n\+tags:\s+tag")
         self.assertNotRegex(out, "tags\s+tag\s*")
 
+    def test_undo_diff_operations(self):
+        code, out, err = self.t("undo", input="n\n")
+        self.assertIn("The following 4 operations would be reverted:", out)
+        self.assertIn("tags_tag: <empty> -> x", out)
+        self.assertIn("tags: <empty> -> tag", out)
+        self.assertIn("project: foo -> bar", out)
+        self.assertIn("priority: H -> <empty>", out)
+
 
 class TestBug634(TestCase):
     def setUp(self):

--- a/test/undo.t
+++ b/test/undo.t
@@ -74,6 +74,7 @@ class TestUndoStyle(TestCase):
         self.t("add one project:foo priority:H")
         self.t("1 modify +tag project:bar priority:")
 
+    @unittest.expectedFailure # undo diffs are not supported
     def test_undo_side_style(self):
         """Test that 'rc.undo.style:side' generates the right output"""
         self.t.config("undo.style", "side")
@@ -81,6 +82,7 @@ class TestUndoStyle(TestCase):
         self.assertNotRegex(out, "-tags:\s*\n\+tags:\s+tag")
         self.assertRegex(out, "tags\s+tag\s*")
 
+    @unittest.expectedFailure # undo diffs are not supported
     def test_undo_diff_style(self):
         """Test that 'rc.undo.style:diff' generates the right output"""
         self.t.config("undo.style", "diff")

--- a/test/undo.t
+++ b/test/undo.t
@@ -92,7 +92,11 @@ class TestUndoStyle(TestCase):
 
     def test_undo_diff_operations(self):
         code, out, err = self.t("undo", input="n\n")
-        self.assertIn("The following 4 operations would be reverted:", out)
+
+        # If the clock ticks a second between `add` and `modify` there is a
+        # fifth operation setting the `modified` property.
+        self.assertRegex(out, "The following [4|5] operations would be reverted:")
+
         self.assertIn("tags_tag: <empty> -> x", out)
         self.assertIn("tags: <empty> -> tag", out)
         self.assertIn("project: foo -> bar", out)


### PR DESCRIPTION
#### Description

A start at phase 1 of GothenburgBitFactory/taskchampion#373. The rust compiles but the C++ does not yet. I was hoping to solicit some high-level guidance before proceeding, namely:

1. Does the callback approach make sense?
  a. I originally started looking at this approach when i realized that the use of dynamic storage backends (`TaskDb.storage`) seems to mean that no transaction could outlive a method (without cloning).
  b. I don't know how Storage is generally guarded against race conditions but the callback method seems like it will take care of this concern.
2. What is the best way to pass the data (`UndoDiff`) through ffi? For example, should I pass the values separately or can I pass the whole struct? Should I serialize it deep in taskchampion (undo.rs) or at the interface (taskchampion/lib/src/replica.rs)? I'm under the vague impression that as long as the data is typed with the right traits the necessary transformations to pass through ffi happen automatically...at least it seems like it could/should work that way.

#### Additional information...

- [X] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [X] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
