### PR TITLE
Add some instructions to the MSRV

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,9 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
+          # If this version is old enough to cause errors, or older than the
+          # TaskChampion MSRV, bump it to the MSRV of the currently-required
+          # TaskChampion package; if necessary, bump that version as well.
           toolchain: "1.73.0" # MSRV
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,3 @@ members = [
 ]
 
 resolver = "2"
-
-# All Rust dependencies are defined here, and then referenced by the
-# Cargo.toml's in the members with `foo.workspace = true`.
-[workspace.dependencies]
-anyhow = "1.0"
-ffizz-header = "0.5"
-libc = "0.2.136"
-pretty_assertions = "1"
-regex = "^1.10.2"
-taskchampion = "0.6"


### PR DESCRIPTION
There is no easy way to determine the MSRV for TaskChampion, other than somehow pulling the right version of the source and grepping for it. In practice, if we update the `taskchampion` dependency to one that has a higher MSRV, we'll get a build error and find this comment. And if we get an error building Taskwarrior due to an old MSRV (for example if something changes on `crates.io`) then we will also find this comment.

This also removes some superfluous dependency versions from the root workspace. `src/taskchampion-cpp/Cargo.toml` specifies versions directly.