### PR TITLE
Remove asserts that do not necessarily hold

### DIFF
--- a/test/random_sort.test.py
+++ b/test/random_sort.test.py
@@ -47,36 +47,16 @@ class TestRandomSort(TestCase):
     def test_random_sort_deterministic(self):
         """Verify that 'sort:random' with different seeds produces different orderings."""
         # With a fixed seed, the order is always the same.
-        code, out1_seed1, err = self.t(
+        code, out1_seed, err = self.t(
             "rc.debug.random.seed=123 all rc.report.all.sort:random"
         )
-        code, out2_seed1, err = self.t(
+        code, out2_seed, err = self.t(
             "rc.debug.random.seed=123 all rc.report.all.sort:random"
         )
         self.assertEqual(
-            out1_seed1,
-            out2_seed1,
+            out1_seed,
+            out2_seed,
             "Random sort with the same seed should produce the same order",
-        )
-
-        # With a different fixed seed, the order is different.
-        code, out1_seed2, err = self.t(
-            "rc.debug.random.seed=456 all rc.report.all.sort:random"
-        )
-        self.assertNotEqual(
-            out1_seed1,
-            out1_seed2,
-            "Random sort with different seeds should produce different orders",
-        )
-
-    def test_random_and_id_sort(self):
-        """Verify that 'sort:random,id' is not the same as 'sort:id'."""
-        code, out_id, err = self.t("all rc.report.all.sort:id")
-        code, out_random_id, err = self.t(
-            "rc.debug.random.seed=123 all rc.report.all.sort:random,id"
-        )
-        self.assertNotEqual(
-            out_id, out_random_id, "random,id sort should be different from id sort"
         )
 
 


### PR DESCRIPTION
Different seeds might -- but do not have to -- produce different orders.

Similarly, sorting a list by random values might produce the same order as sorting by the ids.

This patch fixes GothenburgBitFactory/taskwarrior#3952.