### PR TITLE
Limit the allowed epoch timestamps

### DIFF
--- a/src/columns/ColTypeDate.cpp
+++ b/src/columns/ColTypeDate.cpp
@@ -190,7 +190,11 @@ void ColumnTypeDate::modify(Task& task, const std::string& value) {
   if (value != "" && evaluatedValue.get_date() == 0)
     throw format("'{1}' is not a valid date in the '{2}' format.", value, Variant::dateFormat);
 
-  task.set(_name, evaluatedValue.get_date());
+  time_t epoch = evaluatedValue.get_date();
+  if (epoch < EPOCH_MIN_VALUE || epoch >= EPOCH_MAX_VALUE) {
+    throw format("'{1}' is not a valid date.", value);
+  }
+  task.set(_name, epoch);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The code for parsing epoch timestamps when displaying tasks only supports values between year 1980 and 9999. Previous to this change, it was possible to set e.g., the due timestamp to a value outside of these limits, which would make it impossible to later on show the task.

With this change, we only allow setting values within the same limits used by the code for displaying tasks.

Fixes https://github.com/GothenburgBitFactory/taskwarrior/issues/3444