### PR TITLE
Rename 'expiration.on-sync' to 'auto-purge.on-sync'

### DIFF
--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -217,8 +217,8 @@ rc.gc=0 ...), and not permanently used in the .taskrc file, as this
 significantly affects performance in the long term.
 
 .TP
-.B expiration.on-sync=0
-If set, old tasks will be deleted automatically after each synchronization.
+.B auto-purge.on-sync=0
+If set, old tasks will be purged automatically after each synchronization.
 Tasks are identified as "old" when they have status "Deleted" and have not
 been modified for 180 days.
 

--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -217,7 +217,7 @@ rc.gc=0 ...), and not permanently used in the .taskrc file, as this
 significantly affects performance in the long term.
 
 .TP
-.B auto-purge.on-sync=0
+.B purge.on-sync=0
 If set, old tasks will be purged automatically after each synchronization.
 Tasks are identified as "old" when they have status "Deleted" and have not
 been modified for 180 days.

--- a/scripts/vim/syntax/taskrc.vim
+++ b/scripts/vim/syntax/taskrc.vim
@@ -132,7 +132,7 @@ syn match taskrcGoodKey '^\s*\Vexpressions='he=e-1
 syn match taskrcGoodKey '^\s*\Vextensions='he=e-1
 syn match taskrcGoodKey '^\s*\Vfontunderline='he=e-1
 syn match taskrcGoodKey '^\s*\Vgc='he=e-1
-syn match taskrcGoodKey '^\s*\Vauto-purge.on-sync='he=e-1
+syn match taskrcGoodKey '^\s*\Vpurge.on-sync='he=e-1
 syn match taskrcGoodKey '^\s*\Vhooks='he=e-1
 syn match taskrcGoodKey '^\s*\Vhooks.location='he=e-1
 syn match taskrcGoodKey '^\s*\Vhyphenate='he=e-1

--- a/scripts/vim/syntax/taskrc.vim
+++ b/scripts/vim/syntax/taskrc.vim
@@ -132,7 +132,7 @@ syn match taskrcGoodKey '^\s*\Vexpressions='he=e-1
 syn match taskrcGoodKey '^\s*\Vextensions='he=e-1
 syn match taskrcGoodKey '^\s*\Vfontunderline='he=e-1
 syn match taskrcGoodKey '^\s*\Vgc='he=e-1
-syn match taskrcGoodKey '^\s*\Vexpiration.on-sync='he=e-1
+syn match taskrcGoodKey '^\s*\Vauto-purge.on-sync='he=e-1
 syn match taskrcGoodKey '^\s*\Vhooks='he=e-1
 syn match taskrcGoodKey '^\s*\Vhooks.location='he=e-1
 syn match taskrcGoodKey '^\s*\Vhyphenate='he=e-1

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -118,7 +118,7 @@ std::string configurationDefaults =
   "json.array=1                                   # Enclose JSON output in [ ]\n"
   "abbreviation.minimum=2                         # Shortest allowed abbreviation\n"
   "news.version=                                  # Latest version highlights read by the user\n"
-  "expiration.on-sync=0                           # Expire old tasks on sync\n"
+  "auto-purge.on-sync=0                           # Purge old tasks on sync\n"
   "\n"
   "# Dates\n"
   "dateformat=Y-M-D                               # Preferred input and display date format\n"

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -118,7 +118,7 @@ std::string configurationDefaults =
   "json.array=1                                   # Enclose JSON output in [ ]\n"
   "abbreviation.minimum=2                         # Shortest allowed abbreviation\n"
   "news.version=                                  # Latest version highlights read by the user\n"
-  "auto-purge.on-sync=0                           # Purge old tasks on sync\n"
+  "purge.on-sync=0                                # Purge old tasks on sync\n"
   "\n"
   "# Dates\n"
   "dateformat=Y-M-D                               # Preferred input and display date format\n"

--- a/src/commands/CmdNews.cpp
+++ b/src/commands/CmdNews.cpp
@@ -552,7 +552,7 @@ void NewsItem::version3_1_0 (std::vector<NewsItem>& items) {
     "The `task purge` command removes tasks entirely, in contrast to `task delete` which merely sets\n"
     "the task status to 'Deleted'. This functionality existed in versions 2.x but was temporarily\n"
     "removed in 3.0.\n\n"
-    "The new `auto-purge.on-sync` configuration parameter controls automatic purging of old tasks.\n"
+    "The new `purge.on-sync` configuration parameter controls automatic purging of old tasks.\n"
     "An old task is one with status 'Deleted' that has not been modified in 180 days. This\n"
     "functionality is optional and not enabled by default."
   };

--- a/src/commands/CmdNews.cpp
+++ b/src/commands/CmdNews.cpp
@@ -542,7 +542,7 @@ void NewsItem::version3_1_0 (std::vector<NewsItem>& items) {
   Version version("3.1.0");
   NewsItem sync {
     version,
-    /*title=*/"Purging and Expiring Tasks",
+    /*title=*/"Purging Tasks, Manually or Automatically",
     /*bg_title=*/"",
     /*background=*/"",
     /*punchline=*/
@@ -552,7 +552,7 @@ void NewsItem::version3_1_0 (std::vector<NewsItem>& items) {
     "The `task purge` command removes tasks entirely, in contrast to `task delete` which merely sets\n"
     "the task status to 'Deleted'. This functionality existed in versions 2.x but was temporarily\n"
     "removed in 3.0.\n\n"
-    "The new `expiration.on-sync` configuration parameter controls automatic expiration of old tasks.\n"
+    "The new `auto-purge.on-sync` configuration parameter controls automatic purging of old tasks.\n"
     "An old task is one with status 'Deleted' that has not been modified in 180 days. This\n"
     "functionality is optional and not enabled by default."
   };

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -160,7 +160,7 @@ int CmdShow::execute (std::string& output)
     " due"
     " editor"
     " exit.on.missing.db"
-    " expiration.on-sync"
+    " auto-purge.on-sync"
     " expressions"
     " fontunderline"
     " gc"

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -160,7 +160,7 @@ int CmdShow::execute (std::string& output)
     " due"
     " editor"
     " exit.on.missing.db"
-    " auto-purge.on-sync"
+    " purge.on-sync"
     " expressions"
     " fontunderline"
     " gc"

--- a/src/commands/CmdSync.cpp
+++ b/src/commands/CmdSync.cpp
@@ -109,7 +109,7 @@ int CmdSync::execute (std::string& output)
   Context &context = Context::getContext ();
   context.tdb2.sync(std::move(server), false);
 
-  if (context.config.getBoolean ("expiration.on-sync")) {
+  if (context.config.getBoolean ("auto-purge.on-sync")) {
     context.tdb2.expire_tasks ();
   }
 

--- a/src/commands/CmdSync.cpp
+++ b/src/commands/CmdSync.cpp
@@ -109,7 +109,7 @@ int CmdSync::execute (std::string& output)
   Context &context = Context::getContext ();
   context.tdb2.sync(std::move(server), false);
 
-  if (context.config.getBoolean ("auto-purge.on-sync")) {
+  if (context.config.getBoolean ("purge.on-sync")) {
     context.tdb2.expire_tasks ();
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set (pythonTests
   annotate.test.py
   append.test.py
   args.test.py
+  auto-purge.test.py
   bash_completion.test.py
   blocked.test.py
   bulk.test.py
@@ -111,7 +112,6 @@ set (pythonTests
   encoding.test.py
   enpassant.test.py
   exec.test.py
-  expiration.test.py
   export.test.py
   feature.559.test.py
   feature.default.project.test.py

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,7 +73,6 @@ set (pythonTests
   annotate.test.py
   append.test.py
   args.test.py
-  auto-purge.test.py
   bash_completion.test.py
   blocked.test.py
   bulk.test.py
@@ -147,6 +146,7 @@ set (pythonTests
   prepend.test.py
   pri_sort.test.py
   project.test.py
+  purge.test.py
   quotes.test.py
   rc.override.test.py
   recurrence.test.py

--- a/test/auto-purge.test.py
+++ b/test/auto-purge.test.py
@@ -37,7 +37,7 @@ from basetest import Task, TestCase
 from basetest.utils import mkstemp
 
 
-class TestImport(TestCase):
+class TestAutoPurge(TestCase):
     def setUp(self):
         self.t = Task()
         # Set up local sync within the TASKDATA directory, so that it will be
@@ -48,8 +48,8 @@ class TestImport(TestCase):
         code, out, err = self.t(f"_get {uuid}.status")
         return out.strip() != ""
 
-    def test_expiration(self):
-        """Only tasks that are deleted and have a modification in the past are expired."""
+    def test_auto_purge(self):
+        """Only tasks that are deleted and have a modification in the past are purged."""
         yesterday = int(time.time()) - 3600 * 24
         last_year = int(time.time()) - 265 * 3600 * 24
         old_pending = "a1111111-a111-a111-a111-a11111111111"
@@ -66,16 +66,16 @@ class TestImport(TestCase):
         code, out, err = self.t("import -", input=task_data)
         self.assertIn("Imported 4 tasks", err)
 
-        # By default, expiration does not occur.
+        # By default, auto-purge does not occur.
         code, out, err = self.t("sync")
         self.assertTrue(self.exists(old_pending))
         self.assertTrue(self.exists(old_completed))
         self.assertTrue(self.exists(new_deleted))
         self.assertTrue(self.exists(old_deleted))
 
-        # Configure expiration on sync. The old_deleted task
+        # Configure auto-purge on sync. The old_deleted task
         # should be removed.
-        self.t.config("expiration.on-sync", "1")
+        self.t.config("auto-purge.on-sync", "1")
         code, out, err = self.t("sync")
         self.assertTrue(self.exists(old_pending))
         self.assertTrue(self.exists(old_completed))

--- a/test/purge.test.py
+++ b/test/purge.test.py
@@ -66,16 +66,16 @@ class TestAutoPurge(TestCase):
         code, out, err = self.t("import -", input=task_data)
         self.assertIn("Imported 4 tasks", err)
 
-        # By default, auto-purge does not occur.
+        # By default, purge does not occur.
         code, out, err = self.t("sync")
         self.assertTrue(self.exists(old_pending))
         self.assertTrue(self.exists(old_completed))
         self.assertTrue(self.exists(new_deleted))
         self.assertTrue(self.exists(old_deleted))
 
-        # Configure auto-purge on sync. The old_deleted task
+        # Configure purge on sync. The old_deleted task
         # should be removed.
-        self.t.config("auto-purge.on-sync", "1")
+        self.t.config("purge.on-sync", "1")
         code, out, err = self.t("sync")
         self.assertTrue(self.exists(old_pending))
         self.assertTrue(self.exists(old_completed))


### PR DESCRIPTION
Taskwarrior uses "expire" to refer to deletion of tasks past their "until" date, so let's use `auto-purge` to link this semantically to the `task purge` command.

@ryneeverett requesting your review since this is more a question of naming than C++..

Fixes #3402 (again).