### PR TITLE
Remove unnecessary cbindgen-related Makefile

### DIFF
--- a/src/tc/lib/Makefile
+++ b/src/tc/lib/Makefile
@@ -1,2 +1,0 @@
-taskchampion.h: cbindgen.toml ../target/debug/libtaskchampion.so
-	cbindgen --config cbindgen.toml --crate taskchampion-lib --output $@


### PR DESCRIPTION
I noticed this leftover while working on another PR. We don't use cbindgen at all.