### PR TITLE
Update git log in CMakeLists.txt to not include potential signatures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif (EXISTS ${CMAKE_SOURCE_DIR}/src/libshared/src AND EXISTS ${CMAKE_SOURCE_DI
 message ("-- Looking for SHA1 references")
 if (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
   set (HAVE_COMMIT true)
-  execute_process (COMMAND git log -1 --pretty=format:%h
+  execute_process (COMMAND git log -1 --pretty=format:%h --no-show-signature
                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                    OUTPUT_VARIABLE COMMIT)
   configure_file ( ${CMAKE_SOURCE_DIR}/commit.h.in


### PR DESCRIPTION
Hey there,

today I tried building taskwarrior from the stable branch, but I got error messages about missing quotes in the commit.h file. Turns out, that capturing the `git log` output for the commit ref, my git configuration added output about the trust of the commits (that are in signed). 

I have added the command line option to hide potential signatures to the CMakeLists.txt, and the commit.h was formatted correct again. 

Before my change:

```c
/* commit.h.in. Creates commit.h during a cmake run */

/* git information */
#define COMMIT "gpg: Signature made Thu 19 Dec 2024 04:57:43 PM CET
gpg:                using RSA key B5690EEEBB952194
gpg: Good signature from "GitHub <noreply@github.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 9684 79A1 AFF9 27E3 7D1A  566B B569 0EEE BB95 2194
1ee69ea21"
``` 

After my change:

```c
/* commit.h.in. Creates commit.h during a cmake run */

/* git information */
#define COMMIT "1ee69ea21"
``` 