### PR TITLE
Build in parallel, test sequentially

### DIFF
--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -24,5 +24,5 @@ jobs:
           tar -xf build/task-*.tar.gz &&
           cd task-*.*.* &&
           cmake -S. -Bbuild &&
-          cmake --build build --target task_executable
+          cmake --build build -j 8 --target task_executable
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage
 
       - name: Build project
-        run: cmake --build build -j 8 --target build_tests
+        run: cmake --build build --target build_tests
 
       - name: Test project
         # NOTE: running these in parallel (`-j N`) can result in spurious failures

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,10 +17,11 @@ jobs:
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage
 
       - name: Build project
-        run: cmake --build build --target build_tests
+        run: cmake --build build -j 8 --target build_tests
 
       - name: Test project
-        run: ctest --test-dir build -j 8 --output-on-failure
+        # NOTE: running these in parallel (`-j N`) can result in spurious failures
+        run: ctest --test-dir build --output-on-failure
 
       - name: Generate a code coverage report
         uses: threeal/gcovr-action@v1.0.0


### PR DESCRIPTION
It seems the tests fail with SIGABRT when run with `-j 8` - perhaps there's just too much going on for a 4-thread processor to keep up? Or perhaps the tests interfere with each other? So, this removes the parallelism from tests.

However, _building_ in parallel should be fine, so let's do that.