### PR TITLE
Rely on cxx to enforce matching versions

### DIFF
--- a/.github/workflows/metadata-check.sh
+++ b/.github/workflows/metadata-check.sh
@@ -9,49 +9,9 @@ trap 'rm -rf -- "${META}"' EXIT
 
 cargo metadata --locked --format-version 1 > "${META}"
 
-get_version() {
-  local package="${1}"
-  jq -r '.packages[] | select(.name == "'"${package}"'") | .version' "${META}"
-}
-
 get_msrv() {
   local package="${1}"
   jq -r '.packages[] | select(.name == "'"${package}"'") | .rust_version' "${META}"
-}
-
-# check that the cxx packages all have the same version
-check_cxx_versions() {
-  local cxx_version=$(get_version "cxx")
-  local cxx_build_version=$(get_version "cxx-build")
-  local cxxbridge_cmd_version=$(get_version "cxx-build")
-  local cxxbridge_flags_version=$(get_version "cxxbridge-flags")
-  local cxxbridge_macro_version=$(get_version "cxxbridge-macro")
-
-  ok=true
-  echo "Found cxx version ${cxx_version}"
-  if [ "${cxx_version}" != "${cxx_build_version}" ]; then
-    echo "Found differing cxx-build version ${cxx_build_version}"
-    ok = false
-  fi
-  if [ "${cxx_version}" != "${cxxbridge_cmd_version}" ]; then
-    echo "Found differing cxxbridge-cmd version ${cxxbridge_cmd_version}"
-    ok = false
-  fi
-  if [ "${cxx_version}" != "${cxxbridge_flags_version}" ]; then
-    echo "Found differing cxxbridge-flags version ${cxxbridge_flags_version}"
-    ok = false
-  fi
-  if [ "${cxx_version}" != "${cxxbridge_macro_version}" ]; then
-    echo "Found differing cxxbridge-macro version ${cxxbridge_macro_version}"
-    ok = false
-  fi
-
-  if ! $ok; then
-    echo "All cxx packages must be at the same version. Fix this in src/taskchampion-cpp/Cargo.toml."
-    exit 1
-  else
-    echo "✓ All cxx packages are at the same version."
-  fi
 }
 
 check_msrv() {
@@ -69,5 +29,4 @@ check_msrv() {
   fi
 }
 
-check_cxx_versions
 check_msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,25 +300,26 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.124"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273dcfd3acd4e1e276af13ed2a43eea7001318823e7a726a6b3ed39b4acc0b82"
+checksum = "05e1ec88093d2abd9cf1b09ffd979136b8e922bf31cad966a8fe0d73233112ef"
 dependencies = [
  "cc",
+ "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
+ "foldhash",
  "link-cplusplus",
 ]
 
 [[package]]
 name = "cxx-build"
-version = "1.0.124"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b2766fbd92be34e9ed143898fce6c572dc009de39506ed6903e5a05b68914e"
+checksum = "9afa390d956ee7ccb41aeed7ed7856ab3ffb4fc587e7216be7e0f83e949b4e6c"
 dependencies = [
  "cc",
  "codespan-reporting",
- "once_cell",
  "proc-macro2",
  "quote",
  "scratch",
@@ -327,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.124"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de30fc7f8b99c54cfd811c581e5af6423a4c45d4774fb5f2534aefa2f345f634"
+checksum = "3c23bfff654d6227cbc83de8e059d2f8678ede5fc3a6c5a35d5c379983cc61e6"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -340,18 +341,19 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.124"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839fcd5e43464614ffaa989eaf1c139ef1f0c51672a1ed08023307fa1b909ccd"
+checksum = "f7c01b36e22051bc6928a78583f1621abaaf7621561c2ada1b00f7878fbe2caa"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.124"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2c1c1776b986979be68bb2285da855f8d8a35851a769fca8740df7c3d07877"
+checksum = "f6e14013136fac689345d17b9a6df55977251f11d333c0a571e8d963b55e1f95"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -428,6 +430,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1545,7 +1553,6 @@ version = "0.1.0"
 dependencies = [
  "cxx",
  "cxx-build",
- "cxxbridge-cmd",
  "taskchampion",
 ]
 

--- a/src/taskchampion-cpp/Cargo.toml
+++ b/src/taskchampion-cpp/Cargo.toml
@@ -10,21 +10,11 @@ crate-type = ["staticlib"]
 
 [dependencies]
 taskchampion = "0.9.0"
-# All three cxx* dependencies must have precisely the same version.
-cxx = "=1.0.124"
+cxx = "1.0.133"
 
 [features]
 # use native CA roots, instead of bundled
 tls-native-roots = ["taskchampion/tls-native-roots"]
 
 [build-dependencies]
-# All three cxx* dependencies must have precisely the same version.
-cxx-build = "=1.0.124"
-
-# Include cxxbridge-cmd in Cargo.lock along with the others. This gives a
-# warning "ignoring invalid dependency `cxxbridge-cmd` which is missing a lib
-# target" but this can be safely ignored.
-# See https://github.com/dtolnay/cxx/issues/1407#issuecomment-2509136343
-[target.'cfg(any())'.dependencies]
-# All three cxx* dependencies must have precisely the same version.
-cxxbridge-cmd = "=1.0.124"
+cxx-build = "1.0.133"


### PR DESCRIPTION
Since 1.0.133, the cxxbridge-cmd version in a Cargo.lock will stay in sync with cxx automatically (https://github.com/GothenburgBitFactory/taskwarrior/pull/3712#pullrequestreview-2471488084).