### PR TITLE
Fix suppressing news nag after reading the news

### DIFF
--- a/src/commands/CmdNews.cpp
+++ b/src/commands/CmdNews.cpp
@@ -642,7 +642,7 @@ bool CmdNews::should_nag() {
   Version current_version = Version::Current();
 
   if (news_version == current_version) {
-    return true;
+    return false;
   }
 
   // Check if there are actually any interesting news items to show.


### PR DESCRIPTION
A regression in a99b6084e causes the news nag not to get suppressed after reading the news.