### PR TITLE
Do not back up HTML of each issue

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: "Install backup-github-repo"
-        run: npm install -g backup-github-repo
+        # Uses the fork in https://github.com/maxlath/backup-github-repo/pull/13
+        run: npm install -g https://github.com/djmitche/backup-github-repo#no-html
 
       - name: "Configure backup-github-repo"
         run: |
@@ -40,7 +41,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Run backup-github-repo"
-        run: backup-github-repo
+        run: backup-github-repo --no-html
 
       - name: "Remove unnecessary HTML"
         run: rm -rf repo-backup/html


### PR DESCRIPTION
This uses a [forked version of
backup-github-repo](https://github.com/maxlath/backup-github-repo/pull/13) that supports `--no-html`, to avoid the HTML portion of the backup. This is necessary because the HTML backup exceeds API limits. Refs #3915.