### PR TITLE
update '.data' warning message to '*.data' for better readability

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -62,7 +62,7 @@ void TDB2::open_replica (const std::string& location, bool create_if_missing)
   if (pending_data.exists()) {
     Color warning = Color (Context::getContext ().config.get ("color.warning"));
     std::cerr << warning.colorize (
-      format ("Found existing '.data' files in {1}", location)) << "\n";
+      format ("Found existing '*.data' files in {1}", location)) << "\n";
     std::cerr << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
     std::cerr << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
   }


### PR DESCRIPTION
…es #3406

#### Description

- Update `"Found existing '.data' files in {1}"` to `"Found existing '*.data' files in {1}"` for better readability and preventing misinterpretation.

#### Additional information...

- [x] I changed C++ code or build infrastructure.
  Could not get a build to work locally but the CI tests look good to me.

- [ ] I changed Rust code or build infrastructure.