### PR TITLE
change order of hook invocation and setting task id

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -87,7 +87,7 @@ void TDB2::add (Task& task)
     for (auto& attr : task.all ()) {
       // TaskChampion does not store uuid or id in the taskmap
       if (attr == "uuid" || attr == "id") {
-        continue; 
+        continue;
       }
 
       // Use `set_status` for the task status, to get expected behavior
@@ -118,12 +118,13 @@ void TDB2::add (Task& task)
   // update the cached working set with the new information
   _working_set = std::make_optional (std::move (ws));
 
-  if (id.has_value ()) {
-    task.id = id.value();
-  }
-
   // run hooks for this new task
   Context::getContext ().hooks.onAdd (task);
+
+  if (id.has_value ()) {
+      task.id = id.value();
+  }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
this prevents that the task id is always returned as zero after a hook
is run on it
closes #3312

#### Additional information...

- [X] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

```sh
❯ ./run_all
Passed:                          2700
Failed:                             0
Unexpected successes:               0
Skipped:                            0
Expected failures:                  4
Runtime:                         0.98 seconds
For details run 'make problems'
❯ ./problems
Failed:

Unexpected successes:

Skipped:

Expected failures:
lexer.t                             4
```
