### PR TITLE
Make `tags.none:` filter work again

### DIFF
--- a/src/DOM.cpp
+++ b/src/DOM.cpp
@@ -286,6 +286,13 @@ bool getDOM(const std::string& name, const Task* task, Variant& value) {
       return true;
     }
 
+    // The "tags" property is deprecated, but it is documented as part of the DOM, so simulate it.
+    if (size == 1 && canonical == "tags") {
+      auto tags = ref->getTags();
+      value = Variant(join(",", tags));
+      return true;
+    }
+
     Column* column = Context::getContext().columns[canonical];
 
     if (size == 1 && column) {

--- a/src/commands/CmdEdit.cpp
+++ b/src/commands/CmdEdit.cpp
@@ -317,7 +317,6 @@ void CmdEdit::parseTask(Task& task, const std::string& after, const std::string&
 
   // tags
   value = findValue(after, "\n  Tags:");
-  task.remove("tags");
   task.setTags(split(value, ' '));
 
   // description.


### PR DESCRIPTION
In #3876, this filter didn't work after `task edit`, I think because that was removing the "tags" property. I'm not sure why it was doing that!

However, we shouldn't be relying on this property, since it is deprecated. So this also adds a DOM special-case for `tags` (different from e.g., `tags.next`), as documented in https://taskwarrior.org/docs/dom/. This is already tested (and those tests failed when I got the delimiter wrong), and there's no great way to test the corner-case where this was failing (via `task edit`) so I haven't added any new tests.