### PR TITLE
add cpp standard flag to cmake

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4.1.6
 
       - name: Configure project
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_CXX_STANDARD=17
 
       - name: Build project
         run: cmake --build build --target test_runner --target task_executable


### PR DESCRIPTION
See documentation in CMake.
https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html

Fixes #3682
