### PR TITLE
Introducing Taskwarrior Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ extensions](https://taskwarrior.org/tools/).
 [![Arch](https://img.shields.io/archlinux/v/extra/x86_64/task)](https://archlinux.org/packages/extra/x86_64/task/)
 [![Debian](https://img.shields.io/debian/v/task/testing)](https://packages.debian.org/search?keywords=task&searchon=names&suite=all&section=all)
 [![Fedora](https://img.shields.io/fedora/v/task)](https://bodhi.fedoraproject.org/updates/?packages=task)
-[![Ubuntu](https://img.shields.io/ubuntu/v/task)](https://packages.ubuntu.com/search?keywords=task&searchon=names&suite=hirsute§ion=all)
+[![Homebrew](https://img.shields.io/homebrew/v/task)](https://formulae.brew.sh/formula/task#default)
 [![Ubuntu](https://img.shields.io/ubuntu/v/task)](https://packages.ubuntu.com/search?keywords=task&searchon=names&suite=hirsute&section=all)
 
 Taskwarrior is packaged on a wide range of [Linux/Unix systems, Mac OS and

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Release](https://img.shields.io/github/v/release/GothenburgBitFactory/taskwarrior)](https://github.com/GothenburgBitFactory/taskwarrior/releases/latest)
 [![Release date](https://img.shields.io/github/release-date/GothenburgBitFactory/taskwarrior)](https://github.com/GothenburgBitFactory/taskwarrior/releases/latest)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/GothenburgBitFactory?color=green)](https://github.com/sponsors/GothenburgBitFactory/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Taskwarrior%20Guru-006BFF)](https://gurubase.io/g/taskwarrior)
 </br>
 </div>
 
@@ -23,7 +24,7 @@ extensions](https://taskwarrior.org/tools/).
 [![Arch](https://img.shields.io/archlinux/v/extra/x86_64/task)](https://archlinux.org/packages/extra/x86_64/task/)
 [![Debian](https://img.shields.io/debian/v/task/testing)](https://packages.debian.org/search?keywords=task&searchon=names&suite=all&section=all)
 [![Fedora](https://img.shields.io/fedora/v/task)](https://bodhi.fedoraproject.org/updates/?packages=task)
-[![Homebrew](https://img.shields.io/homebrew/v/task)](https://formulae.brew.sh/formula/task#default)
+[![Ubuntu](https://img.shields.io/ubuntu/v/task)](https://packages.ubuntu.com/search?keywords=task&searchon=names&suite=hirsute§ion=all)
 [![Ubuntu](https://img.shields.io/ubuntu/v/task)](https://packages.ubuntu.com/search?keywords=task&searchon=names&suite=hirsute&section=all)
 
 Taskwarrior is packaged on a wide range of [Linux/Unix systems, Mac OS and


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Taskwarrior Guru](https://gurubase.io/g/taskwarrior) to Gurubase. Taskwarrior Guru uses the data from this repo and data from the [docs](https://taskwarrior.org/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Taskwarrior Guru", which highlights that Taskwarrior now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Taskwarrior Guru in Gurubase, just let me know that's totally fine.
