### PR TITLE
change implementation from has

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -354,8 +354,7 @@ bool TDB2::get(const std::string& uuid, Task& task) {
 ////////////////////////////////////////////////////////////////////////////////
 // Locate task by UUID, wherever it is.
 bool TDB2::has(const std::string& uuid) {
-  Task task;
-  return get(uuid, task);
+  return replica()->get_task_data(tc::uuid_from_string(uuid)).is_some();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Change from `get(uuid, task)` to `get_task_data` to always have a full uuid match and to improve read performance for the diagnostics command.

Closes #3848.
