### PR TITLE
Better links from TW devel docs to TaskChampion

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This directory contains Taskwarrior that is built and installed along with the executable:
+This directory contains Taskwarrior documentation that is built and installed along with the executable:
 
 * [`man`](man/) contains the source for the Taskwarrior manual pages.
 * [`rc`](rc/) contains rcfiles that will be installed in `/usr/share/doc/task/rc` or equivalent.

--- a/doc/devel/README.md
+++ b/doc/devel/README.md
@@ -5,3 +5,16 @@ For all other documenation, see https://taskwarrior.org.
 
  * [Contributing To Taskwarrior](contrib/README.md)
  * [Taskwarrior RFCs](rfcs/README.md)
+
+## Taskwarrior and TaskChampion
+
+As of the 3.0 release, Taskwarrior uses TaskChampion to manage task data.
+Find documentation of TaskChampion here:
+
+ * [TaskChampion README](../../taskchampion)
+ * [TaskChampion CONTRIBUTING guide](../../taskchampion/CONTRIBUTING.md)
+ * [TaskChampion Book](../../taskchampion/docs/src/SUMMARY.md)
+ * [TaskChampion API Documentation](https://docs.rs/taskchampion)
+
+TaskChampion will [become its own
+project](https://github.com/GothenburgBitFactory/taskwarrior/issues/3209) soon.

--- a/doc/devel/contrib/development.md
+++ b/doc/devel/contrib/development.md
@@ -1,5 +1,12 @@
 # Developing Taskwarrior
 
+The following describes the process for developing Taskwarrior. If you are only
+changing TaskChampion (Rust code), you can simply treat it like any other Rust
+project: modify the source under `taskchampion/` and use `cargo test` to run
+the TaskChampion tests.
+
+See the [TaskChampion CONTRIBUTING guide](../../../taskchampion/CONTRIBUTING.md) for more.
+
 ## Satisfy the Requirements:
 
  * CMake 3.0 or later

--- a/doc/devel/contrib/rust-and-c++.md
+++ b/doc/devel/contrib/rust-and-c++.md
@@ -15,7 +15,7 @@ Other applications, besides Taskwarrior, can use TaskChampion to manage tasks.
 Applications written in Rust can use the `taskchampion` crate, while those in other languages may use the `taskchampion-lib` crate.
 Taskwarrior is just one application using the TaskChampion interface.
 
-You can build Taskchampion locally by simply running `cargo build` in the root of this repository.
+You can build TaskChampion locally by simply running `cargo build` in the root of this repository.
 The implementation, including more documentation, is in the [`rust`](../../rust) subdirectory.
 
 ## Taskwarrior's use of TaskChampion

--- a/doc/man/task-sync.5.in
+++ b/doc/man/task-sync.5.in
@@ -98,7 +98,7 @@ The default configuration is to sync to a database in the task directory
 
 .SH RUNNING TASKCHAMPION-SYNC-SERVER
 
-The Taskchampion sync server is an HTTP server supporting multiple users.
+The TaskChampion sync server is an HTTP server supporting multiple users.
 Users are identified by a client ID, and users with different client IDs are
 entirely independent.  Task data is encrypted by Taskwarrior, and the sync
 server never sees un-encrypted data.

--- a/taskchampion/integration-tests/README.md
+++ b/taskchampion/integration-tests/README.md
@@ -1,4 +1,4 @@
-# Integration Tests for Taskchampion
+# Integration Tests for TaskChampion
 
 ## "Regular" Tests
 


### PR DESCRIPTION
This should help newcomers to the project to navigate the TW/TC distinction and find the relevant code, especially when 3.0 is released.

Fixe #2868.