### PR TITLE
Include cxxbridge-cmd in Cargo.lock, check version consistency

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,3 +64,19 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  cargo-metadata:
+    runs-on: ubuntu-latest
+    name: "Cargo Metadata"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt
+          toolchain: stable
+          override: true
+
+      - name: "Check metadata"
+        run: ".github/workflows/metadata-check.sh"

--- a/.github/workflows/metadata-check.sh
+++ b/.github/workflows/metadata-check.sh
@@ -1,0 +1,73 @@
+#! /bin/bash
+
+# Check the 'cargo metadata' for various requirements
+
+set -e
+
+META=$(mktemp)
+trap 'rm -rf -- "${META}"' EXIT
+
+cargo metadata --locked --format-version 1 > "${META}"
+
+get_version() {
+  local package="${1}"
+  jq -r '.packages[] | select(.name == "'"${package}"'") | .version' "${META}"
+}
+
+get_msrv() {
+  local package="${1}"
+  jq -r '.packages[] | select(.name == "'"${package}"'") | .rust_version' "${META}"
+}
+
+# check that the cxx packages all have the same version
+check_cxx_versions() {
+  local cxx_version=$(get_version "cxx")
+  local cxx_build_version=$(get_version "cxx-build")
+  local cxxbridge_cmd_version=$(get_version "cxx-build")
+  local cxxbridge_flags_version=$(get_version "cxxbridge-flags")
+  local cxxbridge_macro_version=$(get_version "cxxbridge-macro")
+
+  ok=true
+  echo "Found cxx version ${cxx_version}"
+  if [ "${cxx_version}" != "${cxx_build_version}" ]; then
+    echo "Found differing cxx-build version ${cxx_build_version}"
+    ok = false
+  fi
+  if [ "${cxx_version}" != "${cxxbridge_cmd_version}" ]; then
+    echo "Found differing cxxbridge-cmd version ${cxxbridge_cmd_version}"
+    ok = false
+  fi
+  if [ "${cxx_version}" != "${cxxbridge_flags_version}" ]; then
+    echo "Found differing cxxbridge-flags version ${cxxbridge_flags_version}"
+    ok = false
+  fi
+  if [ "${cxx_version}" != "${cxxbridge_macro_version}" ]; then
+    echo "Found differing cxxbridge-macro version ${cxxbridge_macro_version}"
+    ok = false
+  fi
+
+  if ! $ok; then
+    echo "All cxx packages must be at the same version. Fix this in src/taskchampion-cpp/Cargo.toml."
+    exit 1
+  else
+    echo "✓ All cxx packages are at the same version."
+  fi
+}
+
+check_msrv() {
+  local taskchampion_msrv=$(get_msrv taskchampion)
+  local taskchampion_lib_msrv=$(get_msrv taskchampion-lib)
+
+  echo "Found taskchampion MSRV ${taskchampion_msrv}"
+  echo "Found taskchampion-lib MSRV ${taskchampion_lib_msrv}"
+
+  if [ "${taskchampion_msrv}" != "${taskchampion_lib_msrv}" ]; then
+    echo "Those MSRVs should be the same (or taskchampion-lib should be greater, in which case adjust this script)"
+    exit 1
+  else
+    echo "✓ MSRVs are at the same version."
+  fi
+}
+
+check_cxx_versions
+check_msrv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -118,6 +118,7 @@ jobs:
           # If this version is old enough to cause errors, or older than the
           # TaskChampion MSRV, bump it to the MSRV of the currently-required
           # TaskChampion package; if necessary, bump that version as well.
+          # This should match the MSRV in `src/taskchampion-cpp/Cargo.toml`.
           toolchain: "1.73.0" # MSRV
           override: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.128"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ccead7d199d584d139148b04b4a368d1ec7556a1d9ea2548febb1b9d49f9a4"
+checksum = "273dcfd3acd4e1e276af13ed2a43eea7001318823e7a726a6b3ed39b4acc0b82"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -280,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.128"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77953e99f01508f89f55c494bfa867171ef3a6c8cea03d26975368f2121a5c1"
+checksum = "d8b2766fbd92be34e9ed143898fce6c572dc009de39506ed6903e5a05b68914e"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -294,16 +326,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxxbridge-flags"
-version = "1.0.128"
+name = "cxxbridge-cmd"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65777e06cc48f0cb0152024c77d6cf9e4bdb4408e7b48bea993d42fa0f5b02b6"
+checksum = "de30fc7f8b99c54cfd811c581e5af6423a4c45d4774fb5f2534aefa2f345f634"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839fcd5e43464614ffaa989eaf1c139ef1f0c51672a1ed08023307fa1b909ccd"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.128"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98532a60dedaebc4848cb2cba5023337cc9ea3af16a5b062633fabfd9f18fb60"
+checksum = "4b2c1c1776b986979be68bb2285da855f8d8a35851a769fca8740df7c3d07877"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1401,6 +1446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1545,7 @@ version = "0.1.0"
 dependencies = [
  "cxx",
  "cxx-build",
+ "cxxbridge-cmd",
  "taskchampion",
 ]
 

--- a/src/taskchampion-cpp/Cargo.toml
+++ b/src/taskchampion-cpp/Cargo.toml
@@ -3,17 +3,28 @@ name = "taskchampion-lib"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version = "1.73.0"  # MSRV
 
 [lib]
 crate-type = ["staticlib"]
 
 [dependencies]
 taskchampion = "0.9.0"
-cxx = "1.0.124"
+# All three cxx* dependencies must have precisely the same version.
+cxx = "=1.0.124"
 
 [features]
 # use native CA roots, instead of bundled
 tls-native-roots = ["taskchampion/tls-native-roots"]
 
 [build-dependencies]
-cxx-build = "1.0"
+# All three cxx* dependencies must have precisely the same version.
+cxx-build = "=1.0.124"
+
+# Include cxxbridge-cmd in Cargo.lock along with the others. This gives a
+# warning "ignoring invalid dependency `cxxbridge-cmd` which is missing a lib
+# target" but this can be safely ignored.
+# See https://github.com/dtolnay/cxx/issues/1407#issuecomment-2509136343
+[target.'cfg(any())'.dependencies]
+# All three cxx* dependencies must have precisely the same version.
+cxxbridge-cmd = "=1.0.124"


### PR DESCRIPTION
This adds cxxbridge-cmd to Cargo.lock per https://github.com/dtolnay/cxx/issues/1407#issuecomment-2509136343, as linked from #3705.

It adds an MSRV to `src/taskchampion-cpp/Cargo.toml` so that the version of `Cargo.lock` is stil compatible with the MSRV.

It additionally adds a check of the Cargo metadata for all of the cxx* versions agreeing, and for the MSRVs agreeing.

cc: @doronbehar 