### PR TITLE
Issue a warning if .data files remain

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -62,9 +62,8 @@ void TDB2::open_replica (const std::string& location, bool create_if_missing)
     Color warning = Color (Context::getContext ().config.get ("color.warning"));
     std::cout << warning.colorize (
       format ("Found existing '.data' files in {1}", location)) << "\n";
-    std::cout << "  Taskwarrior's storage format changed in 3.0.\n";
+    std::cout << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
     std::cout << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
-    std::cout << "  Remove the files to silence this warning.\n\n";
   }
   replica = tc::Replica(location, create_if_missing);
 }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -57,6 +57,15 @@ TDB2::TDB2 ()
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::open_replica (const std::string& location, bool create_if_missing)
 {
+  File pending_data = File (location + "/pending.data");
+  if (pending_data.exists()) {
+    Color warning = Color (Context::getContext ().config.get ("color.warning"));
+    std::cout << warning.colorize (
+      format ("Found existing '.data' files in {1}", location)) << "\n";
+    std::cout << "  Taskwarrior's storage format changed in 3.0.\n";
+    std::cout << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
+    std::cout << "  Remove the files to silence this warning.\n\n";
+  }
   replica = tc::Replica(location, create_if_missing);
 }
 

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -60,10 +60,10 @@ void TDB2::open_replica (const std::string& location, bool create_if_missing)
   File pending_data = File (location + "/pending.data");
   if (pending_data.exists()) {
     Color warning = Color (Context::getContext ().config.get ("color.warning"));
-    std::cout << warning.colorize (
+    std::cerr << warning.colorize (
       format ("Found existing '.data' files in {1}", location)) << "\n";
-    std::cout << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
-    std::cout << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
+    std::cerr << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
+    std::cerr << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
   }
   replica = tc::Replica(location, create_if_missing);
 }


### PR DESCRIPTION
This will help users realize that they have updated to an incompatible version and must export and import their tasks.
