### PR TITLE
Update task-sync(5) to highlight AWS support

### DIFF
--- a/doc/man/task-sync.5.in
+++ b/doc/man/task-sync.5.in
@@ -44,7 +44,7 @@ periodically, such as via
 Taskwarrior provides several options for synchronizing your tasks:
 
  - To a server specifically designed to handle Taskwarrior data.
- + To a cloud storage provider. Currently only GCP is supported.
+ + To a cloud storage provider. Currently both AWS and GCP are supported.
  - To a local, on-disk file.
 
 For most of these, you will need an encryption secret used to encrypt and


### PR DESCRIPTION
In #3723 we've added AWS (S3) sync support to taskwarrior.  We even updated most of the docs (all the hard parts, on what actual config settings to set).

In #3921 we noticed one tiny section that still only mentioned GCP support though.  This fixes that!

Fixes #3921 