### PR TITLE
Be resilient to a missing 'entry' in urgency

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -2319,7 +2319,8 @@ float Task::urgency_due () const
 ////////////////////////////////////////////////////////////////////////////////
 float Task::urgency_age () const
 {
-  assert (has ("entry"));
+  if (!has ("entry"))
+    return 1.0;
 
   Datetime now;
   Datetime entry (get_date ("entry"));


### PR DESCRIPTION
Any combination of properties is possible - Taskwarrior should make the best of the tasks it finds, rather than crashing.

Fixes #3478.