### PR TITLE
Enable context based filtering for modify commands

### DIFF
--- a/src/commands/CmdModify.cpp
+++ b/src/commands/CmdModify.cpp
@@ -48,7 +48,7 @@ CmdModify::CmdModify() {
   _read_only = false;
   _displays_id = false;
   _needs_gc = false;
-  _uses_context = false;
+  _uses_context = true;
   _accepts_filter = true;
   _accepts_modifications = true;
   _accepts_miscellaneous = false;


### PR DESCRIPTION
Enable context based filtering for modify commands by setting the parameter to true.

This was tested by running the following commands

```
task add main1
task add main2 +tag1
task context define work "project:Work"
task add project:Work work1
task add project:Work work2 +tag1
task context work

task modify +testtag
task +tag1 modify +testtag2

task context none
task list

## Validate that testtag is set only in work1 and work2
## Validate that testtag2 is set only in work2
```