### PR TITLE
Fix missing line in man task-color

### DIFF
--- a/doc/man/task-color.5.in
+++ b/doc/man/task-color.5.in
@@ -278,7 +278,7 @@ The keyword rule shown here as 'keyword.' corresponds to a wildcard pattern,
 meaning 'color.keyword.*', or in other words all the keyword rules.
 
 There is also 'color.project.none', 'color.tag.none' and
-'color.uda.priority.none' to specifically represent missing data.
+\[aq]color.uda.priority.none' to specifically represent missing data.
 
 .SH THEMES
 Taskwarrior supports themes.  What this really means is that with the ability to


### PR DESCRIPTION
Escape leading single quote to prevent groff misinterpretation as a control character.

## Issue
In `man 5 task-color`, the sentence cuts off unexpectedly:
`There is also 'color.project.none', 'color.tag.none' and`
This occurs just before the `THEMES` section.

![screenshot-2024-11-05-01-35-39](https://github.com/user-attachments/assets/a52158a2-ea85-4ddf-940a-f5135c1ca11a)


## Explanation
According to `man 7 groff` [documentation](https://man7.org/linux/man-pages/man7/groff.7.html#Syntax_characters), a leading single quote `'` is interpreted as a **control character** and should be escaped as `\[aq]` to render correctly.

<pre>
       '   The neutral apostrophe is the no-break control character,
           recognized where the control character is.  It suppresses the
           (first) break implied by the .bp, .cf, .fi, .fl, .in, .nf,
           .rj, .sp, .ti, and .trf requests.  The requested operation
           takes effect at the next break.  It makes .br nilpotent.  The
           no-break control character can be changed with the .c2
           request.  When formatted, “'” may be typeset as a
           typographical quotation mark; use the \[aq] special character
           escape sequence to format a neutral apostrophe glyph.
</pre>

The `man 7 groff_char` [page](https://man7.org/linux/man-pages/man7/groff_char.7.html) provides further details on character usage, and there has been long-standing [discussion](https://groff.gnu.narkive.com/NO7CXAb7/getting-properly-rendered-single-quotes-in) about this issue.

As suggested in the `Getting Started` section of `man 1 groff` [documentation](https://www.man7.org/linux/man-pages/man1/groff.1.html), here’s a quick way of testing the escaped sequences output:

```bash
echo "\[aq]test" | groff -Tascii | sed '/^$/d'
```

For UTF-8:
```bash
echo "\[aq]test" | groff -Tutf8 | sed '/^$/d'
```

## Other options
Other approaches considered:
- **Move the word "and"** from the previous line to avoid starting with a single quote. However, a linter might reformat this in the future, returning it to the original state
- **Use the `\'` escape sequence** which renders as `’` rather than `'`
- **Use `\(aq` instead of `\[aq]`** — while shorter, `\[aq]` clearly separates the escape sequence from the text, and documentation specifically recommends it