### PR TITLE
Correctly handle undo with multiple tasks

### DIFF
--- a/src/commands/CmdUndo.cpp
+++ b/src/commands/CmdUndo.cpp
@@ -102,7 +102,7 @@ bool CmdUndo::confirm_revert(const std::vector<Operation>& undo_ops) {
         view.set(row, 1, mods.str());
       }
       last_uuid = op.get_uuid();
-      mods.clear();
+      mods = std::stringstream();
     }
 
     if (op.is_create()) {

--- a/test/undo.test.py
+++ b/test/undo.test.py
@@ -73,7 +73,13 @@ class TestUndo(TestCase):
         # modification-time updates if the modifications spanned a second boundary.
         self.assertRegex(
             out,
-            '\s+'.join([r"""[0-9a-f-]{36} (Update property 'modified' from\s+'[0-9]+' to '[0-9]+'\s+)?Add tag 'sometag'\s+Add property 'tags' with value 'sometag'"""] * 3))
+            "\s+".join(
+                [
+                    r"""[0-9a-f-]{36} (Update property 'modified' from\s+'[0-9]+' to '[0-9]+'\s+)?Add tag 'sometag'\s+Add property 'tags' with value 'sometag'"""
+                ]
+                * 3
+            ),
+        )
 
     def test_undo_en_passant(self):
         """Verify that en-passant changes during undo are an error"""

--- a/test/undo.test.py
+++ b/test/undo.test.py
@@ -27,6 +27,7 @@
 
 import sys
 import os
+import re
 import unittest
 
 # Ensure python finds the local simpletap module
@@ -60,6 +61,19 @@ class TestUndo(TestCase):
         self.t("undo", input="y\n")
         code, out, err = self.t("_get 1.status")
         self.assertEqual(out.strip(), "pending")
+
+    def test_modify_multiple_tasks(self):
+        """'add' then 'done' then 'undo'"""
+        self.t("add one")
+        self.t("add two")
+        self.t("add three")
+        self.t("rc.bulk=0 1,2,3 modify +sometag")
+        code, out, err = self.t("undo", input="y\n")
+        # This undo output should show one tag modification for each task, possibly with some
+        # modification-time updates if the modifications spanned a second boundary.
+        self.assertRegex(
+            out,
+            '\s+'.join([r"""[0-9a-f-]{36} (Update property 'modified' from\s+'[0-9]+' to '[0-9]+'\s+)?Add tag 'sometag'\s+Add property 'tags' with value 'sometag'"""] * 3))
 
     def test_undo_en_passant(self):
         """Verify that en-passant changes during undo are an error"""


### PR DESCRIPTION
The `std::stringstream::clear` method does not, in fact, clear the string -- it just resets some internal flags. Assigning a new stringstream to the variable is not the most efficient way to do this, but it's the clearest.

Fixes #3885.