### PR TITLE
Include fewer deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,28 +11,8 @@ resolver = "2"
 # Cargo.toml's in the members with `foo.workspace = true`.
 [workspace.dependencies]
 anyhow = "1.0"
-byteorder = "1.5"
-cc = "1.0.73"
-chrono = { version = "^0.4.22", features = ["serde"] }
 ffizz-header = "0.5"
-flate2 = "1"
-google-cloud-storage = { version = "0.15.0", default-features = false, features = ["rustls-tls", "auth"] }
-lazy_static = "1"
 libc = "0.2.136"
-log = "^0.4.17"
 pretty_assertions = "1"
-proptest = "^1.4.0"
-ring = "0.17"
-rstest = "0.17"
-rusqlite = { version = "0.29", features = ["bundled"] }
-serde_json = "^1.0"
-serde = { version = "^1.0.147", features = ["derive"] }
-strum = "0.25"
-strum_macros = "0.25"
-tempfile = "3"
-tokio = { version = "1", features = ["rt-multi-thread"] }
-thiserror = "1.0"
-ureq = { version = "^2.9.0", features = ["tls"] }
-uuid = { version = "^1.8.0", features = ["serde", "v4"] }
-url = { version = "2" }
+regex = "^1.10.2"
 taskchampion = "0.5"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.4.1"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
 taskchampion-lib = { path = "../src/tc/lib" }
-regex = "^1.10.2"
+regex.workspace = true


### PR DESCRIPTION
Somewhere in the process of moving TaskChampion back to its own repo, Taskwarrior's `Cargo.toml` ended up containing all of its dependencies, unnecessarily.

~~This included an old version of `chrono` (addressed in https://github.com/GothenburgBitFactory/taskchampion/pull/399). Removing the old version requirement from `Cargo.toml` results in using a newer version, addressing a (benign) security vulnerability.~~ (addressed in 210ec1013219c6123eb927f754a1c20b9df8a3ae)