### PR TITLE
Throw error if trying to set end date for a pending task

### DIFF
--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1476,7 +1476,8 @@ void Task::validate(bool applyDefault /* = true */) {
   // Pending tasks cannot have an end date, remove if present
   if ((status == Task::pending) && (get("end") != "")) {
     remove("end");
-    throw format("Could not modify task {1}. You cannot set an end date on a pending task.", this->id);
+    throw format("Could not modify task {1}. You cannot set an end date on a pending task.",
+                 this->id);
   }
 
   // Provide a modified date unless user already specified one.

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1474,7 +1474,10 @@ void Task::validate(bool applyDefault /* = true */) {
     setAsNow("end");
 
   // Pending tasks cannot have an end date, remove if present
-  if ((status == Task::pending) && (get("end") != "")) remove("end");
+  if ((status == Task::pending) && (get("end") != "")) {
+    remove("end");
+    throw format("Could not modify task {1}. You cannot set an end date on a pending task.", this->id);
+  }
 
   // Provide a modified date unless user already specified one.
   if (!has("modified") || get("modified") == "") setAsNow("modified");

--- a/test/modify.test.py
+++ b/test/modify.test.py
@@ -55,6 +55,16 @@ class TestBug1763(TestCase):
         code, out, err = self.t("1 modify due:")
         self.assertIn("Modified 0 tasks.", out)
 
+class TestBug3584(TestCase):
+    def setUp(self):
+        self.t = Task()
+
+    def test_mod_pending_task_end_date(self):
+        """Adding the end date for a pending task throws an error"""
+        self.t("add foo")
+        code, out, err = self.t.runError("1 modify end:1d")
+        self.assertIn("Could not modify task 1. You cannot set an end date on a pending task.", err)
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner

--- a/test/modify.test.py
+++ b/test/modify.test.py
@@ -55,6 +55,7 @@ class TestBug1763(TestCase):
         code, out, err = self.t("1 modify due:")
         self.assertIn("Modified 0 tasks.", out)
 
+
 class TestBug3584(TestCase):
     def setUp(self):
         self.t = Task()
@@ -63,7 +64,10 @@ class TestBug3584(TestCase):
         """Adding the end date for a pending task throws an error"""
         self.t("add foo")
         code, out, err = self.t.runError("1 modify end:1d")
-        self.assertIn("Could not modify task 1. You cannot set an end date on a pending task.", err)
+        self.assertIn(
+            "Could not modify task 1. You cannot set an end date on a pending task.",
+            err,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3584 
-throw an error if we are trying to set an end date for pending tasks
-tests