### PR TITLE
Consider all news "major"

### DIFF
--- a/src/commands/CmdNews.h
+++ b/src/commands/CmdNews.h
@@ -36,7 +36,6 @@
 class NewsItem {
 public:
   Version _version;
-  bool _major = false;
   std::string _title;
   std::string _bg_title;
   std::string _background;
@@ -54,7 +53,6 @@ public:
 private:
   NewsItem (
     Version,
-    bool,
     const std::string&,
     const std::string& = "",
     const std::string& = "",


### PR DESCRIPTION
This has the effect that `task news` will unconditionally update the config with the new version once news has been shown (assuming the user does not kill the process first).

Fixes #3391.