### PR TITLE
Add `color.calendar.scheduled` to `no-color.theme`

### DIFF
--- a/doc/rc/bubblegum-256.theme
+++ b/doc/rc/bubblegum-256.theme
@@ -84,6 +84,7 @@ color.calendar.due=color0 on rgb325
 color.calendar.due.today=color0 on rgb404
 color.calendar.holiday=color15 on rgb102
 color.calendar.overdue=color0 on color5
+color.calendar.scheduled=
 color.calendar.today=color15 on rgb103
 color.calendar.weekend=gray12 on gray3
 color.calendar.weeknumber=rgb104

--- a/doc/rc/dark-16.theme
+++ b/doc/rc/dark-16.theme
@@ -86,6 +86,7 @@ color.calendar.due=white on red
 color.calendar.due.today=bold white on red
 color.calendar.holiday=black on bright yellow
 color.calendar.overdue=black on bright red
+color.calendar.scheduled=
 color.calendar.today=bold white on bright blue
 color.calendar.weekend=white on bright black
 color.calendar.weeknumber=bold blue

--- a/doc/rc/dark-256.theme
+++ b/doc/rc/dark-256.theme
@@ -82,6 +82,7 @@ color.summary.bar=black on rgb141
 color.calendar.due.today=color15 on color1
 color.calendar.due=color0 on color1
 color.calendar.holiday=color0 on color11
+color.calendar.scheduled=
 color.calendar.overdue=color0 on color9
 color.calendar.today=color15 on rgb013
 color.calendar.weekend=on color235

--- a/doc/rc/dark-blue-256.theme
+++ b/doc/rc/dark-blue-256.theme
@@ -83,6 +83,7 @@ color.calendar.due.today=color0 on color252
 color.calendar.due=color0 on color249
 color.calendar.holiday=color255 on rgb013
 color.calendar.overdue=color0 on color255
+color.calendar.scheduled=
 color.calendar.today=color0 on rgb115
 color.calendar.weekend=on color235
 color.calendar.weeknumber=rgb015

--- a/doc/rc/dark-gray-256.theme
+++ b/doc/rc/dark-gray-256.theme
@@ -83,6 +83,7 @@ color.calendar.due=on gray8
 color.calendar.due.today=black on gray15
 color.calendar.holiday=black on gray20
 color.calendar.overdue=gray2 on gray10
+color.calendar.scheduled=
 color.calendar.today=bold white
 color.calendar.weekend=on gray2
 color.calendar.weeknumber=gray6

--- a/doc/rc/dark-gray-blue-256.theme
+++ b/doc/rc/dark-gray-blue-256.theme
@@ -83,6 +83,7 @@ color.calendar.due=color0 on gray10
 color.calendar.due.today=color0 on gray15
 color.calendar.holiday=color15 on rgb005
 color.calendar.overdue=color0 on gray20
+color.calendar.scheduled=
 color.calendar.today=underline black on color15
 color.calendar.weekend=on gray4
 color.calendar.weeknumber=gray10

--- a/doc/rc/dark-green-256.theme
+++ b/doc/rc/dark-green-256.theme
@@ -83,6 +83,7 @@ color.calendar.due.today=color0 on color225
 color.calendar.due=color0 on color249
 color.calendar.holiday=rgb151 on rgb020
 color.calendar.overdue=color0 on color255
+color.calendar.scheduled=
 color.calendar.today=color0 on rgb151
 color.calendar.weekend=on color235
 color.calendar.weeknumber=rgb010

--- a/doc/rc/dark-red-256.theme
+++ b/doc/rc/dark-red-256.theme
@@ -83,6 +83,7 @@ color.calendar.due.today=color0 on color252
 color.calendar.due=color0 on color249
 color.calendar.holiday=rgb522 on rgb300
 color.calendar.overdue=color0 on color255
+color.calendar.scheduled=
 color.calendar.today=color0 on rgb511
 color.calendar.weekend=on color235
 color.calendar.weeknumber=rgb100

--- a/doc/rc/dark-violets-256.theme
+++ b/doc/rc/dark-violets-256.theme
@@ -83,6 +83,7 @@ color.calendar.due=color0 on rgb325
 color.calendar.due.today=color0 on rgb404
 color.calendar.holiday=color15 on rgb102
 color.calendar.overdue=color0 on color5
+color.calendar.scheduled=
 color.calendar.today=color15 on rgb103
 color.calendar.weekend=gray12 on gray3
 color.calendar.weeknumber=rgb104

--- a/doc/rc/dark-yellow-green.theme
+++ b/doc/rc/dark-yellow-green.theme
@@ -83,6 +83,7 @@ color.calendar.due=color0 on rgb440
 color.calendar.due.today=color0 on rgb430
 color.calendar.holiday=rgb151 on rgb020
 color.calendar.overdue=color0 on rgb420
+color.calendar.scheduled=
 color.calendar.today=color15 on rgb110
 color.calendar.weekend=on color235
 color.calendar.weeknumber=rgb110

--- a/doc/rc/light-16.theme
+++ b/doc/rc/light-16.theme
@@ -83,6 +83,7 @@ color.calendar.due=on bright green
 color.calendar.due.today=blue on bright yellow
 color.calendar.holiday=on yellow
 color.calendar.overdue=on bright red
+color.calendar.scheduled=
 color.calendar.today=blue
 color.calendar.weekend=on white
 color.calendar.weeknumber=blue

--- a/doc/rc/light-256.theme
+++ b/doc/rc/light-256.theme
@@ -83,6 +83,7 @@ color.calendar.due=on rgb343
 color.calendar.due.today=on rgb353
 color.calendar.holiday=color0 on rgb530
 color.calendar.overdue=on rgb533
+color.calendar.scheduled=
 color.calendar.today=rgb005
 color.calendar.weekend=on gray21
 color.calendar.weeknumber=gray16

--- a/doc/rc/no-color.theme
+++ b/doc/rc/no-color.theme
@@ -86,6 +86,7 @@ color.calendar.due=
 color.calendar.due.today=
 color.calendar.holiday=
 color.calendar.overdue=
+color.calendar.scheduled=
 color.calendar.today=
 color.calendar.weekend=
 color.calendar.weeknumber=

--- a/doc/rc/solarized-dark-256.theme
+++ b/doc/rc/solarized-dark-256.theme
@@ -100,6 +100,7 @@ color.calendar.due=color0 on color9
 color.calendar.due.today=color0 on color1
 color.calendar.holiday=color0 on color3
 color.calendar.overdue=color0 on color5
+color.calendar.scheduled=
 color.calendar.today=color0 on color4
 color.calendar.weekend=on color0
 color.calendar.weeknumber=color4

--- a/doc/rc/solarized-light-256.theme
+++ b/doc/rc/solarized-light-256.theme
@@ -100,6 +100,7 @@ color.calendar.due=color7 on color9
 color.calendar.due.today=color7 on color1
 color.calendar.holiday=color7 on color3
 color.calendar.overdue=color7 on color5
+color.calendar.scheduled=
 color.calendar.today=color7 on color4
 color.calendar.weekend=on color7
 color.calendar.weeknumber=color14


### PR DESCRIPTION
## Issue
The built-in `no-color.theme` file lacks a `color.calendar.scheduled setting`, causing this color to remain active with the default settings rather than being reset.

![screenshot-2024-11-05-14-22-25](https://github.com/user-attachments/assets/0712e225-6efc-435e-ab20-1ca04fe616dd)

> There is a `no-color.theme` file that has no color at all, and while this sounds useless, it allows you to start with no color, and add your own. If you are building your own theme, this is what you would start with.

[Documentation](https://taskwarrior.org/docs/themes/#default-theme)

## Other considerations
It may be beneficial to add this setting to other built-in themes as well. However, including `color.calendar.scheduled=` directly would reset any color currently assigned by default. As an alternative, I could add a commented-out placeholder line `# color.calendar.scheduled=` to avoid interfering with existing color settings while providing a hint for future customization. Let me know if this approach would be useful.