### PR TITLE
Add note about gcp application-default credentials to (5)task-sync

### DIFF
--- a/doc/man/task-sync.5.in
+++ b/doc/man/task-sync.5.in
@@ -86,9 +86,12 @@ Authenticate to the project with:
     $ gcloud config set project $PROJECT_NAME
     $ gcloud auth application-default login
 
+This will download a file named "application_default_credentials.json" (the
+location will be shown in the output of the gcloud login command)
 Then configure Taskwarrior with:
 
     $ task config sync.gcp.bucket               <bucket-name>
+    $ task config sync.gcp.credential_path      <absolute-path-to-downloaded-credentials>
 
 However you can bring your own service account credentials if your 
 `application-default` is already being used by some other application


### PR DESCRIPTION
The `task-sync` man page only mentions the `sync.gcp.credential_path` as part of setting up custom IAM roles, but it is also required if using application-default credentials. Not setting the credential path causes `task sync` to panic, as taskchampion tries to create a GcpService but unwraps `credential_path` in the process. This doesn't fix the taskchampion problem (if possible I plan to make a PR for that too), but it does make it easier for others to deal with this error if they encounter it.