### PR TITLE
Disable mac tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,7 @@ jobs:
   # MacOS tests do not run in Docker, and use the actions-rs Rust installaction
   tests-macos-12:
     name: tests (Mac OS 12.latest)
+    if: false # see #3242
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tests-macos-13:
     name: tests (Mac OS 13.latest)
+    if: false # see #3242
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
These workflows frequently fail with SIGABRT, such as in https://github.com/GothenburgBitFactory/taskwarrior/actions/runs/7535473090/job/20511503463?pr=3241. That PR did not change anything related to the failing tests, and this occurs even with PRs that do not change code.

In the absence of developer resources to debug the issue with the runners, let's disable these tests so that we don't continue to spend time trying to figure out why innocent PRs are failing. This will also save some CI costs, although I'm not sure those are an issue for this repository.