### PR TITLE
Optionally use system provided corrosion

### DIFF
--- a/src/tc/CMakeLists.txt
+++ b/src/tc/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required (VERSION 3.22)
 
-add_subdirectory(${CMAKE_SOURCE_DIR}/src/tc/corrosion)
+OPTION(SYSTEM_CORROSION "Use system provided corrosion instead of vendored version" OFF)
+if(SYSTEM_CORROSION)
+  find_package(Corrosion REQUIRED)
+else()
+  add_subdirectory(${CMAKE_SOURCE_DIR}/src/tc/corrosion)
+endif()
 
 # Import taskchampion-lib as a CMake library.
 corrosion_import_crate(


### PR DESCRIPTION
As I mentioned in #3348, some distros (or devs) prefer to use the corrosion version provided by their distro. This adds a CMake option to do that instead of taking the vendored one.
