### PR TITLE
Update to TaskChampion 2.0.2

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
           # If this version is old enough to cause errors, or older than the
           # TaskChampion MSRV, bump it to the MSRV of the currently-required
           # TaskChampion package; if necessary, bump that version as well.
-          toolchain: "1.78.0" # MSRV
+          toolchain: "1.81.0" # MSRV
           override: true
 
       - uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,7 +119,7 @@ jobs:
           # TaskChampion MSRV, bump it to the MSRV of the currently-required
           # TaskChampion package; if necessary, bump that version as well.
           # This should match the MSRV in `src/taskchampion-cpp/Cargo.toml`.
-          toolchain: "1.78.0" # MSRV
+          toolchain: "1.81.0" # MSRV
           override: true
 
       - uses: actions-rs/cargo@v1.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "taskchampion"
-version = "1.0.2"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e41712ec2dd9cb5e7f4f20daf13a8e0937a927fb886153f2523a6686c35983"
+checksum = "830bb062bb2d89bdee0063d7c02d1e24ee0a1702c683f394eb0520fb88dc4a5c"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/INSTALL
+++ b/INSTALL
@@ -22,7 +22,7 @@ You will need the following libraries:
   - libuuid (not needed for OSX)
 
 You will need a Rust toolchain of the Minimum Supported Rust Version (MSRV):
-  - rust 1.78.0
+  - rust 1.81.0
 
 Basic Installation
 ------------------

--- a/src/taskchampion-cpp/Cargo.toml
+++ b/src/taskchampion-cpp/Cargo.toml
@@ -3,13 +3,13 @@ name = "taskchampion-lib"
 version = "0.1.0"
 edition = "2021"
 publish = false
-rust-version = "1.78.0"  # MSRV
+rust-version = "1.81.0"  # MSRV
 
 [lib]
 crate-type = ["staticlib"]
 
 [dependencies]
-taskchampion = "=1.0.2"
+taskchampion = "=2.0.2"
 cxx = "1.0.133"
 
 [features]

--- a/src/taskchampion-cpp/src/lib.rs
+++ b/src/taskchampion-cpp/src/lib.rs
@@ -494,6 +494,7 @@ fn new_replica_on_disk(
     let storage = tc::StorageConfig::OnDisk {
         taskdb_dir: PathBuf::from(taskdb_dir),
         create_if_missing,
+        access_mode: tc::storage::AccessMode::ReadWrite,
     }
     .into_storage()?;
     Ok(Box::new(tc::Replica::new(storage).into()))


### PR DESCRIPTION
Note that this does not update Taskwarrior to take advantage of the new read-only mode (for #3418).