### PR TITLE
Disable Clang's return-type-c-linkage warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,9 @@ if (SOLARIS)
 endif (SOLARIS)
 
 # Disable the Clang return-type-c-linkage warning globally. See #3225.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-return-type-c-linkage>")
+if (CXX_COMPILER_ID EQUAL "Clang" OR CXX_COMPILER_ID EQUAL "AppleClang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type-c-linkage")
+endif (CXX_COMPILER_ID EQUAL "Clang" OR CXX_COMPILER_ID EQUAL "AppleClang")
 
 message ("-- Configuring cmake.h")
 configure_file (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ if (SOLARIS)
   endif (NSL_LIBRARY)
 endif (SOLARIS)
 
+# Disable the Clang return-type-c-linkage warning globally. See #3225.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-return-type-c-linkage>")
+
 message ("-- Configuring cmake.h")
 configure_file (
   ${CMAKE_SOURCE_DIR}/cmake.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,9 +126,9 @@ if (SOLARIS)
 endif (SOLARIS)
 
 # Disable the Clang return-type-c-linkage warning globally. See #3225.
-if (CXX_COMPILER_ID EQUAL "Clang" OR CXX_COMPILER_ID EQUAL "AppleClang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type-c-linkage")
-endif (CXX_COMPILER_ID EQUAL "Clang" OR CXX_COMPILER_ID EQUAL "AppleClang")
+endif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 
 message ("-- Configuring cmake.h")
 configure_file (


### PR DESCRIPTION
#### Description

Hopefully this makes the mac builders (which I think use Clang?) happier.
