### PR TITLE
Pass rc.weekstart to libshared for ISO8601 weeknum parsing if "monday"

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1105,6 +1105,11 @@ void Context::staticInitialization() {
   Task::regex = Variant::searchUsingRegex = config.getBoolean("regex");
   Lexer::dateFormat = Variant::dateFormat = config.get("dateformat");
 
+  auto weekStart = Datetime::dayOfWeek(config.get("weekstart"));
+  if (weekStart != 0 && weekStart != 1)
+    throw std::string(
+        "The 'weekstart' configuration variable may only contain 'Sunday' or 'Monday'.");
+  Datetime::weekstart = weekStart;
   Datetime::isoEnabled = config.getBoolean("date.iso");
   Datetime::standaloneDateEnabled = false;
   Datetime::standaloneTimeEnabled = false;

--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -404,12 +404,7 @@ int CmdCalendar::execute(std::string& output) {
 std::string CmdCalendar::renderMonths(int firstMonth, int firstYear, const Datetime& today,
                                       std::vector<Task>& all, int monthsPerLine) {
   auto& config = Context::getContext().config;
-
-  // What day of the week does the user consider the first?
-  auto weekStart = Datetime::dayOfWeek(config.get("weekstart"));
-  if (weekStart != 0 && weekStart != 1)
-    throw std::string(
-        "The 'weekstart' configuration variable may only contain 'Sunday' or 'Monday'.");
+  auto weekStart = Datetime::weekstart;
 
   // Build table for the number of months to be displayed.
   Table view;


### PR DESCRIPTION
Libshared `master` branch has been updated to have some consideration of `Datetime::weekstart`: date parsing (in particular week/day numbers) will behave differently depending on whether that value is 0 or 1 (see GothenburgBitFactory/libshared#81).

Previously, that code always behaved as the new code does when `weekstart=0` when parsing dates (weekstart was used *only* for `task calendar`).  The new code will use ISO8601 date parsing if that value is 1, which it is initialized to in the top of the file.  Since this will cause a change in behavior, we can least surprise users by initializing it from user config, which is done in `Context::StaticInitialization()`.

The hardcoded default rcfile sets weekstart to Sunday (0, the existing behavior) so only users that set `rc.weekstart=monday` explicitly will see new ISO8601 date parsing behavior, everyone else should see the same behavior as before.

**Note:** the week shortcuts (`sow`, `sonw`, etc) will still always use Monday weeks, regardless of weekstart, until the additional work mentioned in #3623 is done.  That will be left for a part2 some time later.  We can track that work in #3629.

Old code did not distinguish weekstart, and always used Sunday week parsing:
```
 $ task3.old rc.weekstart=sunday calc 2013-W49
2013-12-01T00:00:00

 $ task3.old rc.weekstart=monday calc 2013-W49
2013-12-01T00:00:00
```

The date 2013-12-01 is actually in week 48 for both Sunday and Monday-based weeks, and week 49 only begins on the 2nd, which is seen correctly in ISO-8601 weeks:
```
 $ date -d 2013-12-01 +s:%U,m:%V
s:48,m:48

 $ date -d 2013-12-02 +s:%U,m:%V
s:48,m:49
```

This is reflected in the new code when Monday is selected as the weekstart:
```
 $ src/task rc.weekstart=sunday calc 2013-W49
2013-12-01T00:00:00

 $ src/task rc.weekstart=monday calc 2013-W49
2013-12-02T00:00:00

 $ env - ncal -w -M 12 2013
    December 2013
Mo     2  9 16 23 30
Tu     3 10 17 24 31
We     4 11 18 25
Th     5 12 19 26
Fr     6 13 20 27
Sa     7 14 21 28
Su  1  8 15 22 29
   48 49 50 51 52  1
```

The old code is left intact when Sunday-based weeks are used.  It seems to be Taskwarrior's own definition of weeks, since it differs from `strftime()` expansion `%U`, as noted above.  Nonetheless, the Sunday behavior was left unchanged from previous Taskwarrior versions, and that remains the default.  For correctness, it is recommended for users to configure Monday-based weeks, which would now be determined using an ISO-8601 standard algorithm.

Please apply, thanks.

1. Fixes #3623 (brings in new weekstart code from libshared)
2. Fixes #2922 (considers weekstart when parsing week numbers)
3. Unblocks #3651 (updates libshared peg to current master)
4. Enables #3629 (part1 done for parsing; more work needed)
