### PR TITLE
Add a release-check action to verify release tarballs have all the necessary parts

### DIFF
--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -24,5 +24,5 @@ jobs:
           tar -xf build/task-*.tar.gz &&
           cd task-*.*.* &&
           cmake -S. -Bbuild &&
-          make -Cbuild task_executable
+          cmake -Bbuild --target task_executable
 

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -1,4 +1,4 @@
-name: tests
+name: release-tests
 on: [push, pull_request]
 jobs:
   check-tarball:

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -1,0 +1,27 @@
+name: tests
+on: [push, pull_request]
+jobs:
+  check-tarball:
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "stable"
+          override: true
+
+      - name: make a release tarball and build from it
+        run: |
+          cmake -S. -Bbuild &&
+          make -Cbuild package_source &&
+          tar -xf build/task-*.tar.gz &&
+          cd task-*.*.* &&
+          cmake -S. -Bbuild &&
+          make task_executable
+

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -2,6 +2,7 @@ name: release-tests
 on: [push, pull_request]
 jobs:
   check-tarball:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -24,5 +24,5 @@ jobs:
           tar -xf build/task-*.tar.gz &&
           cd task-*.*.* &&
           cmake -S. -Bbuild &&
-          cmake -Bbuild --target task_executable
+          cmake --build build --target task_executable
 

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -24,5 +24,5 @@ jobs:
           tar -xf build/task-*.tar.gz &&
           cd task-*.*.* &&
           cmake -S. -Bbuild &&
-          make task_executable
+          make -Cbuild task_executable
 


### PR DESCRIPTION
This action creates a release tarball, un-tars it, and builds from it. This should verify that no critical piece is missing. Fixes #3428.