### PR TITLE
Test modification of a task by an on-add hook (test case for #3416)

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -81,6 +81,9 @@ void TDB2::add (Task& task)
   std::string uuid = task.get ("uuid");
   changes[uuid] = task;
 
+  // run hooks for this new task
+  Context::getContext ().hooks.onAdd (task);
+
   auto innertask = replica.import_task_with_uuid (uuid);
 
   {
@@ -120,9 +123,6 @@ void TDB2::add (Task& task)
 
   // update the cached working set with the new information
   _working_set = std::make_optional (std::move (ws));
-
-  // run hooks for this new task
-  Context::getContext ().hooks.onAdd (task);
 
   if (id.has_value ()) {
       task.id = id.value();

--- a/test/hooks.on-add.test.py
+++ b/test/hooks.on-add.test.py
@@ -60,7 +60,7 @@ class TestHooksOnAdd(TestCase):
 
     def test_onadd_builtin_accept_modify(self):
         """on-add-accept-modify - a well-behaved, successful, on-add hook, that modifies the added task."""
-        hookname = 'on-add.the'
+        hookname = 'on-add-modify'
         self.t.hooks.add_default(hookname, log=True)
 
         code, out, err = self.t("add teh foo")

--- a/test/hooks.on-add.test.py
+++ b/test/hooks.on-add.test.py
@@ -58,6 +58,23 @@ class TestHooksOnAdd(TestCase):
         code, out, err = self.t("1 info")
         self.assertIn("Description   foo", out)
 
+    def test_onadd_builtin_accept_modify(self):
+        """on-add-accept-modify - a well-behaved, successful, on-add hook, that modifies the added task."""
+        hookname = 'on-add.the'
+        self.t.hooks.add_default(hookname, log=True)
+
+        code, out, err = self.t("add teh foo")
+
+        hook = self.t.hooks[hookname]
+        hook.assertTriggeredCount(1)
+        hook.assertExitcode(0)
+
+        logs = hook.get_logs()
+        self.assertEqual(logs["output"]["msgs"][0], "FEEDBACK")
+
+        code, out, err = self.t("1 info")
+        self.assertIn("Description   the foo", out)
+
     def test_onadd_builtin_reject(self):
         """on-add-reject - a well-behaved, failing, on-add hook."""
         hookname = 'on-add-reject'

--- a/test/test_hooks/on-add-modify
+++ b/test/test_hooks/on-add-modify
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Input:
+# - Line of JSON for proposed new task.
+read new_task
+
+if (echo $new_task | grep -qE '[tT]eh');
+then
+  new_task=$(echo $new_task | sed -r 's/([tT])eh/\1he/g')
+fi
+
+# Output:
+# - JSON, modified
+# - Optional feedback/error.
+echo $new_task
+echo 'FEEDBACK'
+
+# Status:
+# - 0:     JSON accepted, non-JSON is feedback.
+# - non-0: JSON ignored, non-JSON is error.
+exit 0


### PR DESCRIPTION
This PR adds a test case that shows the bug described in #3416. I confirmed it fails on current develop.

I think the bug's root cause is https://github.com/GothenburgBitFactory/taskwarrior/commit/5bb98579841d41e680280ada7bf3a3e9a9940553#r141727451. 

For a fix:
`TBD2::update()` as a method was removed in the referenced commit. And it seems calling `TBD2::modify()` instead will fire on-modify hooks when saving changes by on-add to the database. That's about as far as I got, I hope this contribution will help someone else make progress.