### PR TITLE
Install uuid-dev in GitHub action

### DIFF
--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -17,6 +17,9 @@ jobs:
           toolchain: "stable"
           override: true
 
+      - name: Install uuid-dev
+        run: sudo apt install uuid-dev
+
       - name: make a release tarball and build from it
         run: |
           cmake -S. -Bbuild &&


### PR DESCRIPTION
This started failing in #3646. I'm guessing that the latest Ubuntu image dropped this library, perhaps accidentally.