### PR TITLE
Update task-sync(5) to include delete perms for GCP sync

### DIFF
--- a/doc/man/task-sync.5.in
+++ b/doc/man/task-sync.5.in
@@ -108,6 +108,7 @@ Select the following permissions:
     - storage.objects.get
     - storage.objects.list
     - storage.objects.update
+    - storage.objects.delete
 
  Create your new role.
 


### PR DESCRIPTION
Fixes #3441, as discovered via #3395 

`grep -R "storage.objects" .` revealed that only the man page for `task-sync(5)` mentions GCP role permissions so that is the only place it was added to.