### PR TITLE
use CMake project settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required (VERSION 3.22)
+
+project (task
+  VERSION 3.0.0
+  DESCRIPTION "Taskwarrior - a command-line TODO list manager"
+  HOMEPAGE_URL https://taskwarrior.org/)
+
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 include (FetchContent)
@@ -7,10 +13,7 @@ include (CheckStructHasMember)
 
 set (HAVE_CMAKE true)
 
-project (task)
 include (CXXSniffer)
-
-set (PROJECT_VERSION "3.0.0")
 
 OPTION (ENABLE_WASM "Enable 'wasm' support" OFF)
 


### PR DESCRIPTION
This adds a description as well as the homepage to the CMake settings. Further it would also now use the numbering scheme as supposed to in CMake, this way other people could now pin a specific version if taskwarrior is included in another project.
Documentation from CMake is https://cmake.org/cmake/help/latest/command/project.html

#### Additional information...

- [X] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.
```sh
❯ ./problems
/home/felix/data/taskwarrior/build-test/test/./problems:55: SyntaxWarning: invalid escape sequence '\S'
  file = re.compile("^# (?:./)?(\S+\.t)(?:\.exe)?$")
/home/felix/data/taskwarrior/build-test/test/./problems:56: SyntaxWarning: invalid escape sequence '\d'
  timestamp = re.compile("^# (\d+(?:\.\d+)?) ==>.*$")
Failed:                        

Unexpected successes:          

Skipped:                       

Expected failures:             
lexer.t                             4
```
