### PR TITLE
Use modern FetchContent design patterns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22...4.0)
+cmake_minimum_required (VERSION 3.24...4.0)
 enable_testing()
 
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 enable_testing()
 
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 message ("-- Configuring man pages")
 set (man_FILES task-color.5 task-sync.5 taskrc.5 task.1)
 foreach (man_FILE ${man_FILES})

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 
 configure_file(compare_runs.py compare_runs.py COPYONLY)
 configure_file(load load)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 install (DIRECTORY bash fish vim hooks
          DESTINATION ${TASK_DOCDIR}/scripts)
 install (FILES zsh/_task

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src
                      ${CMAKE_SOURCE_DIR}/src/commands

--- a/src/columns/CMakeLists.txt
+++ b/src/columns/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src
                      ${CMAKE_SOURCE_DIR}/src/commands

--- a/src/commands/CMakeLists.txt
+++ b/src/commands/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src
                      ${CMAKE_SOURCE_DIR}/src/commands

--- a/src/taskchampion-cpp/CMakeLists.txt
+++ b/src/taskchampion-cpp/CMakeLists.txt
@@ -1,13 +1,55 @@
-cmake_minimum_required (VERSION 3.22...4.0)
+cmake_minimum_required (VERSION 3.24...4.0)
 
-OPTION(SYSTEM_CORROSION "Use system provided corrosion instead of vendored version" OFF)
+include(FetchContent)
+
+option(SYSTEM_CORROSION "Use system provided corrosion instead of vendored version" OFF)
+option(TASK_USE_CORROSION_SUBMODULE "Whether to use corrosion from the submodule instead of downloading" OFF)
+set(TASK_CORROSION_VERSION v0.5.2 CACHE STRING "Corrosion version to use in FetchContent")
+
+if(TASK_USE_CORROSION_SUBMODULE)
+  find_package(Git QUIET)
+  if(GIT_FOUND AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/corrosion/.git)
+    # Try to initialize the submodule
+    message(STATUS "Submodule update: corrosion")
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive corrosion
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      RESULT_VARIABLE submodule_res
+    )
+    if(NOT submodule_res EQUAL 0)
+      message(WARNING "git submodule init failed, setting TASK_USE_CORROSION_SUBMODULE to OFF")
+      set(TASK_USE_CORROSION_SUBMODULE OFF CACHE BOOL "(Failed to git submodule init)" FORCE)
+    endif()
+  elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/corrosion/CMakeLists.txt)
+    # Maybe the sources were populated in a different way, use them still
+    message(STATUS "Could not initialize submodule corrosion, but the files were already there")
+  else()
+    message(WARNING "cannot initialize git submodule, setting TASK_USE_CORROSION_SUBMODULE to OFF")
+    set(TASK_USE_CORROSION_SUBMODULE OFF CACHE BOOL "(Cannot git submodule init)" FORCE)
+  endif()
+endif()
+
+if(TASK_USE_CORROSION_SUBMODULE)
+  set(FETCHCONTENT_SOURCE_DIR_CORROSION ${CMAKE_CURRENT_SOURCE_DIR}/corrosion)
+endif()
+if(SYSTEM_CORROSION)
+  # Make sure find_package is always used without FetchContent fallback
+  set(CMAKE_REQUIRE_FIND_PACKAGE_Corrosion ON)
+endif()
+
+FetchContent_Declare(Corrosion
+    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+    GIT_TAG        ${TASK_CORROSION_VERSION}
+    FIND_PACKAGE_ARGS CONFIG
+)
+FetchContent_MakeAvailable(Corrosion)
+
 if(SYSTEM_CORROSION)
   find_package(Corrosion REQUIRED)
 else()
   add_subdirectory(${CMAKE_SOURCE_DIR}/src/taskchampion-cpp/corrosion)
 endif()
 
-OPTION (ENABLE_TLS_NATIVE_ROOTS "Use the system's TLS root certificates" OFF)
+option (ENABLE_TLS_NATIVE_ROOTS "Use the system's TLS root certificates" OFF)
 
 if (ENABLE_TLS_NATIVE_ROOTS)
   message ("Enabling native TLS roots")

--- a/src/taskchampion-cpp/CMakeLists.txt
+++ b/src/taskchampion-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 
 OPTION(SYSTEM_CORROSION "Use system provided corrosion instead of vendored version" OFF)
 if(SYSTEM_CORROSION)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.22...4.0)
 
 # -- C++ tests
 

--- a/test/docker/ubuntu2204
+++ b/test/docker/ubuntu2204
@@ -1,7 +1,14 @@
 FROM ubuntu:22.04
 
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y gpg wget curl
+
+# add Kitware's CMake apt repo
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' > /etc/apt/sources.list.d/kitware.list
+
 RUN apt-get update
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y build-essential cmake git uuid-dev faketime locales python3 curl
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y build-essential git uuid-dev faketime locales python3 cmake
 
 # Setup language environment
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
The modern FetchContent + find_package support allows to streamline the package inclusion patterns where `find_package` is run with a fallback to `FetchContent` unless:
- `SYSTEM_CORROSION`/`CMAKE_REQUIRE_FIND_PACKAGE_Corrosion` is set: `FetchContent` fallback is ignored, `find_package` call is make `REQUIRED`
- `FETCHCONTENT_SOURCE_DIR_CORROSION` (or a few equivalents) is set: `find_package` is not called and it's effectively just a `add_subdirectory` call
- `TASK_USE_CORROSION_SUBMODULE` will try to set `FETCHCONTENT_SOURCE_DIR_CORROSION` after running submodule init, and if it fails, it force sets itself off.

Drive-by change: specify a CMake policy higher bound for future proofing downstream maintenance. Also bumped the minimum CMake to 3.24 for the FetchContent/find_package support.