### PR TITLE
Consider news read if `news.version` > current version

### DIFF
--- a/src/commands/CmdNews.cpp
+++ b/src/commands/CmdNews.cpp
@@ -593,7 +593,7 @@ int CmdNews::execute(std::string& output) {
   std::cout << outro.str();
 
   // Set a mark in the config to remember which version's release notes were displayed
-  if (news_version != current_version) {
+  if (news_version < current_version) {
     CmdConfig::setConfigVariable("news.version", std::string(current_version), false);
 
     // Revert back to default signal handling after displaying the outro
@@ -641,7 +641,7 @@ bool CmdNews::should_nag() {
 
   Version current_version = Version::Current();
 
-  if (news_version == current_version) {
+  if (news_version >= current_version) {
     return false;
   }
 


### PR DESCRIPTION
Avoids two installations of taskwarrior with differing versions from constantly nagging and rewriting `news.version`

Note that this potentially isn't the best behavior across major versions updates, although in that case `task news` doesn't display any new items anyways so it's probably fine