### PR TITLE
Store all modified tasks for use by on-exit hook

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#include <vector>
 #include <list>
 #include <unordered_set>
 #include <stdlib.h>
@@ -78,6 +79,8 @@ void TDB2::add (Task& task)
   task.validate (true);
 
   std::string uuid = task.get ("uuid");
+  changes[uuid] = task;
+
   auto innertask = replica.import_task_with_uuid (uuid);
 
   {
@@ -150,6 +153,8 @@ void TDB2::modify (Task& task)
   task.validate (false);
   auto uuid = task.get ("uuid");
 
+  changes[uuid] = task;
+
 	// invoke the hook and allow it to modify the task before updating
   Task original;
   get (uuid, original);
@@ -209,9 +214,10 @@ const tc::WorkingSet &TDB2::working_set ()
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::get_changes (std::vector <Task>& changes)
 {
-  // TODO: changes in an invocation of `task` are not currently tracked, so this
-  // list is always empty.
+  std::map<std::string, Task>& changes_map = this->changes;
   changes.clear();
+  std::transform(changes_map.begin(), changes_map.end(), std::back_inserter(changes),
+                 [](const auto& kv) { return kv.second; });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -84,6 +84,9 @@ private:
   tc::Replica replica;
   std::optional<tc::WorkingSet> _working_set;
 
+  // UUID -> Task containing all tasks modified in this invocation.
+  std::map<std::string, Task> changes;
+
   const tc::WorkingSet &working_set ();
   static std::string option_string (std::string input);
   static void show_diff (const std::string&, const std::string&, const std::string&);

--- a/test/hooks.on-exit.t
+++ b/test/hooks.on-exit.t
@@ -56,6 +56,22 @@ class TestHooksOnExit(TestCase):
         logs = hook.get_logs()
         self.assertEqual(logs["output"]["msgs"][0], "FEEDBACK")
 
+    def test_onexit_builtin_good_gets_changed_tasks(self):
+        """on-exit-good - a well-behaved, successful, on-exit hook."""
+        hookname = 'on-exit-good'
+        self.t.hooks.add_default(hookname, log=True)
+
+        code, out, err = self.t("add foo")
+        self.assertIn("Created task", out)
+
+        hook = self.t.hooks[hookname]
+        hook.assertTriggeredCount(1)
+        hook.assertExitcode(0)
+
+        logs = hook.get_logs()
+        self.assertEqual(logs["output"]["msgs"][0], "CHANGED TASK")
+        self.assertEqual(logs["output"]["msgs"][1], "FEEDBACK")
+
     def test_onexit_builtin_bad(self):
         """on-exit-bad - a well-behaved, failing, on-exit hook."""
         hookname = 'on-exit-bad'


### PR DESCRIPTION
The on-exit hook gets all modified tasks as input, but this was omitted in the previous release. This adds a test for the desired behavior, and updates TDB2 to correctly store the required information.

Fixes #3327.