### PR TITLE
taskchampion: fix incorrect tag prefix: tag_ -> tags_

### DIFF
--- a/taskchampion/docs/src/tasks.md
+++ b/taskchampion/docs/src/tasks.md
@@ -38,7 +38,7 @@ The following keys, and key formats, are defined:
 * `modified` - the time of the last modification of this task
 * `start` - the most recent time at which this task was started (a task with no `start` key is not active)
 * `end` - if present, the time at which this task was completed or deleted (note that this key may not agree with `status`: it may be present for a pending task, or absent for a deleted or completed task)
-* `tag_<tag>` - indicates this task has tag `<tag>` (value is ignored)
+* `tags_<tag>` - indicates this task has tag `<tag>` (value is ignored)
 * `wait` - indicates the time before which this task should be hidden, as it is not actionable
 * `entry` - the time at which the task was created
 * `annotation_<timestamp>` - value is an annotation created at the given time; for example, `annotation_1693329505`.

--- a/taskchampion/integration-tests/src/bindings_tests/task.c
+++ b/taskchampion/integration-tests/src/bindings_tests/task.c
@@ -637,7 +637,7 @@ static void test_task_taskmap(void) {
 
     TCKVList taskmap = tc_task_get_taskmap(task);
     tckvlist_assert_key(&taskmap, "annotation_1644623411", "ann1");
-    tckvlist_assert_key(&taskmap, "tag_next", "");
+    tckvlist_assert_key(&taskmap, "tags_next", "");
     tckvlist_assert_key(&taskmap, "status", "pending");
     tckvlist_assert_key(&taskmap, "description", "my task");
     tc_kv_list_free(&taskmap);


### PR DESCRIPTION
### Description
Taskwarrior uses tags_ as a tag prefix, modified taskchampion so it does the same

Fixes #3254 

### modified:
- taskchampion source
- tests
- documentation
- [X] I changed Rust code or build infrastructure.