### PR TITLE
Change 'should' to 'may' in server snapshot requirements

### DIFF
--- a/taskchampion/docs/src/sync-protocol.md
+++ b/taskchampion/docs/src/sync-protocol.md
@@ -102,7 +102,7 @@ The request contains the following:
  * version ID at which the snapshot was made, and
  * encrypted snapshot data.
 
-The server should validate that the snapshot is for an existing version and is newer than any existing snapshot.
+The server may validate that the snapshot is for an existing version and is newer than any existing snapshot.
 It may also validate that the snapshot is for a "recent" version (e.g., one of the last 5 versions).
 If a snapshot already exists for the given version, the server may keep or discard the new snapshot but should return a success indication to the client.
 


### PR DESCRIPTION
For an object store backend, none of the suggestions in this paragraph make much sense. "May" is much softer, in terms of https://datatracker.ietf.org/doc/html/rfc2119. And in particular, the cloud server implementation does not do any of these things.

Fixes #3222, and replaces #3247.