### PR TITLE
Updating the URL for Migration Documentation

### DIFF
--- a/src/commands/CmdCustom.cpp
+++ b/src/commands/CmdCustom.cpp
@@ -242,7 +242,7 @@ int CmdCustom::execute(std::string& output) {
     Color warning = Color(Context::getContext().config.get("color.warning"));
     std::cerr << warning.colorize(format("Found existing '*.data' files in {1}", location)) << "\n";
     std::cerr << "  Taskwarrior's storage format changed in 3.0, requiring a manual migration.\n";
-    std::cerr << "  See https://github.com/GothenburgBitFactory/taskwarrior/releases.\n";
+    std::cerr << "  See https://taskwarrior.org/docs/upgrade-3/\n";
   }
 
   feedback_backlog();


### PR DESCRIPTION
When I run `task list` with a 2.x`.taskrc` (using taskwarrior 3.1.0), I get the following message:
```
task list
Found existing '*.data' files in /Users/geoffp/.task
  Taskwarrior's storage format changed in 3.0, requiring a manual migration.
  See https://github.com/GothenburgBitFactory/taskwarrior/releases.
No matches.
```

Unfortunately this URL is confusing as I couldn't find any migration data there (it now routes to changelog for 3.2.0).

A better approach is to point the user directly at the user documentation for the 3.0 migration.