### PR TITLE
add targets for individual tests

### DIFF
--- a/doc/devel/contrib/development.md
+++ b/doc/devel/contrib/development.md
@@ -56,7 +56,7 @@ First switch to the test directory:
 ```
 Then you can run all tests, showing details, with
 ```
-    $ make VERBOSE=1
+    $ make VERBOSE=1 test
 ```
 Alternately, run the tests with the details hidden in `all.log`:
 ```
@@ -65,6 +65,10 @@ Alternately, run the tests with the details hidden in `all.log`:
 Either way, you can get a summary of any test failures with:
 ```
     $ ./problems
+```
+You can run a single test suite, with source file `foo.test.cpp` or `foo.test.py`, with
+```
+    $ make foo.test
 ```
 
 Note that any development should be performed using a git clone, and the current development branch.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,13 @@ foreach (src_FILE ${test_SRCS})
   if (DARWIN)
     target_link_libraries (${src_FILE} "-framework CoreFoundation -framework Security -framework SystemConfiguration")
   endif (DARWIN)
+
+  # Add a custom `foo.test` target.
+  string(REGEX REPLACE "\\.[^.]*$" "" test_target ${src_FILE})
+  add_custom_target (${test_target}
+                     ./${src_FILE}
+                     DEPENDS ${src_FILE}
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test)
 endforeach (src_FILE)
 
 configure_file(run_all run_all COPYONLY)
@@ -197,6 +204,13 @@ set (pythonTests
 
 foreach (python_Test ${pythonTests})
   configure_file(${python_Test} ${python_Test} COPYONLY)
+
+  # Add a custom `foo.test` target.
+  string(REGEX REPLACE "\\.[^.]*$" "" test_target ${python_Test})
+  add_custom_target (${test_target}
+                     ./${python_Test}
+                     DEPENDS ${python_Test}
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test)
 endforeach(python_Test)
 
 #SET(CMAKE_BUILD_TYPE gcov)


### PR DESCRIPTION
This means you can do `make -Cbuild verbose.test` and it will run just that test.

cc @felixschurk - WDYT?