### PR TITLE
Remove `locking` config

### DIFF
--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -210,14 +210,6 @@ Note that the TASKDATA environment variable overrides this setting.
 This is a path to the hook scripts directory. By default it is ~/.task/hooks.
 
 .TP
-.B locking=1
-Determines whether to use file locking when accessing the database. Defaults to
-"1". Solaris users who store the database on an NFS mount may need to set
-locking to "0". Note that there is danger in setting this value to "0" -
-another program (or another instance of task) may write to the database at the
-same time.
-
-.TP
 .B gc=1
 Can be used to temporarily suspend garbage collection (gc), so that task IDs
 don't change. Note that this should be used in the form of a command line

--- a/scripts/hooks/on-exit.shadow-file
+++ b/scripts/hooks/on-exit.shadow-file
@@ -22,9 +22,8 @@ SHADOW_FILE=$(task _get rc.shadow.file)
 #   rc.detection=off       Disables terminal size detection
 #   rc.gc=off              Disables GC, thus not changing IDs unexpectedly
 #   rc.color=off           Disable color in the shadow file
-#   rc.locking=off         Disable file locking, to prevent race condition
 #   rc.hooks=off           Disable hooks, to prevent race condition
-task $SHADOW_COMMAND rc.detection=off rc.gc=off rc.color=off rc.locking=off rc.hooks=off > $SHADOW_FILE 2>/dev/null
+task $SHADOW_COMMAND rc.detection=off rc.gc=off rc.color=off rc.hooks=off > $SHADOW_FILE 2>/dev/null
 if [[ $? != 0 ]]
 then
   echo Could not create $SHADOW_FILE

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -78,7 +78,6 @@ std::string configurationDefaults =
   "\n"
   "# Files\n"
   "data.location=~/.task\n"
-  "locking=1                                      # Use file-level locking\n"
   "gc=1                                           # Garbage-collect data files - DO NOT CHANGE unless you are sure\n"
   "exit.on.missing.db=0                           # Whether to exit if ~/.task is not found\n"
   "hooks=1                                        # Master control switch for hooks\n"

--- a/src/commands/CmdDiagnostics.cpp
+++ b/src/commands/CmdDiagnostics.cpp
@@ -177,12 +177,6 @@ int CmdDiagnostics::execute (std::string& output)
         << env
         << '\n';
 
-  out << "    Locking: "
-      << (Context::getContext ().config.getBoolean ("locking")
-           ? "Enabled"
-           : "Disabled")
-      << '\n';
-
   out << "         GC: "
       << (Context::getContext ().config.getBoolean ("gc")
            ? "Enabled"

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -176,7 +176,6 @@ int CmdShow::execute (std::string& output)
     " limit"
     " list.all.projects"
     " list.all.tags"
-    " locking"
     " nag"
     " news.version"
     " obfuscate"

--- a/test/diag.test.py
+++ b/test/diag.test.py
@@ -52,7 +52,6 @@ class TestDiagnostics(TestCase):
         self.tap(out)
         self.assertRegex(out, r"Compliance:\s+C\+\+17")
         self.assertIn("edlin", out)
-        self.assertIn("Locking", out)
 
     def test_64bit_time_t(self):
         """Test that time_t has size of 64 bits"""


### PR DESCRIPTION
This flag is no longer needed. It was used to control file locking on the *.data files.

Fixes: #3517 