### PR TITLE
Fix suppressing news nag after reading the news

### DIFF
--- a/src/commands/CmdNews.cpp
+++ b/src/commands/CmdNews.cpp
@@ -588,6 +588,11 @@ int CmdNews::execute(std::string& output) {
   }
   wait_for_enter();
 
+  // Set a mark in the config to remember which version's release notes were displayed
+  if (news_version < current_version) {
+    CmdConfig::setConfigVariable("news.version", std::string(current_version), false);
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
The news nag suppression regressed again in 5c67d22. That commit intended to remove the sponsorship outro from the news, but also removed the bookkeeping that marks the news as read. This commit reverts that part back to its previous state.