### PR TITLE
Actually run shell tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -226,9 +226,9 @@ set (shell_SRCS
 configure_file(bash_tap.sh bash_tap.sh COPYONLY)
 configure_file(bash_tap_tw.sh bash_tap_tw.sh COPYONLY)
 
-foreach (test ${shell_SRCS})
-  add_test(NAME ${test}
-    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/${test}
+foreach (shell_Test ${shell_SRCS})
+  add_test(NAME ${shell_Test}
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/${shell_Test}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
-endforeach(test)
+endforeach(shell_Test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,9 +60,6 @@ foreach (src_FILE ${test_SRCS})
     )
 endforeach (src_FILE)
 
-configure_file(bash_tap.sh bash_tap.sh COPYONLY)
-configure_file(bash_tap_tw.sh bash_tap_tw.sh COPYONLY)
-
 add_subdirectory(basetest)
 add_subdirectory(simpletap)
 
@@ -198,3 +195,40 @@ foreach (python_Test ${pythonTests})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 endforeach(python_Test)
+
+# -- Shell tests
+
+set (shell_SRCS
+  tw-1637.test.sh
+  tw-1643.test.sh
+  tw-1688.test.sh
+  tw-1715.test.sh
+  tw-1718.test.sh
+  tw-1804.test.sh
+  tw-1883.test.sh
+  tw-1895.test.sh
+  tw-1938.test.sh
+  tw-2124.test.sh
+  tw-2189.test.sh
+  tw-2257.test.sh
+  tw-2386.test.sh
+  tw-2392.test.sh
+  tw-2429.test.sh
+  tw-2451.test.sh
+  tw-2514.test.sh
+  tw-2530.test.sh
+  tw-2550.test.sh
+  tw-2581.test.sh
+  tw-3102.test.sh
+  tw-3109.test.sh
+)
+
+configure_file(bash_tap.sh bash_tap.sh COPYONLY)
+configure_file(bash_tap_tw.sh bash_tap_tw.sh COPYONLY)
+
+foreach (test ${shell_SRCS})
+  add_test(NAME ${test}
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/${test}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+endforeach(test)

--- a/test/bash_tap.sh
+++ b/test/bash_tap.sh
@@ -8,13 +8,7 @@ function bashtap_on_error {
     # $bashtap_line contains the last executed line, or an error.
     echo -n "$bashtap_output"
 
-    # Determine if this failure was expected
-    if [[ ! -z "$EXPFAIL" ]]
-    then
-        todo_suffix=" # TODO"
-    fi
-
-    echo "not ok 1 - ${bashtap_line}${todo_suffix}"
+    echo "not ok 1 - ${bashtap_line}"
     bashtap_clean_tmpdir
 }
 
@@ -81,41 +75,35 @@ function bashtap_get_absolute_path {
 bashtap_org_pwd=$(pwd)
 bashtap_org_script=$(bashtap_get_absolute_path "$0")
 
-if [ "${0:(-2)}" == ".t" ] || [ "$1" == "-t" ]; then
-    # Make sure any failing commands are caught.
-    set -e
-    set -o pipefail
+# Make sure any failing commands are caught.
+set -e
+set -o pipefail
 
-    # TAP header. Hardcoded number of tests, 1.
-    echo "1..1"
+# TAP header. Hardcoded number of tests, 1.
+echo "1..1"
 
-    # Output TAP failure on early exit.
-    trap bashtap_on_error EXIT
+# Output TAP failure on early exit.
+trap bashtap_on_error EXIT
 
-    # The different calls to mktemp are necessary for OSX compatibility.
-    bashtap_tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'bash_tap')
-    if [ ! -z "$bashtap_tmpdir" ]; then
-        cd "$bashtap_tmpdir"
-    else
-        bashtap_line="Unable to create temporary directory."
-        exit 1
-    fi
-
-    # Scripts sourced before bash_tap.sh may declare this function.
-    if declare -f bashtap_setup >/dev/null; then
-        bashtap_setup
-    fi
-
-    # Run test file interpreting failing commands as a test failure.
-    bashtap_run_testcase && echo "ok 1"
-
-    # Since we're in a sourced file and just ran the parent script,
-    # exit without running it a second time.
-    trap - EXIT
-    bashtap_clean_tmpdir
-    exit
+# The different calls to mktemp are necessary for OSX compatibility.
+bashtap_tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'bash_tap')
+if [ ! -z "$bashtap_tmpdir" ]; then
+    cd "$bashtap_tmpdir"
 else
-    if declare -f bashtap_setup >/dev/null; then
-        bashtap_setup
-    fi
+    bashtap_line="Unable to create temporary directory."
+    exit 1
 fi
+
+# Scripts sourced before bash_tap.sh may declare this function.
+if declare -f bashtap_setup >/dev/null; then
+    bashtap_setup
+fi
+
+# Run test file interpreting failing commands as a test failure.
+bashtap_run_testcase && echo "ok 1"
+
+# Since we're in a sourced file and just ran the parent script,
+# exit without running it a second time.
+trap - EXIT
+bashtap_clean_tmpdir
+exit

--- a/test/bash_tap_tw.sh
+++ b/test/bash_tap_tw.sh
@@ -13,7 +13,7 @@
 
 function setup_taskrc {
     # Configuration
-    for i in pending.data completed.data undo.data backlog.data taskrc; do
+    for i in taskchampion.sqlite3 taskrc; do
        if [ -f "$i" ]; then
            rm "$i" 2>&1 >/dev/null
        fi
@@ -26,6 +26,7 @@ function setup_taskrc {
     echo 'color.header=rgb025'            >> taskrc
     echo 'color.footer=rgb025'            >> taskrc
     echo 'color.error=bold white on red'  >> taskrc
+    echo 'news.version=99.0.0'            >> taskrc
 }
 
 function find_task_binary {

--- a/test/tw-2124.test.sh
+++ b/test/tw-2124.test.sh
@@ -7,9 +7,3 @@
 # Filtering for description with a dash works
 task add foo-bar
 task foo-bar list | grep foo-bar
-
-# Filtering for tag with dash does not work right now
-export EXPFAIL=true
-
-task add test +one-two
-task +one-two list

--- a/test/tw-2514.test.sh
+++ b/test/tw-2514.test.sh
@@ -7,8 +7,6 @@ task 1 mod start:yesterday+18h
 task 1 done end:yesterday+20h
 
 # this does not work without journal.info
-export EXPFAIL=true
-
 # Check that 2 hour interval is reported by task info
-task info | grep -F "Start deleted"
-[[ ! -z `task info | grep -F "Start deleted (duration: 2:00:00)."` ]]
+#task info | grep -F "Start deleted"
+#[[ ! -z `task info | grep -F "Start deleted (duration: 2:00:00)."` ]]


### PR DESCRIPTION
Two of these used EXPFAIL which, because nothing is interpreting the TAP output, does not work. So, that functionality is removed, and the expected-to-fail bits are commented out or removed.

There was a conditional on the filename in `bash_tap.sh` which caused it to not actually do anything and just run the test as a simple shell script. That, too, has been removed.