### PR TITLE
prefix regex strings to be treated as raw strings

### DIFF
--- a/test/problems
+++ b/test/problems
@@ -52,8 +52,8 @@ if __name__ == "__main__":
     unexpected = defaultdict(int)
     passed = defaultdict(int)
 
-    file = re.compile("^# (?:./)?(\S+\.t)(?:\.exe)?$")
-    timestamp = re.compile("^# (\d+(?:\.\d+)?) ==>.*$")
+    file = re.compile(r"^# (?:./)?(\S+\.t)(?:\.exe)?$")
+    timestamp = re.compile(r"^# (\d+(?:\.\d+)?) ==>.*$")
 
     expected_fail = re.compile(r"^not ok.*?#\s*TODO", re.I)
     unexpected_pass = re.compile(r"^not ok .*?#\s*FIXED", re.I)


### PR DESCRIPTION
Source for documentation
https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals.
Closes #3316.

#### Description

Replace this text with a description of the PR.

#### Additional information...

- [x] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

```sh
❯ ./run_all
Passed:                          2700
Failed:                             0
Unexpected successes:               0
Skipped:                            0
Expected failures:                  4
Runtime:                         1.94 seconds
For details run 'make problems'
❯ ./problems
Failed:

Unexpected successes:

Skipped:

Expected failures:
lexer.t                             4
```
