### PR TITLE
Update CMake minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 include (CheckFunctionExists)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 message ("-- Configuring man pages")
 set (man_FILES task-color.5 task-sync.5 taskrc.5 task.1)
 foreach (man_FILE ${man_FILES})

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 add_custom_target (performance ./run_perf
                                DEPENDS task_executable

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 install (DIRECTORY bash fish vim hooks
          DESTINATION ${TASK_DOCDIR}/scripts)
 install (FILES zsh/_task

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src
                      ${CMAKE_SOURCE_DIR}/src/commands

--- a/src/columns/CMakeLists.txt
+++ b/src/columns/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src
                      ${CMAKE_SOURCE_DIR}/src/commands

--- a/src/commands/CMakeLists.txt
+++ b/src/commands/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src
                      ${CMAKE_SOURCE_DIR}/src/commands

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 # This is a work-around for the following CMake issue:
 # https://gitlab.kitware.com/cmake/cmake/issues/16062


### PR DESCRIPTION
CMake 4 no longer supports versions older than 3.5, and versions between 3.5-3.10 are deprecated. This PR updates the minimum required version to 3.10 to ensure compatibility with modern CMake versions.

## Background

This issue is already affecting NixOS users (see https://github.com/NixOS/nixpkgs/issues/449826) and will likely impact other distributions as they upgrade to CMake 4.x in the coming months.

## Changes

- Updated `cmake_minimum_required (VERSION 3.0)` to `cmake_minimum_required (VERSION 3.10)`

## Testing

This change has been tested and builds successfully with both CMake 3.x and CMake 4.x.