### PR TITLE
Install corrosion as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/libshared"]
 	path = src/libshared
 	url = https://github.com/GothenburgBitFactory/libshared.git
+[submodule "src/tc/corrosion"]
+	path = src/tc/corrosion
+	url = https://github.com/corrosion-rs/corrosion.git

--- a/src/tc/CMakeLists.txt
+++ b/src/tc/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required (VERSION 3.22)
 
-FetchContent_Declare (
-    Corrosion
-    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.4.7
-)
-FetchContent_MakeAvailable(Corrosion)
+add_subdirectory(${CMAKE_SOURCE_DIR}/src/tc/corrosion)
 
 # Import taskchampion-lib as a CMake library.
 corrosion_import_crate(


### PR DESCRIPTION
#### Description

This will enable nixpkgs -- and any other distribution that builds in a network sandbox and/or wants to use their own corrosion package rather than building another one -- to do so without patching taskwarrior.

Since we're already using submodules for libshared I don't think this should make the build process any more complicated for anyone else.

See
https://github.com/NixOS/nixpkgs/issues/300679#issuecomment-2041252688 for context.

#### Additional information...

- [X] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd test && ./problems`.

- [X] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
