### PR TITLE
Add newline in sync error message

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -226,7 +226,7 @@ void TDB2::get_changes(std::vector<Task>& changes) {
 void TDB2::revert() {
   rust::Vec<tc::Operation> undo_ops = replica()->get_undo_operations();
   if (undo_ops.size() == 0) {
-    std::cout << "No operations to undo.";
+    std::cout << "No operations to undo.\n";
     return;
   }
   if (confirm_revert(undo_ops)) {


### PR DESCRIPTION
I noticed this in my own usage, after trying to `task undo` after a sync had completed.