### PR TITLE
add faketime and change to apt-get in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
     fi \
     && rm -f /tmp/reinstall-cmake.sh
 
-RUN sudo apt update && sudo apt install uuid-dev
+RUN sudo apt-get update && sudo apt-get install uuid-dev faketime
 
 # [Optional] Uncomment this section to install additional vcpkg ports.
 # RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"


### PR DESCRIPTION
We require faketime to be installed for running the tests, therefore its added. Further for non-interactive usage apt-get is recommended, therefore the change.