### PR TITLE
Remove optional spaces before interpreter in shebangs

### DIFF
--- a/.github/workflows/metadata-check.sh
+++ b/.github/workflows/metadata-check.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # Check the 'cargo metadata' for various requirements
 

--- a/doc/rc/refresh
+++ b/doc/rc/refresh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 for i in holidays*rc
 do

--- a/performance/load
+++ b/performance/load
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/performance/run_perf
+++ b/performance/run_perf
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 echo 'Performance: setup'
 rm -f ./taskchampion.sqlite3

--- a/scripts/add-ons/update-holidays.pl
+++ b/scripts/add-ons/update-holidays.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/perl
 ################################################################################
 ##
 ## Copyright 2006 - 2021, Tomas Babej, Paul Beckingham, Federico Hernandez.


### PR DESCRIPTION
The remaining ~200 shebangs in this repo are space-less.