### PR TITLE
Fix SyntaxWarning invalid escape sequence in Python code

### DIFF
--- a/performance/compare_runs.py
+++ b/performance/compare_runs.py
@@ -29,7 +29,7 @@ def parse_perf(input):
         tests[command] = []
 
         # Parse concatenated run_perf output
-        for i in re.findall("^  - task %s\.\.\.\n"
+        for i in re.findall("^  - task %s\\.\\.\\.\n"
                             "Perf task ([^ ]+) ([^ ]+) ([^ ]+) (.+)$"
                             % command, input, re.MULTILINE):
             info = i[0:3] + ({k:v for k, v in (i.split(":") for i in i[-1].split())},)

--- a/test/alias.test.py
+++ b/test/alias.test.py
@@ -171,7 +171,7 @@ class TestBug1031(TestCase):
         self.t("add from")
         code, out, err = self.t("1 info")
 
-        expected = "Description\s+to"
+        expected = r"Description\s+to"
         self.assertRegex(out, expected)
 
     def test_alias_to_to(self):
@@ -179,7 +179,7 @@ class TestBug1031(TestCase):
         self.t("add from -- to")
         code, out, err = self.t("1 info")
 
-        expected = "Description\s+to to"
+        expected = r"Description\s+to to"
         self.assertRegex(out, expected)
 
     def test_alias_to_from(self):
@@ -187,7 +187,7 @@ class TestBug1031(TestCase):
         self.t("add to -- from")
         code, out, err = self.t("1 info")
 
-        expected = "Description\s+to from"
+        expected = r"Description\s+to from"
         self.assertRegex(out, expected)
 
 

--- a/test/annotate.test.py
+++ b/test/annotate.test.py
@@ -87,17 +87,17 @@ class TestAnnotate(TestCase):
 
         self.assertTasksExist(out)
 
-        self.assertRegex(out, "one\n.+\d{1,2}/\d{1,2}/\d{4}\s+foo1",
+        self.assertRegex(out, "one\n.+\\d{1,2}/\\d{1,2}/\\d{4}\\s+foo1",
                                  msg='full - first  annotation task 1')
-        self.assertRegex(out, "foo1\n.+\d{1,2}/\d{1,2}/\d{4}\s+foo2",
+        self.assertRegex(out, "foo1\n.+\\d{1,2}/\\d{1,2}/\\d{4}\\s+foo2",
                                  msg='full - first  annotation task 1')
-        self.assertRegex(out, "foo2\n.+\d{1,2}/\d{1,2}/\d{4}\s+foo3",
+        self.assertRegex(out, "foo2\n.+\\d{1,2}/\\d{1,2}/\\d{4}\\s+foo3",
                                  msg='full - first  annotation task 1')
-        self.assertRegex(out, "two\n.+\d{1,2}/\d{1,2}/\d{4}\s+bar1",
+        self.assertRegex(out, "two\n.+\\d{1,2}/\\d{1,2}/\\d{4}\\s+bar1",
                                  msg='full - first  annotation task 1')
-        self.assertRegex(out, "bar1\n.+\d{1,2}/\d{1,2}/\d{4}\s+bar2",
+        self.assertRegex(out, "bar1\n.+\\d{1,2}/\\d{1,2}/\\d{4}\\s+bar2",
                                  msg='full - first  annotation task 1')
-        self.assertRegex(out, "three\n.+\d{1,2}/\d{1,2}/\d{4}\s+baz1",
+        self.assertRegex(out, "three\n.+\\d{1,2}/\\d{1,2}/\\d{4}\\s+baz1",
                                  msg='full - first  annotation task 1')
 
     def test_annotate_dateformat(self):
@@ -114,17 +114,17 @@ class TestAnnotate(TestCase):
 
         self.assertTasksExist(out)
 
-        self.assertRegex(out, "one\n.+\d{1,6}\s+\d{1,6}\s+foo1",
+        self.assertRegex(out, "one\n.+\\d{1,6}\\s+\\d{1,6}\\s+foo1",
                                  msg="dateformat - first  annotation task 1")
-        self.assertRegex(out, "foo1\n.+\d{1,6}\s+\d{1,6}\s+foo2",
+        self.assertRegex(out, "foo1\n.+\\d{1,6}\\s+\\d{1,6}\\s+foo2",
                                  msg="dateformat - second  annotation task 1")
-        self.assertRegex(out, "foo2\n.+\d{1,6}\s+\d{1,6}\s+foo3",
+        self.assertRegex(out, "foo2\n.+\\d{1,6}\\s+\\d{1,6}\\s+foo3",
                                  msg="dateformat - third  annotation task 1")
-        self.assertRegex(out, "two\n.+\d{1,6}\s+\d{1,6}\s+bar1",
+        self.assertRegex(out, "two\n.+\\d{1,6}\\s+\\d{1,6}\\s+bar1",
                                  msg="dateformat - first  annotation task 2")
-        self.assertRegex(out, "bar1\n.+\d{1,6}\s+\d{1,6}\s+bar2",
+        self.assertRegex(out, "bar1\n.+\\d{1,6}\\s+\\d{1,6}\\s+bar2",
                                  msg="dateformat - second  annotation task 2")
-        self.assertRegex(out, "three\n.+\d{1,6}\s+\d{1,6}\s+baz1",
+        self.assertRegex(out, "three\n.+\\d{1,6}\\s+\\d{1,6}\\s+baz1",
                                  msg="dateformat - first  annotation task 3")
 
 class TestAnnotationPropagation(TestCase):

--- a/test/append.test.py
+++ b/test/append.test.py
@@ -50,7 +50,7 @@ class TestAppend(TestCase):
 
         code, out, err = self.t("info 1")
 
-        expected = "Description\s+foo\sbar\n"
+        expected = "Description\\s+foo\\sbar\n"
         self.assertRegex(out, expected)
 
     def test_append_error_on_empty(self):
@@ -82,10 +82,10 @@ class TestBug440(TestCase):
         code2, out2, err2 = self.t("2 ls")
 
         self.assertNotIn("Foo", out1)
-        self.assertRegex(out1, "\w+ Appendtext")
+        self.assertRegex(out1, r"\w+ Appendtext")
 
         self.assertNotIn("Foo", out2)
-        self.assertRegex(out2, "\w+ Appendtext")
+        self.assertRegex(out2, r"\w+ Appendtext")
 
 
 if __name__ == "__main__":

--- a/test/calc.test.py
+++ b/test/calc.test.py
@@ -90,7 +90,7 @@ class TestCalc(TestCase):
         """version"""
         code, out, err = run_cmd_wait_nofail((CALC, "--version"))
 
-        self.assertRegex(out, "calc \d\.\d+\.\d+")
+        self.assertRegex(out, r"calc \d\.\d+\.\d+")
         self.assertIn("Copyright", out)
         self.assertGreaterEqual(code, 1)
 

--- a/test/color.cmd.test.py
+++ b/test/color.cmd.test.py
@@ -63,17 +63,17 @@ class TestColorCommand(TestCase):
     def test_colors_sample(self):
         """ Verify 'task colors red' shows a sample"""
         code, out, err = self.t("colors rc._forcecolor:on red")
-        self.assertRegex(out, "Your sample:\n\n  .\[31mtask color red.\[0m")
+        self.assertRegex(out, "Your sample:\n\n  .\\[31mtask color red.\\[0m")
 
     def test_colors_legend(self):
         """ Verify 'task colors legend' shows theme colors"""
         code, out, err = self.t("colors rc._forcecolor:on legend")
-        self.assertRegex(out, "color.debug\s+.\[0m\s.\[38;5;4mcolor4\s+.\[0m")
+        self.assertRegex(out, r"color.debug\s+.\[0m\s.\[38;5;4mcolor4\s+.\[0m")
 
     def test_colors_legend_override(self):
         """Verify 'task colors legend' obeys rc overrides"""
         code, out, err = self.t("colors rc._forcecolor:on rc.color.debug:red legend")
-        self.assertRegex(out, "color.debug\s+.\[0m\s.\[31mred\s+.\[0m")
+        self.assertRegex(out, r"color.debug\s+.\[0m\s.\[31mred\s+.\[0m")
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner

--- a/test/color.rules.test.py
+++ b/test/color.rules.test.py
@@ -127,7 +127,7 @@ class TestColorRules(TestCase):
         """Overdue color rule from an hour ago."""
         code, out, err = self.t('/anhourago/ info')
         # Match 4-bit or 8-bit blue color code
-        self.assertRegex(out, '\x1b\[(38;5;4|34)m')
+        self.assertRegex(out, '\x1b\\[(38;5;4|34)m')
 
     def test_due_tomorrow(self):
         """Due tomorrow color rule."""

--- a/test/columns.test.py
+++ b/test/columns.test.py
@@ -243,14 +243,14 @@ class TestRecurringAttributeFormats(TestCase):
     def test_recurrence_formats_short(self):
         """Verify formatting of assorted short recurrence columns"""
         code, out, err = self.t("xxx rc.report.xxx.columns:id,status,due,recur.indicator,mask,imask,parent.short")
-        self.assertRegex(out, "1\sRecurring\s+\d{4}-\d{2}-\d{2}\s+R\s+-")
-        self.assertRegex(out, "2\sPending\s+\d{4}-\d{2}-\d{2}\s+R\s+0\s+[0-9a-fA-F]{8}")
+        self.assertRegex(out, r"1\sRecurring\s+\d{4}-\d{2}-\d{2}\s+R\s+-")
+        self.assertRegex(out, r"2\sPending\s+\d{4}-\d{2}-\d{2}\s+R\s+0\s+[0-9a-fA-F]{8}")
 
     def test_recurrence_formats_long(self):
         """Verify formatting of assorted long recurrence columns"""
         code, out, err = self.t("xxx rc.report.xxx.columns:id,status,due,recur.duration,mask,imask,parent.long")
-        self.assertRegex(out, "1\sRecurring\s+\d{4}-\d{2}-\d{2}\s+P30D\s+-")
-        self.assertRegex(out, "2\sPending\s+\d{4}-\d{2}-\d{2}\s+P30D\s+0\s+[0-9a-fA-F-]{36}")
+        self.assertRegex(out, r"1\sRecurring\s+\d{4}-\d{2}-\d{2}\s+P30D\s+-")
+        self.assertRegex(out, r"2\sPending\s+\d{4}-\d{2}-\d{2}\s+P30D\s+0\s+[0-9a-fA-F-]{36}")
 
     def test_recurrence_format_unrecognized(self):
         """Verify *.donkey formatting fails"""

--- a/test/commands.test.py
+++ b/test/commands.test.py
@@ -42,16 +42,16 @@ class TestCommands(TestCase):
     def test_command_dna(self):
         """Verify 'add', 'modify', 'list' dna"""
         code, out, err = self.t("commands")
-        self.assertRegex(out, "add\s+operation\s+RW\s+Ctxt\s+Mods\s+Adds a new task")
-        self.assertRegex(out, "list\s+report\s+RO\s+ID\s+GC\s+Ctxt\s+Filt\s+Most details of")
-        self.assertRegex(out, "modify\s+operation\s+RW\s+Filt\s+Mods\s+Modifies the")
+        self.assertRegex(out, r"add\s+operation\s+RW\s+Ctxt\s+Mods\s+Adds a new task")
+        self.assertRegex(out, r"list\s+report\s+RO\s+ID\s+GC\s+Ctxt\s+Filt\s+Most details of")
+        self.assertRegex(out, r"modify\s+operation\s+RW\s+Filt\s+Mods\s+Modifies the")
 
     def test_command_dna_color(self):
         """Verify 'add', 'modify', 'list' dna"""
         code, out, err = self.t("commands rc._forcecolor:on")
-        self.assertRegex(out, "add\s+operation\s+RW\s+Ctxt\s+Mods\s+Adds a new task")
-        self.assertRegex(out, "list\s+report\s+RO\s+ID\s+GC\s+Ctxt\s+Filt\s+Most details of")
-        self.assertRegex(out, "modify\s+operation\s+RW\s+Filt\s+Mods\s+Modifies the")
+        self.assertRegex(out, r"add\s+operation\s+RW\s+Ctxt\s+Mods\s+Adds a new task")
+        self.assertRegex(out, r"list\s+report\s+RO\s+ID\s+GC\s+Ctxt\s+Filt\s+Most details of")
+        self.assertRegex(out, r"modify\s+operation\s+RW\s+Filt\s+Mods\s+Modifies the")
 
 
 if __name__ == "__main__":

--- a/test/context.test.py
+++ b/test/context.test.py
@@ -204,7 +204,7 @@ class ContextManagementTest(TestCase):
         """Test that context is unset if its definition has been removed."""
         self.t('context define work project:Work', input='y\ny\n')
         self.t('context work')
-        code, out, err = self.t('context delete work', input='y\n\\y\n')
+        code, out, err = self.t('context delete work', input='y\ny\n')
         self.assertIn("Context 'work' deleted.", out)
 
         # Assert that taskrc does not countain context work definition

--- a/test/context.test.py
+++ b/test/context.test.py
@@ -204,7 +204,7 @@ class ContextManagementTest(TestCase):
         """Test that context is unset if its definition has been removed."""
         self.t('context define work project:Work', input='y\ny\n')
         self.t('context work')
-        code, out, err = self.t('context delete work', input='y\n\y\n')
+        code, out, err = self.t('context delete work', input='y\n\\y\n')
         self.assertIn("Context 'work' deleted.", out)
 
         # Assert that taskrc does not countain context work definition

--- a/test/custom.tag_ind.test.py
+++ b/test/custom.tag_ind.test.py
@@ -52,12 +52,12 @@ class TestCustomTagIndicator(TestCase):
         """Verify default tag indicator (+) is shown"""
         code, out, err = self.t("foo")
         self.assertRegex(out, "ID.+T")
-        self.assertRegex(out, "1\s+\+")
+        self.assertRegex(out, r"1\s+\+")
 
     def test_custom_indicator(self):
         """Verify custom tag indicator (TAG) is shown"""
         code, out, err = self.t("rc.tag.indicator:TAG foo")
-        self.assertRegex(out, "1\s+TAG")
+        self.assertRegex(out, r"1\s+TAG")
 
 
 if __name__ == "__main__":

--- a/test/custom.test.py
+++ b/test/custom.test.py
@@ -48,7 +48,7 @@ class TestCustomReports(TestCase):
     def test_custom_report_help(self):
         """Verify custom report description is shown in help"""
         code, out, err = self.t("help")
-        self.assertRegex(out, "task <filter> foo\s+DESC\n")
+        self.assertRegex(out, "task <filter> foo\\s+DESC\n")
 
     def test_custom_filter(self):
         """Verify custome report filtr is applied"""

--- a/test/default.test.py
+++ b/test/default.test.py
@@ -53,7 +53,7 @@ class TestCMD(TestCase):
     def test_info_command(self):
         """info command"""
         code, out, err = self.t('1')
-        self.assertRegex(out, 'Description\s+one')
+        self.assertRegex(out, r'Description\s+one')
 
 
 class TestDefaults(TestCase):

--- a/test/diag.test.py
+++ b/test/diag.test.py
@@ -50,7 +50,7 @@ class TestDiagnostics(TestCase):
         self.t.activate_hooks()
         code, out, err = self.t.diag()
         self.tap(out)
-        self.assertRegex(out, "Compliance:\s+C\+\+17")
+        self.assertRegex(out, r"Compliance:\s+C\+\+17")
         self.assertIn("edlin", out)
         self.assertIn("Locking", out)
 

--- a/test/due.test.py
+++ b/test/due.test.py
@@ -64,8 +64,8 @@ class TestDue(TestCase):
     def test_due(self):
         """due tasks displayed correctly"""
         code, out, err = self.t("list")
-        self.assertRegex(out, "\033\[31m.+{0}.+\033\[0m".format(self.just))
-        self.assertRegex(out, "\s+{0}\s+".format(self.almost))
+        self.assertRegex(out, "\033\\[31m.+{0}.+\033\\[0m".format(self.just))
+        self.assertRegex(out, r"\s+{0}\s+".format(self.almost))
 
 
 class TestBug418(TestCase):

--- a/test/encoding.test.py
+++ b/test/encoding.test.py
@@ -70,9 +70,9 @@ class TestUtf8(TestCase):
 
         code, out, err = self.t("ls")
 
-        expected = re.compile("\S\s{4}abc", re.MULTILINE)
+        expected = re.compile(r"\S\s{4}abc", re.MULTILINE)
         self.assertRegex(out, expected)
-        expected = re.compile("\S\s{5}def", re.MULTILINE)
+        expected = re.compile(r"\S\s{5}def", re.MULTILINE)
         self.assertRegex(out, expected)
 
 

--- a/test/feature.default.project.test.py
+++ b/test/feature.default.project.test.py
@@ -55,7 +55,7 @@ class TestDefaultProject(TestCase):
 
         self.assertIn("foobar", out)
 
-        expected = "Project\s+garden"
+        expected = r"Project\s+garden"
         self.assertRegex(out, expected)
 
         self.t("1 modify project:")
@@ -64,7 +64,7 @@ class TestDefaultProject(TestCase):
         self.assertIn("foobar", out)
         self.assertNotRegex(out, expected)
 
-        notexpected = "Project\s+" + self.default_project
+        notexpected = r"Project\s+" + self.default_project
         self.assertNotRegex(out, notexpected)
 
     def test_without_project(self):
@@ -76,7 +76,7 @@ class TestDefaultProject(TestCase):
 
         self.assertIn("foobar", out)
 
-        expected = "Project\s+" + self.default_project
+        expected = r"Project\s+" + self.default_project
         self.assertRegex(out, expected)
 
     def test_default_project_inline_override(self):
@@ -124,7 +124,7 @@ class TestDefaultProject(TestCase):
         self.t("1 annotate Hello")
         code, out, err = self.t("1 info")
 
-        expected = "Description\s+foobar\n[0-9-: ]+ Hello"
+        expected = "Description\\s+foobar\n[0-9-: ]+ Hello"
         self.assertRegex(out, expected)
         self.assertNotIn("Project", out)
 
@@ -158,7 +158,7 @@ class TestDefaultProject(TestCase):
         code, out, err = self.t("1 info")
 
         self.assertIn(DESC, out)
-        self.assertRegex(out, "Status\s+Recurring")  # is a parent task
+        self.assertRegex(out, r"Status\s+Recurring")  # is a parent task
         self.assertIn(self.default_project, out)
 
         self.t.faketime("+1d")

--- a/test/feature.recurrence.test.py
+++ b/test/feature.recurrence.test.py
@@ -62,8 +62,8 @@ class TestRecurrenceProblems(TestCase):
         self.t("add foo due:today recur:yearly until:eom")
         code, out, err = self.t("info 1")
 
-        self.assertNotRegex(out, "Until\s+\d{10}")
-        self.assertRegex(out, "Until\s+\d+\/\d+\/\d{4}")
+        self.assertNotRegex(out, r"Until\s+\d{10}")
+        self.assertRegex(out, r"Until\s+\d+\/\d+\/\d{4}")
 
 
 if __name__ == "__main__":

--- a/test/format.test.py
+++ b/test/format.test.py
@@ -118,12 +118,12 @@ class TestFormatDepends(TestCase):
     def test_depends_default(self):
         self.t.config("report.formatdep.columns", "description,depends")
         code, out, err = self.t("formatdep")
-        self.assertRegex(out, "one\s+1")
+        self.assertRegex(out, r"one\s+1")
 
     def test_depends_count(self):
         self.t.config("report.formatdep.columns", "description,depends.count")
         code, out, err = self.t("formatdep")
-        self.assertRegex(out, "one\s+\[1\]")
+        self.assertRegex(out, r"one\s+\[1\]")
 
 
 class TestBug101(TestCase):

--- a/test/gc.test.py
+++ b/test/gc.test.py
@@ -50,7 +50,7 @@ class TestGC(TestCase):
         self.t.config("gc", "0")
         self.t("1 done")
         code, out, err = self.t("gctest")
-        self.assertRegex(out, "1\s+one", "should still have ID")
+        self.assertRegex(out, r"1\s+one", "should still have ID")
 
     def test_gc_off_mod(self):
         """mod by ID after done with gc off"""
@@ -59,7 +59,7 @@ class TestGC(TestCase):
         self.t("gctest")
         self.t("2 mod +TWO")
         code, out, err = self.t("gctest")
-        self.assertRegex(out, "2\s+two\s+TWO", "modified 'two'")
+        self.assertRegex(out, r"2\s+two\s+TWO", "modified 'two'")
 
     def test_gc_on_id(self):
         """IDs reshuffle after report when GC on"""
@@ -67,8 +67,8 @@ class TestGC(TestCase):
         self.t("1 done")
         self.t("2 mod +TWO")
         code, out, err = self.t("gctest")
-        self.assertRegex(out, "1\s+two\s+TWO")
-        self.assertRegex(out, "2\s+three")
+        self.assertRegex(out, r"1\s+two\s+TWO")
+        self.assertRegex(out, r"2\s+three")
 
 
 if __name__ == "__main__":

--- a/test/history.test.py
+++ b/test/history.test.py
@@ -55,17 +55,17 @@ class TestHistoryDaily(TestCase):
     def test_history_daily(self):
         """Verify 'history.daily' correctly categorizes data"""
         code, out, err = self.t("history.daily")
-        self.assertRegex(out, "7\s+1\s+0\s+6")
-        self.assertRegex(out, "2\s+3\s+3\s+-4")
-        self.assertRegex(out, "4\s+2\s+1\s+1")
+        self.assertRegex(out, r"7\s+1\s+0\s+6")
+        self.assertRegex(out, r"2\s+3\s+3\s+-4")
+        self.assertRegex(out, r"4\s+2\s+1\s+1")
 
         code, out, err = self.t("ghistory.daily rc._forcecolor:on")
-        self.assertRegex(out, "\s7.+\s1.+")
-        self.assertRegex(out, "\s2.+\s3.+\s3.+")
+        self.assertRegex(out, r"\s7.+\s1.+")
+        self.assertRegex(out, r"\s2.+\s3.+\s3.+")
 
         code, out, err = self.t("ghistory.daily")
-        self.assertRegex(out, "2015\s+January\s+2\s+\++X+\s")
-        self.assertRegex(out, "\s+February\s+2\s+\++X+\-+")
+        self.assertRegex(out, r"2015\s+January\s+2\s+\++X+\s")
+        self.assertRegex(out, r"\s+February\s+2\s+\++X+\-+")
 
 class TestHistoryWeekly(TestCase):
     def setUp(self):
@@ -88,17 +88,17 @@ class TestHistoryWeekly(TestCase):
     def test_history_weekly(self):
         """Verify 'history.weekly' correctly categorizes data"""
         code, out, err = self.t("history.weekly")
-        self.assertRegex(out, "7\s+1\s+0\s+6")
-        self.assertRegex(out, "2\s+3\s+3\s+-4")
-        self.assertRegex(out, "4\s+2\s+1\s+1")
+        self.assertRegex(out, r"7\s+1\s+0\s+6")
+        self.assertRegex(out, r"2\s+3\s+3\s+-4")
+        self.assertRegex(out, r"4\s+2\s+1\s+1")
 
         code, out, err = self.t("ghistory.weekly rc._forcecolor:on")
-        self.assertRegex(out, "\s7.+\s1.+")
-        self.assertRegex(out, "\s2.+\s3.+\s3.+")
+        self.assertRegex(out, r"\s7.+\s1.+")
+        self.assertRegex(out, r"\s2.+\s3.+\s3.+")
 
         code, out, err = self.t("ghistory.weekly")
-        self.assertRegex(out, "2014\s+December\s+28\s+\++X+\s")
-        self.assertRegex(out, "2015\s+February\s+1\s+\++X+\-+")
+        self.assertRegex(out, r"2014\s+December\s+28\s+\++X+\s")
+        self.assertRegex(out, r"2015\s+February\s+1\s+\++X+\-+")
 
 
 class TestHistoryMonthly(TestCase):
@@ -122,17 +122,17 @@ class TestHistoryMonthly(TestCase):
     def test_history_monthly(self):
         """Verify 'history.monthly' correctly categorizes data"""
         code, out, err = self.t("history.monthly")
-        self.assertRegex(out, "7\s+1\s+0\s+6")
-        self.assertRegex(out, "2\s+3\s+3\s+-4")
-        self.assertRegex(out, "4\s+2\s+1\s+1")
+        self.assertRegex(out, r"7\s+1\s+0\s+6")
+        self.assertRegex(out, r"2\s+3\s+3\s+-4")
+        self.assertRegex(out, r"4\s+2\s+1\s+1")
 
         code, out, err = self.t("ghistory.monthly rc._forcecolor:on")
-        self.assertRegex(out, "\s7.+\s1.+")
-        self.assertRegex(out, "\s2.+\s3.+\s3.+")
+        self.assertRegex(out, r"\s7.+\s1.+")
+        self.assertRegex(out, r"\s2.+\s3.+\s3.+")
 
         code, out, err = self.t("ghistory.monthly")
-        self.assertRegex(out, "2015\s+January\s+\++X+\s")
-        self.assertRegex(out, "\s+February\s+\++X+\-+")
+        self.assertRegex(out, r"2015\s+January\s+\++X+\s")
+        self.assertRegex(out, r"\s+February\s+\++X+\-+")
 
 
 class TestHistoryAnnual(TestCase):
@@ -160,17 +160,17 @@ class TestHistoryAnnual(TestCase):
     def test_history_annual(self):
         """Verify 'history.annual' correctly categorizes data"""
         code, out, err = self.t("history.annual")
-        self.assertRegex(out, "7\s+1\s+0\s+6")
-        self.assertRegex(out, "2\s+3\s+3\s+-4")
-        self.assertRegex(out, "4\s+2\s+1\s+1")
+        self.assertRegex(out, r"7\s+1\s+0\s+6")
+        self.assertRegex(out, r"2\s+3\s+3\s+-4")
+        self.assertRegex(out, r"4\s+2\s+1\s+1")
 
         code, out, err = self.t("ghistory.annual rc._forcecolor:on")
-        self.assertRegex(out, "\s7.+\s1.+")
-        self.assertRegex(out, "\s2.+\s3.+\s3.+")
+        self.assertRegex(out, r"\s7.+\s1.+")
+        self.assertRegex(out, r"\s2.+\s3.+\s3.+")
 
         code, out, err = self.t("ghistory.annual")
-        self.assertRegex(out, "2014\s+\++X+\s")
-        self.assertRegex(out, "2015\s+\++X+\-+")
+        self.assertRegex(out, r"2014\s+\++X+\s")
+        self.assertRegex(out, r"2015\s+\++X+\-+")
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner

--- a/test/info.test.py
+++ b/test/info.test.py
@@ -64,21 +64,21 @@ class TestInfoCommand(TestCase):
         self.t("1 annotate bar", input="n\n")
         code, out, err = self.t("1 info")
 
-        self.assertRegex(out, "ID\s+1")
-        self.assertRegex(out, "Description\s+foo")
-        self.assertRegex(out, "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\s+bar")
-        self.assertRegex(out, "Status\s+Recurring")
-        self.assertRegex(out, "Project\s+P")
-        self.assertRegex(out, "Recurrence\s+P1M")
-        self.assertRegex(out, "Entered\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
-        self.assertRegex(out, "Waiting until\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
-        self.assertRegex(out, "Scheduled\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
-        self.assertRegex(out, "Start\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
-        self.assertRegex(out, "Due\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
-        self.assertRegex(out, "Until\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
-        self.assertRegex(out, "Last modified\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
+        self.assertRegex(out, r"ID\s+1")
+        self.assertRegex(out, r"Description\s+foo")
+        self.assertRegex(out, r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\s+bar")
+        self.assertRegex(out, r"Status\s+Recurring")
+        self.assertRegex(out, r"Project\s+P")
+        self.assertRegex(out, r"Recurrence\s+P1M")
+        self.assertRegex(out, r"Entered\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
+        self.assertRegex(out, r"Waiting until\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
+        self.assertRegex(out, r"Scheduled\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
+        self.assertRegex(out, r"Start\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
+        self.assertRegex(out, r"Due\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
+        self.assertRegex(out, r"Until\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
+        self.assertRegex(out, r"Last modified\s+\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}")
 
-        self.assertRegex(out, "Tags\s+tag")
+        self.assertRegex(out, r"Tags\s+tag")
         self.assertIn("ACTIVE", out)
         self.assertIn("ANNOTATED", out)
         self.assertIn("MONTH", out)
@@ -89,9 +89,9 @@ class TestInfoCommand(TestCase):
         self.assertIn("YEAR", out)
         self.assertIn("UDA", out)
 
-        self.assertRegex(out, "UUID\s+[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
-        self.assertRegex(out, "Urgency\s+\d+(\.\d+)?")
-        self.assertRegex(out, "Priority\s+H")
+        self.assertRegex(out, r"UUID\s+[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+        self.assertRegex(out, r"Urgency\s+\d+(\.\d+)?")
+        self.assertRegex(out, r"Priority\s+H")
 
         self.assertIn("project", out)
         self.assertIn("active", out)
@@ -116,7 +116,7 @@ class TestBug425(TestCase):
         self.t("1 modify Bar in Bar")
 
         code, out, err = self.t("1 ls")
-        self.assertRegex(out, "1\s+Bar in Bar")
+        self.assertRegex(out, r"1\s+Bar in Bar")
 
 
 if __name__ == "__main__":

--- a/test/logo.test.py
+++ b/test/logo.test.py
@@ -43,7 +43,7 @@ class TestLogoCommand(TestCase):
     def test_logo_command(self):
         """Check that there are colors. For coverage"""
         code, out, err = self.t("logo rc._forcecolor:on")
-        self.assertRegex(out, ".\[48;5;\d+m  .\[0m")
+        self.assertRegex(out, r".\[48;5;\d+m  .\[0m")
 
     def test_logo_command_no_color(self):
         """Check that it only works with color. For coverage"""

--- a/test/project.test.py
+++ b/test/project.test.py
@@ -39,8 +39,8 @@ class TestProjects(TestCase):
     def setUp(self):
         self.t = Task()
 
-        self.STATUS = ("The project '{0}' has changed\.  "
-                       "Project '{0}' is {1} complete \({2} remaining\)\.")
+        self.STATUS = (r"The project '{0}' has changed\.  "
+                       r"Project '{0}' is {1} complete \({2} remaining\)\.")
 
     def test_project_summary_count(self):
         """'task projects' shouldn't consider deleted tasks in summary.
@@ -52,7 +52,7 @@ class TestProjects(TestCase):
         self.t("3 delete", input="y\n")
         code, out, err = self.t("project:B projects")
 
-        expected = "1 project \(1 task\)"
+        expected = r"1 project \(1 task\)"
         self.assertRegex(out, expected)
 
     def test_project_progress(self):
@@ -415,16 +415,16 @@ class TestBug899(TestCase):
     def test_log_project(self):
         """899: Verify task log behaves correctly when logging into a project"""
         code, out, err = self.t("add one pro:A")
-        self.assertRegex(err, " 0% complete \(1 task ")
+        self.assertRegex(err, r" 0% complete \(1 task ")
 
         code, out, err = self.t("add two pro:A")
-        self.assertRegex(err, " 0% complete \(2 of 2 ")
+        self.assertRegex(err, r" 0% complete \(2 of 2 ")
 
         code, out, err = self.t("1 done")
-        self.assertRegex(err, " 50% complete \(1 of 2 ")
+        self.assertRegex(err, r" 50% complete \(1 of 2 ")
 
         code, out, err = self.t("log three pro:A")
-        self.assertRegex(err, " 66% complete \(1 of 3 ")
+        self.assertRegex(err, r" 66% complete \(1 of 3 ")
 
 
 class TestBug1267(TestCase):

--- a/test/quotes.test.py
+++ b/test/quotes.test.py
@@ -61,7 +61,7 @@ class TestBug268(TestCase):
         """escaped backslashes do not work with 'modify'"""
 
         self.t("add a b or c")
-        self.t('1 modify "/a b/a\/b/"')
+        self.t(r'1 modify "/a b/a\/b/"')
 
         code, out, err = self.t("1 info")
         self.assertIn("a/b or c", out)
@@ -125,7 +125,7 @@ class TestBug1436(TestCase):
 
     def test_backslashes(self):
         """1436: Prove to the reader that backslashes are eaten twice (which means
-           \\ --> \) once by Python, and once more by some mystery process
+           \\ --> \\) once by Python, and once more by some mystery process
            launch thing.
 
            This problem is entirely testing artifact, and not Taskwarrior.

--- a/test/quotes.test.py
+++ b/test/quotes.test.py
@@ -125,7 +125,7 @@ class TestBug1436(TestCase):
 
     def test_backslashes(self):
         """1436: Prove to the reader that backslashes are eaten twice (which means
-           \\ --> \\) once by Python, and once more by some mystery process
+           two backslashes to one) once by Python, and once more by some mystery process
            launch thing.
 
            This problem is entirely testing artifact, and not Taskwarrior.

--- a/test/recurrence.test.py
+++ b/test/recurrence.test.py
@@ -59,12 +59,12 @@ class TestRecurrenceSorting(TestCase):
     def test_sort_ascending(self):
         """Verify sorting by 'recur+' is correct"""
         code, out, err = self.t("asc rc.verbose:nothing")
-        self.assertRegex(out, "4\s+P1D\s+one\s+6\s+P3D\s+three\s+5\s+P7D\s+two")
+        self.assertRegex(out, r"4\s+P1D\s+one\s+6\s+P3D\s+three\s+5\s+P7D\s+two")
 
     def test_sort_descending(self):
         """Verify sorting by 'recur-' is correct"""
         code, out, err = self.t("desc rc.verbose:nothing")
-        self.assertRegex(out, "5\s+P7D\s+two\s+6\s+P3D\s+three\s+4\s+P1D\s+one")
+        self.assertRegex(out, r"5\s+P7D\s+two\s+6\s+P3D\s+three\s+4\s+P1D\s+one")
 
 
 class TestRecurrenceDisabled(TestCase):
@@ -179,9 +179,9 @@ class TestRecurrenceTasks(TestCase):
         #   3 complex
         #   4 complex
         code, out, err = self.t("minimal rc.verbose:nothing")
-        self.assertRegex(out, "1\s+simple")
-        self.assertRegex(out, "3\s+complex")
-        self.assertRegex(out, "4\s+complex")
+        self.assertRegex(out, r"1\s+simple")
+        self.assertRegex(out, r"3\s+complex")
+        self.assertRegex(out, r"4\s+complex")
 
         # Modify a child task and do not propagate the change.
         self.t("3 modify complex2", input="n\n")

--- a/test/search.test.py
+++ b/test/search.test.py
@@ -263,7 +263,7 @@ class TestBug1479(TestCase):
         self.t("add project:P1 one")
         self.t("add project:P2 one two")
 
-        code, out, err = self.t("description:one\ two list")
+        code, out, err = self.t(r"description:one\ two list")
         self.assertNotIn("P1", out)
         self.assertIn("P2", out)
 

--- a/test/sequence.test.py
+++ b/test/sequence.test.py
@@ -58,7 +58,7 @@ class TestSequences(TestCase):
         """Test sequences in start/stop"""
         self.t("1,2 start")
         code, out, err = self.t("_get 1.start 2.start")
-        self.assertRegex(out, "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\n")
+        self.assertRegex(out, "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2} \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\n")
 
         self.t("1,2 stop")
         code, out, err = self.t("_get 1.start 2.start")

--- a/test/stats.test.py
+++ b/test/stats.test.py
@@ -48,13 +48,13 @@ class TestStatisticsCommand(TestCase):
         self.t("log three")
 
         code, out, err = self.t("stats")
-        self.assertRegex(out, "Pending\s+1\n")
-        self.assertRegex(out, "Completed\s+1\n")
-        self.assertRegex(out, "Deleted\s+1\n")
-        self.assertRegex(out, "Total\s+3\n")
+        self.assertRegex(out, "Pending\\s+1\n")
+        self.assertRegex(out, "Completed\\s+1\n")
+        self.assertRegex(out, "Deleted\\s+1\n")
+        self.assertRegex(out, "Total\\s+3\n")
 
         code, out, err = self.t("stats rc._forcecolor:on")
-        self.assertRegex(out, "Pending\s+1\n")
+        self.assertRegex(out, "Pending\\s+1\n")
 
 
 if __name__ == "__main__":

--- a/test/template.test.py
+++ b/test/template.test.py
@@ -72,7 +72,7 @@ class TestBugNumber(TestCase):
         """Copyright is current"""
         code, out, err = self.t("version")
 
-        expected = "Copyright \(C\) \d{4} - %d" % (datetime.now().year,)
+        expected = r"Copyright \(C\) \d{4} - %d" % (datetime.now().year,)
         self.assertRegex(out.decode("utf8"), expected)
 
         # TAP diagnostics on the bas

--- a/test/tw-1379.test.py
+++ b/test/tw-1379.test.py
@@ -49,8 +49,8 @@ class TestBug1379(TestCase):
         self.t.config("color.label.sort", "")
 
         # For use with regex
-        self.RED = "\033\[31m"
-        self.CLEAR = "\033\[0m"
+        self.RED = "\033\\[31m"
+        self.CLEAR = "\033\\[0m"
 
     def test_color_BLOCKED(self):
         """color.tag.BLOCKED changes color of BLOCKED tasks"""

--- a/test/uda.test.py
+++ b/test/uda.test.py
@@ -103,8 +103,8 @@ class TestUdaDate(TestBaseUda):
         self.assertIn("Created task", out)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+[\d\/]+\s+with")
-        self.assertRegex(out, "2\s+without")
+        self.assertRegex(out, r"1\s+[\d\/]+\s+with")
+        self.assertRegex(out, r"2\s+without")
 
     def test_uda_bad_date_task(self):
         """Add tasks with an invalid UDA date"""
@@ -134,7 +134,7 @@ class TestUdaDefault(TestBaseUda):
         self.assertIn("Created task", out)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+strong\s+one")
+        self.assertRegex(out, r"1\s+strong\s+one")
 
     def test_uda_default_task(self):
         """Add tasks with default UDA"""
@@ -143,7 +143,7 @@ class TestUdaDefault(TestBaseUda):
         self.assertIn("Created task", out)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+weak\s+two")
+        self.assertRegex(out, r"1\s+weak\s+two")
 
     def test_uda_without_default_task(self):
         """Add tasks without default UDA"""
@@ -152,7 +152,7 @@ class TestUdaDefault(TestBaseUda):
         self.assertIn("Created task", out)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+weak\s+10\s+three")
+        self.assertRegex(out, r"1\s+weak\s+10\s+three")
 
 
 class TestUdaDuration(TestBaseUda):
@@ -200,8 +200,8 @@ class TestUdaNumeric(TestBaseUda):
         self.assertIn("Created task", out)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+\d+\s+with")
-        self.assertRegex(out, "2\s+without")
+        self.assertRegex(out, r"1\s+\d+\s+with")
+        self.assertRegex(out, r"2\s+without")
 
     def test_uda_bad_numeric_task(self):
         """Add tasks with an invalid UDA numeric"""
@@ -225,8 +225,8 @@ class TestUdaString(TestBaseUda):
         self.assertIn("Created task", out)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+one two\s+with")
-        self.assertRegex(out, "2\s+without")
+        self.assertRegex(out, r"1\s+one two\s+with")
+        self.assertRegex(out, r"2\s+without")
 
 
 class TestUdaValue(TestBaseUda):
@@ -245,8 +245,8 @@ class TestUdaValue(TestBaseUda):
         self.assertIn("Created task", out)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+weak\s+one")
-        self.assertRegex(out, "2\s+strong\s+two")
+        self.assertRegex(out, r"1\s+weak\s+one")
+        self.assertRegex(out, r"2\s+strong\s+two")
 
     def test_uda_invalid_value_task(self):
         """Add tasks with invalid UDA value"""
@@ -259,8 +259,8 @@ class TestUdaValue(TestBaseUda):
                       "'toxic'", err)
 
         code, out, err = self.t("uda")
-        self.assertRegex(out, "1\s+strong\s+one")
-        self.assertNotRegex(out, "1\s+toxic\s+two")
+        self.assertRegex(out, r"1\s+strong\s+one")
+        self.assertNotRegex(out, r"1\s+toxic\s+two")
 
 
 class TestBug1063(TestCase):

--- a/test/uda_orphan.test.py
+++ b/test/uda_orphan.test.py
@@ -56,12 +56,12 @@ class TestUDAOrphans(TestCase):
 
         # 'info' should show orphans.
         code, out, err = self.t("1 info")
-        self.assertRegex(out, "\[extra\s+foo\]")
+        self.assertRegex(out, r"\[extra\s+foo\]")
 
         # 'modify' should not change the orphan
         self.t("1 modify /one/two/")
         code, out, err = self.t("1 info")
-        self.assertRegex(out, "\[extra\s+foo\]")
+        self.assertRegex(out, r"\[extra\s+foo\]")
 
         # 'export' should include orphans.
         code, out, err = self.t("1 export")

--- a/test/uda_sort.test.py
+++ b/test/uda_sort.test.py
@@ -147,7 +147,7 @@ class TestBug1319(TestCase):
         self.t("add four when:morning")
 
         code, out, err = self.t("rc.verbose:nothing foo")
-        self.assertRegex(out, "4\s+morning\s+four\s+3\s+noon\s+three\s+2\s+evening\s+two\s+1\s+night\s+one")
+        self.assertRegex(out, r"4\s+morning\s+four\s+3\s+noon\s+three\s+2\s+evening\s+two\s+1\s+night\s+one")
 
 
 if __name__ == "__main__":

--- a/test/undo.test.py
+++ b/test/undo.test.py
@@ -79,16 +79,16 @@ class TestUndoStyle(TestCase):
         """Test that 'rc.undo.style:side' generates the right output"""
         self.t.config("undo.style", "side")
         code, out, err = self.t("undo", input="n\n")
-        self.assertNotRegex(out, "-tags:\s*\n\+tags:\s+tag")
-        self.assertRegex(out, "tags\s+tag\s*")
+        self.assertNotRegex(out, "-tags:\\s*\n\\+tags:\\s+tag")
+        self.assertRegex(out, r"tags\s+tag\s*")
 
     @unittest.expectedFailure # undo diffs are not supported
     def test_undo_diff_style(self):
         """Test that 'rc.undo.style:diff' generates the right output"""
         self.t.config("undo.style", "diff")
         code, out, err = self.t("undo", input="n\n")
-        self.assertRegex(out, "-tags:\s*\n\+tags:\s+tag")
-        self.assertNotRegex(out, "tags\s+tag\s*")
+        self.assertRegex(out, "-tags:\\s*\n\\+tags:\\s+tag")
+        self.assertNotRegex(out, r"tags\s+tag\s*")
 
     def test_undo_diff_operations(self):
         code, out, err = self.t("undo", input="n\n")

--- a/test/upgrade.test.py
+++ b/test/upgrade.test.py
@@ -44,19 +44,19 @@ class TestUpgrade(TestCase):
         self.t("add one")
 
         code, out, err = self.t("1 info")
-        self.assertRegex(out, "Status\s+Pending")
+        self.assertRegex(out, r"Status\s+Pending")
 
         self.t("1 modify due:tomorrow recur:weekly")
         self.t("list")
 
         code, out, err = self.t("1 info")
-        self.assertRegex(out, "Status\s+Recurring")
-        self.assertRegex(out, "Recurrence\s+weekly")
+        self.assertRegex(out, r"Status\s+Recurring")
+        self.assertRegex(out, r"Recurrence\s+weekly")
 
         # Also check for the presence of a children task with pending state
         code, out, err = self.t("2 info")
-        self.assertRegex(out, "Status\s+Pending")
-        self.assertRegex(out, "Recurrence\s+weekly")
+        self.assertRegex(out, r"Status\s+Pending")
+        self.assertRegex(out, r"Recurrence\s+weekly")
 
 
 if __name__ == "__main__":

--- a/test/version.test.py
+++ b/test/version.test.py
@@ -54,12 +54,12 @@ class TestVersion(TestCase):
         """Copyright is current"""
         code, out, err = self.t("version")
 
-        expected = "Copyright \(C\) \d{4} - %d" % (datetime.now().year,)
+        expected = r"Copyright \(C\) \d{4} - %d" % (datetime.now().year,)
         self.assertRegex(out, expected)
 
     def slurp(self, file="../CMakeLists.txt"):
-        number = "\.".join(["[0-9]+"] * 3)
-        ver = re.compile("^set \(PROJECT_VERSION \"({0}[^\"]*)\"\)$".format(number))
+        number = r"\.".join(["[0-9]+"] * 3)
+        ver = re.compile("^set \\(PROJECT_VERSION \"({0}[^\"]*)\"\\)$".format(number))
         with open(file) as fh:
             for line in fh:
                 if "PROJECT_VERSION" in line:


### PR DESCRIPTION
#### Description

These SyntaxWarnings are currently sprinkled throughout the GitHub Actions test results.

https://docs.astral.sh/ruff/rules/invalid-escape-sequence

% `ruff check --select=W605 --statistics`
```
471	W605	[*] Invalid escape sequence: `\ `
```
% `ruff check --select=W605 --fix`
```
Found 471 errors (471 fixed, 0 remaining).
```
% `ruff rule W605`
# invalid-escape-sequence (W605)

Derived from the **pycodestyle** linter.

Fix is always available.

## What it does
Checks for invalid escape sequences.

## Why is this bad?
Invalid escape sequences are deprecated in Python 3.6.

## Example
```python
regex = "\.png$"
```

Use instead:
```python
regex = r"\.png$"
```

Or, if the string already contains a valid escape sequence:
```python
value = "new line\nand invalid escape \_ here"
```

Use instead:
```python
value = "new line\nand invalid escape \\_ here"
```

## References
- [Python documentation: String and Bytes literals](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)


#### Additional information...

- [ ] I changed C++ code or build infrastructure.
  Please run the test suite and include the output of `cd build/test && make && ./problems`.

- [ ] I changed Rust code or build infrastructure.
  Please run `cargo test` and address any failures before submitting.
