### PR TITLE
loosen tag restriction to allow all non-whitespace, after the first char

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -772,7 +772,16 @@ task 1,4-10,19 delete
 .TP
 .B +tag|-tag
 Tags are arbitrary words associated with a task. Use + to add a tag and - to
-remove a tag from a task. A task can have any quantity of tags.
+remove a tag from a task. A task can have any quantity of tags.  Tags cannot
+contain whitespace, and cannot start with any of the special characters:
+
+.ig
+    see also taskwarrior:src/Lexer.cpp isSingleCharOperator()
+    see also taskchampion:src/task/task.rs INVALID_TAG_CHARACTERS
+..
+.nf
+    +-*/()<>^!%=~
+.fi
 
 Certain tags (called 'special tags'), can be used to affect the way tasks are
 treated.  For example, if a task has the special tag 'nocolor', then it is

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -708,7 +708,7 @@ bool Lexer::isSet(std::string& token, Lexer::Type& type) {
 ////////////////////////////////////////////////////////////////////////////////
 // Lexer::Type::tag
 //   ^ | '(' | ')' | <unicodeWhitespace>
-//     [ +|- ] <isIdentifierStart> [ <isIdentifierNext> ]*
+//     [ +|- ] <isIdentifierStart> [ <word> ]
 bool Lexer::isTag(std::string& token, Lexer::Type& type) {
   std::size_t marker = _cursor;
 
@@ -721,14 +721,12 @@ bool Lexer::isTag(std::string& token, Lexer::Type& type) {
     ++marker;
 
     if (isIdentifierStart(_text[marker])) {
-      utf8_next_char(_text, marker);
-
-      while (isIdentifierNext(_text[marker])) utf8_next_char(_text, marker);
-
-      token = _text.substr(_cursor, marker - _cursor);
-      type = Lexer::Type::tag;
-      _cursor = marker;
-      return true;
+      if (readWord(_text, marker, token)) {
+        token = _text.substr(_cursor, marker - _cursor);
+        type = Lexer::Type::tag;
+        _cursor = marker;
+        return true;
+      }
     }
   }
 

--- a/test/tag.test.py
+++ b/test/tag.test.py
@@ -595,6 +595,33 @@ class TestBug818(TestCase):
         self.assertIn("four", out)
 
 
+class TestIssue3957(TestCase):
+    def setUp(self):
+        """Executed before each test in the class"""
+        self.t = Task()
+
+    def test_tag_dashes_and_utf8_glyphs(self):
+        """
+        - All non-whitespace valid if not first char
+        - Single char tags work
+        - UTF-8 can work as first/only chars too
+        """
+        crabglyph = "\U0001f980"
+        testtags = ["", "this-test", "that-test.foo", f"foo-{crabglyph}"]
+
+        self.t(f"add{' +'.join(testtags)} one")
+        code, out, err = self.t("_get 1.tags")
+        self.assertEqual(sorted(testtags[1:]), sorted(out.strip().split(",")))
+
+        self.t("add +x two")
+        code, out, err = self.t("_get 2.tags")
+        self.assertEqual("x\n", out)
+
+        self.t(f"add +{crabglyph} three")
+        code, out, err = self.t("_get 3.tags")
+        self.assertEqual(f"{crabglyph}\n", out)
+
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
 


### PR DESCRIPTION
This patch allows tags to be any non-whitespace characters, excepting the first char, which still must be an "identifier" character (see `Lexer::isIdentifier()`), in particular so that "task calc" works with negative numbers and subtraction.  Apparently CLI2 doesn't know the command yet when doing the parse, so it has the same rules for every command.

I tried to get this to work on tags with spaces (for parity with Timewarrior), but could not get it working before I ran out of time to spend on this.  That will have to be left as a future endeavor.  I don't personally use spaces.

In the meantime, at least tags with dashes work now, and tags can also use utf8 chars, including as the first/only character, if they wish.

The patch includes a few extra tests using tags with dashes and glyphs.

Note: I did not test sync.

Fixes #3957