### PR TITLE
Recommend LSP's in development docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.22)
 
+set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 project (task
   VERSION 3.0.0
   DESCRIPTION "Taskwarrior - a command-line TODO list manager"

--- a/doc/devel/contrib/development.md
+++ b/doc/devel/contrib/development.md
@@ -12,8 +12,12 @@ See the [TaskChampion CONTRIBUTING guide](../../../taskchampion/CONTRIBUTING.md)
  * CMake 3.0 or later
  * gcc 7.0 or later, clang 6.0 or later, or a compiler with full C++17 support
  * libuuid (if not on macOS)
- * python 3 (optional, for running the test suite)
  * Rust 1.64.0 or higher (hint: use https://rustup.rs/ instead of using your system's package manager)
+
+## Install Optional Dependencies:
+ * python 3 (for running the test suite)
+ * clangd or ccls (for C++ integration in many editors)
+ * rust-analyzer (for Rust integration in many editors)
 
 ## Obtain and Build Code:
 The following documentation works with CMake 3.14 and later.
@@ -24,7 +28,7 @@ See the general CMake man pages or the [cmake-documentation](https://cmake.org/c
 ```sh
 git clone https://github.com/GothenburgBitFactory/taskwarrior
 cd taskwarrior
-cmake -S . -B build  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 cmake --build build
 ```
 Other possible build types can be `Release` and `Debug`.

--- a/doc/devel/contrib/development.md
+++ b/doc/devel/contrib/development.md
@@ -28,7 +28,7 @@ See the general CMake man pages or the [cmake-documentation](https://cmake.org/c
 ```sh
 git clone https://github.com/GothenburgBitFactory/taskwarrior
 cd taskwarrior
-cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build
 ```
 Other possible build types can be `Release` and `Debug`.


### PR DESCRIPTION
Per conversation in #3338.

There are already a lot of documented compile options so I think we're better off suggesting that everybody create a compile_commands.json whether or not they're using an LSP because it doesn't cost much.

While I was at it it seemed reasonable to mention rust LSP too. Now that rls is deprecated I'm not sure there is any competitor to rust-analyzer worth mentioning.