### PR TITLE
Fix builds with Rust 1.79

### DIFF
--- a/src/tc/CMakeLists.txt
+++ b/src/tc/CMakeLists.txt
@@ -27,4 +27,4 @@ set (tc_SRCS
   Task.cpp Task.h)
 
 add_library (tc STATIC ${tc_SRCS})
-target_link_libraries(tc taskchampion-lib)
+target_link_libraries(tc taskchampion_lib)

--- a/src/tc/lib/Cargo.toml
+++ b/src/tc/lib/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
+name = "taskchampion_lib"
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]


### PR DESCRIPTION
https://github.com/corrosion-rs/corrosion/issues/501 required some updates once 1.79 came out (yesterday).

This both
 * Updates the crate's library name to use underscores (which fixes the issue), and
 * Updates corrosion to 0.5.0 (which would also have fixed the issue, and is a good idea anyway)