### PR TITLE
use cached urgency() for json exports

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -275,7 +275,7 @@ void Hooks::onAdd(Task& task) const {
 // - all emitted non-JSON lines are considered feedback or error messages
 //   depending on the status code.
 //
-void Hooks::onModify(const Task& before, Task& after) const {
+void Hooks::onModify(Task& before, Task& after) const {
   if (!_enabled) return;
 
   Timer timer;

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -40,7 +40,7 @@ class Hooks {
   void onLaunch() const;
   void onExit() const;
   void onAdd(Task&) const;
-  void onModify(const Task&, Task&) const;
+  void onModify(Task&, Task&) const;
   std::vector<std::string> list() const;
 
  private:

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -777,7 +777,7 @@ void Task::parseLegacy(const std::string& line) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::string Task::composeJSON(bool decorate /*= false*/) const {
+std::string Task::composeJSON(bool decorate /*= false*/) {
   std::stringstream out;
   out << '{';
 

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -894,7 +894,7 @@ std::string Task::composeJSON(bool decorate /*= false*/) const {
 
 #ifdef PRODUCT_TASKWARRIOR
   // Include urgency.
-  if (decorate) out << ',' << "\"urgency\":" << urgency_c();
+  if (decorate) out << ',' << "\"urgency\":" << urgency();
 #endif
 
   out << '}';

--- a/src/Task.h
+++ b/src/Task.h
@@ -68,7 +68,7 @@ class Task {
   Task(rust::Box<tc::TaskData>);
 
   void parse(const std::string&);
-  std::string composeJSON(bool decorate = false) const;
+  std::string composeJSON(bool decorate = false);
 
   // Status values.
   enum status { pending, completed, deleted, recurring, waiting };


### PR DESCRIPTION
speeding up the export of tasks for cases with urgency.inherit=1

fixes #3866 

untested, PR submitted for running GitHub Actions as requested in #3866 