### PR TITLE
Fix compiler warning about unused variable

### DIFF
--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -619,10 +619,9 @@ CmdEdit::editResult CmdEdit::editFile(Task& task) {
   auto dateformat = Context::getContext().config.get("dateformat.edit");
   if (dateformat == "") dateformat = Context::getContext().config.get("dateformat");
 
-  // Change directory for the editor
+  // Change directory for the editor, doing nothing on error.
   auto current_dir = Directory::cwd();
-  int ignored = chdir(location._data.c_str());
-  ++ignored;  // Keep compiler quiet.
+  chdir(location._data.c_str());
 
   // Check if the file already exists, if so, bail out
   Path filepath = Path(file.str());
@@ -702,7 +701,7 @@ ARE_THESE_REALLY_HARMFUL:
 
   // Cleanup.
   File::remove(file.str());
-  ignored = chdir(current_dir.c_str());
+  chdir(current_dir.c_str());
   return changes ? CmdEdit::editResult::changes : CmdEdit::editResult::nochanges;
 }
 


### PR DESCRIPTION
This was added to indicate that the return value of chdir was unused, but newer compilers "see through" this and determine it to be unused. The return value is not marked must-use, so just doing nothing with it is sufficient.

Fixes #3872.