### PR TITLE
increase timout to 10s and run on ubuntu-latest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   coverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install apt packages
         run: sudo apt-get install -y build-essential cmake git uuid-dev faketime locales python3 curl gcovr ninja-build

--- a/test/basetest/utils.py
+++ b/test/basetest/utils.py
@@ -66,13 +66,13 @@ def binary_location(cmd, USE_PATH=False):
         return os.path.join(BIN_PREFIX, cmd)
 
 
-def wait_condition(cond, timeout=1, sleeptime=.01):
+def wait_condition(cond, timeout=10, sleeptime=.01):
     """Wait for condition to return anything other than None
     """
     # NOTE Increasing sleeptime can dramatically increase testsuite runtime
     # It also reduces CPU load significantly
     if timeout is None:
-        timeout = 1
+        timeout = 10
 
     if timeout < sleeptime:
         print("Warning, timeout cannot be smaller than", sleeptime)


### PR DESCRIPTION
As identified in #3512 it seams as the problem was the internal timeout. Closes #3507.

I mainly created the "new" PR that we do not need to commit more times with the logging etc, and that the Coveralls action has a normal chance to run successfully.