### PR TITLE
Only warn about .data files when showing reports

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -58,14 +58,6 @@ TDB2::TDB2 ()
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::open_replica (const std::string& location, bool create_if_missing)
 {
-  File pending_data = File (location + "/pending.data");
-  if (pending_data.exists()) {
-    Color warning = Color (Context::getContext ().config.get ("color.warning"));
-    std::cerr << warning.colorize (
-      format ("Found existing '*.data' files in {1}", location)) << "\n";
-    std::cerr << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
-    std::cerr << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
-  }
   replica = tc::Replica(location, create_if_missing);
 }
 

--- a/src/commands/CmdCustom.cpp
+++ b/src/commands/CmdCustom.cpp
@@ -281,7 +281,6 @@ int CmdCustom::execute (std::string& output)
       format ("Found existing '*.data' files in {1}", location)) << "\n";
     std::cerr << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
     std::cerr << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
-    std::cerr << "  Remove the '*.data' files to silence this warning.\n";
   }
 
   feedback_backlog ();

--- a/src/commands/CmdCustom.cpp
+++ b/src/commands/CmdCustom.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <map>
 #include <vector>
+#include <iostream>
 #include <algorithm>
 #include <stdlib.h>
 #include <Context.h>
@@ -272,6 +273,16 @@ int CmdCustom::execute (std::string& output)
     }
   }
 
+  std::string location  = (Context::getContext ().data_dir);
+  File pending_data = File (location + "/pending.data");
+  if (pending_data.exists()) {
+    Color warning = Color (Context::getContext ().config.get ("color.warning"));
+    std::cerr << warning.colorize (
+      format ("Found existing '*.data' files in {1}", location)) << "\n";
+    std::cerr << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
+    std::cerr << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
+    std::cerr << "  Remove the '*.data' files to silence this warning.\n";
+  }
 
   feedback_backlog ();
   output = out.str ();


### PR DESCRIPTION
This avoids the warning appearing in shell completion, for example.

Fixes #3419.