### PR TITLE
Add shell quoting and 'read -r' in example hooks

### DIFF
--- a/scripts/hooks/on-add
+++ b/scripts/hooks/on-add
@@ -5,12 +5,12 @@
 
 # Input:
 # - Line of JSON for proposed new task.
-read new_task
+read -r new_task
 
 # Output:
 # - JSON, modified or unmodified.
 # - Optional feedback/error.
-echo $new_task
+echo "$new_task"
 echo 'on-add'
 
 # Status:

--- a/scripts/hooks/on-add.the
+++ b/scripts/hooks/on-add.the
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-read new_task
+read -r new_task
 
-if (echo $new_task | grep -qE '[tT]eh');
+if (echo "$new_task" | grep -qE '[tT]eh');
 then
-  new_task=$(echo $new_task | sed -r 's/([tT])eh/\1he/g')
+  new_task=$(echo "$new_task" | sed -r 's/([tT])eh/\1he/g')
   echo "Auto-corrected 'teh' --> 'the'"
 fi
 
-echo $new_task
+echo "$new_task"
 exit 0

--- a/scripts/hooks/on-exit
+++ b/scripts/hooks/on-exit
@@ -10,7 +10,7 @@
 # - Optional feedback/error.
 
 n=0
-while read modified_task
+while read -r modified_task
 do
   n=$(($n + 1))
 done

--- a/scripts/hooks/on-exit.shadow-file
+++ b/scripts/hooks/on-exit.shadow-file
@@ -26,9 +26,9 @@ SHADOW_FILE=$(task _get rc.shadow.file)
 task $SHADOW_COMMAND rc.detection=off rc.gc=off rc.color=off rc.hooks=off > $SHADOW_FILE 2>/dev/null
 if [[ $? != 0 ]]
 then
-  echo Could not create $SHADOW_FILE
+  echo "Could not create $SHADOW_FILE"
   exit 1
 fi
 
-echo Shadow file $SHADOW_FILE updated.
+echo "Shadow file $SHADOW_FILE updated."
 exit 0

--- a/scripts/hooks/on-modify
+++ b/scripts/hooks/on-modify
@@ -6,13 +6,13 @@
 # Input:
 # - line of JSON for the original task
 # - line of JSON for the modified task, the diff being the modification
-read original_task
-read modified_task
+read -r original_task
+read -r modified_task
 
 # Output:
 # - JSON, modified or unmodified.
 # - Optional feedback/error.
-echo $modified_task
+echo "$modified_task"
 echo 'on-modify'
 
 # Status:


### PR DESCRIPTION
This helps to avoid interpretation of escape sequences, such as backslash-escapes, in these values.

Patch provided by @bughunter2 in https://github.com/GothenburgBitFactory/taskwarrior/issues/3899.