### PR TITLE
Let task show recognize limit in taskrc

### DIFF
--- a/scripts/vim/syntax/taskrc.vim
+++ b/scripts/vim/syntax/taskrc.vim
@@ -142,6 +142,7 @@ syn match taskrcGoodKey '^\s*\Vjournal.time='he=e-1
 syn match taskrcGoodKey '^\s*\Vjournal.time.start.annotation='he=e-1
 syn match taskrcGoodKey '^\s*\Vjournal.time.stop.annotation='he=e-1
 syn match taskrcGoodKey '^\s*\Vjson.array='he=e-1
+syn match taskrcGoodKey '^\s*\Vlimit='he=e-1
 syn match taskrcGoodKey '^\s*\Vlist.all.projects='he=e-1
 syn match taskrcGoodKey '^\s*\Vlist.all.tags='he=e-1
 syn match taskrcGoodKey '^\s*\Vlocale='he=e-1

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -173,6 +173,7 @@ int CmdShow::execute (std::string& output)
     " journal.time.start.annotation"
     " journal.time.stop.annotation"
     " json.array"
+    " limit"
     " list.all.projects"
     " list.all.tags"
     " locking"


### PR DESCRIPTION
This is just 2 line changes to recognize that `limit=page` (or `limit=n`) is allowable in the `taskrc` file.

Related to #3465.

I'm not a coder, but I read the instructions in the README.md files, and tested with `./src/task`, and it's working as expected.

The man page for `task` already shows how to use `limit=page`. Should this be added to `man taskrc`? If so, why are there two nearly-identical `taskrc` files at `doc/man`?