### PR TITLE
xtask msrv: this subcommand is not capitalized

### DIFF
--- a/taskchampion/xtask/src/main.rs
+++ b/taskchampion/xtask/src/main.rs
@@ -58,7 +58,7 @@ fn codegen(workspace_dir: &Path) -> anyhow::Result<()> {
 fn msrv(args: Vec<String>, workspace_dir: &Path) -> anyhow::Result<()> {
     // check that (X.Y) argument is (mostly) valid:
     if args.len() < 3 || !args[2].chars().all(|c| c.is_numeric() || c == '.') {
-        anyhow::bail!("xtask: Invalid argument format. Xtask MSRV argument takes the form \"X.Y(y)\", where XYy are numbers. eg: `cargo run xtask MSRV 1.68`");
+        anyhow::bail!("xtask: Invalid argument format. Xtask msrv argument takes the form \"X.Y(y)\", where XYy are numbers. eg: `cargo run xtask msrv 1.68`");
     }
     let version_replacement_string = &args[2];
 


### PR DESCRIPTION
    $ cargo xtask MSRV 1.99
        Finished dev [unoptimized + debuginfo] target(s) in 0.21s
         Running `target/debug/xtask MSRV 1.99`
    Error: xtask: unknown xtask
    $ cargo xtask msrv 1.99
        Finished dev [unoptimized + debuginfo] target(s) in 0.21s
         Running `target/debug/xtask msrv 1.99`
    xtask: Updated MSRV in ../.github/workflows/checks.yml
    xtask: Updated MSRV in ../.github/workflows/rust-tests.yml
    xtask: Updated MSRV in taskchampion/src/lib.rs
    xtask: Updated MSRV in taskchampion/Cargo.toml

#### Description

Replace this text with a description of the PR.

#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [ ] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
