### PR TITLE
Do not claim that Taskwarrior automatically syncs

### DIFF
--- a/doc/man/task-sync.5.in
+++ b/doc/man/task-sync.5.in
@@ -30,10 +30,8 @@ the existing replica, and run `task sync`.
 
 .SS When to Synchronize
 
-Taskwarrior can perform a sync operation at every garbage collection (gc) run.
-This is the default, and is appropriate for local synchronization.
-
-For synchronization to a server, a better solution is to run
+Taskwarrior performs a sync operation when you run `task sync`.
+For synchronization to a server, a common solution is to run
 
 .nf
     $ task sync

--- a/doc/man/task-sync.5.in
+++ b/doc/man/task-sync.5.in
@@ -30,7 +30,6 @@ the existing replica, and run `task sync`.
 
 .SS When to Synchronize
 
-Taskwarrior performs a sync operation when you run `task sync`.
 For synchronization to a server, a common solution is to run
 
 .nf


### PR DESCRIPTION
Taskwarrior only syncs when `task sync` is run.

Fixes #3534.