### PR TITLE
Add test that on-add returning 1 does not add task

### DIFF
--- a/test/hooks.on-add.test.py
+++ b/test/hooks.on-add.test.py
@@ -89,6 +89,10 @@ class TestHooksOnAdd(TestCase):
         logs = hook.get_logs()
         self.assertEqual(logs["output"]["msgs"][0], "FEEDBACK")
 
+        # task was not added
+        code, out, err = self.t.runError("1 info")
+        self.assertIn("No matches", err)
+
     def test_onadd_builtin_misbehave1(self):
         """on-add-misbehave1 - does not consume input."""
         hookname = 'on-add-misbehave1'


### PR DESCRIPTION
This test existed, but didn't notice that the task was actually added. The bug itself was fixed in #3443.