### PR TITLE
Remove unused, undefined method TDB2::dump

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -451,11 +451,6 @@ int TDB2::num_local_changes() { return (int)replica()->num_local_operations(); }
 int TDB2::num_reverts_possible() { return (int)replica()->num_undo_points(); }
 
 ////////////////////////////////////////////////////////////////////////////////
-void TDB2::dump() {
-  // TODO
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // For any task that has depenencies, follow the chain of dependencies until the
 // end.  Along the way, update the Task::is_blocked and Task::is_blocking data
 // cache.

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -72,8 +72,6 @@ class TDB2 {
   int num_local_changes();
   int num_reverts_possible();
 
-  void dump();
-
   rust::Box<tc::Replica> &replica();
 
  private:


### PR DESCRIPTION
It seems odd to still have a class titled TDB2 around, so I went looking for ways to refactor. But aside from the name, most of what the class is doing makes sense, so the only change I ended up with was dropping this unused method.