### PR TITLE
Check if end date is being set to a pending task

### DIFF
--- a/src/commands/CmdModify.cpp
+++ b/src/commands/CmdModify.cpp
@@ -116,6 +116,11 @@ void CmdModify::checkConsistency(Task &before, Task &after) {
 
   if (before.has("recur") && (!after.has("recur") || after.get("recur") == ""))
     throw std::string("You cannot remove the recurrence from a recurring task.");
+
+  if ((before.getStatus() == Task::pending) && (after.getStatus() == Task::pending) &&
+      (after.get("end") != ""))
+    throw format("Could not modify task {1}. You cannot set an end date on a pending task.",
+                 before.identifier(true));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/modify.test.py
+++ b/test/modify.test.py
@@ -56,6 +56,20 @@ class TestBug1763(TestCase):
         self.assertIn("Modified 0 tasks.", out)
 
 
+class TestBug3584(TestCase):
+    def setUp(self):
+        self.t = Task()
+
+    def test_mod_pending_task_end_date(self):
+        """Adding end date for a pending task throws an error"""
+        self.t("add foo")
+        code, out, err = self.t.runError("1 modify end:1d")
+        self.assertIn(
+            "Could not modify task 1. You cannot set an end date on a pending task.",
+            err,
+        )
+
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
 


### PR DESCRIPTION
Fixes #3584 
- throw error if end date is being set to a pending task
- add a test for the bug