### PR TITLE
Replace "gc" with "rebuild" in man pages.

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -744,11 +744,12 @@ the online documentation at:
 
 .TP
 .B ID
-Tasks can be specified uniquely by IDs, which are simply the indexes of the
-tasks in the database.  The ID of a task may therefore change, but only when
-a command is run that displays IDs.  When modifying tasks, it is safe to
-rely on the last displayed ID.  Always run a report to check you have the right
-ID for a task. IDs can be given to task as a sequence, for example:
+Tasks can be specified uniquely by IDs, which are the indexes of the "working
+set" of tasks (mostly pending and recurrent tasks).  The ID of a task may
+therefore change, but only when a report that displays IDs is run.  When
+modifying tasks, it is safe to rely on the last displayed ID.  Always run a
+report to check you have the right ID for a task. IDs can be given to task as a
+sequence, for example:
 
 .nf
 task 1,4-10,19 delete

--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -211,10 +211,10 @@ This is a path to the hook scripts directory. By default it is ~/.task/hooks.
 
 .TP
 .B gc=1
-Can be used to temporarily suspend garbage collection (gc), so that task IDs
-don't change. Note that this should be used in the form of a command line
-override (task rc.gc=0 ...), and not permanently used in the .taskrc file,
-as this significantly affects performance in the long term.
+Can be used to temporarily suspend rebuilding, so that task IDs don't change.
+Note that this should be used in the form of a command line override (task
+rc.gc=0 ...), and not permanently used in the .taskrc file, as this
+significantly affects performance in the long term.
 
 .TP
 .B hooks=1


### PR DESCRIPTION
Also, explain IDs in the context of the working set of tasks.

Related to: https://github.com/GothenburgBitFactory/tw.org/issues/877