### PR TITLE
Pass color setting to table component

### DIFF
--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -345,6 +345,7 @@ int CmdCalendar::execute(std::string& output) {
       holTable.width(Context::getContext().getWidth());
       holTable.add("Date");
       holTable.add("Holiday");
+      holTable.withColor(Context::getContext().color());
       setHeaderUnderline(holTable);
 
       auto dateFormat = config.get("dateformat.holiday");
@@ -408,6 +409,7 @@ std::string CmdCalendar::renderMonths(int firstMonth, int firstYear, const Datet
   Table view;
   setHeaderUnderline(view);
   view.width(Context::getContext().getWidth());
+  view.withColor(Context::getContext().color());
   for (int i = 0; i < (monthsPerLine * 8); i += 8) {
     if (weekStart == 1) {
       view.add("", false);

--- a/src/commands/CmdColor.cpp
+++ b/src/commands/CmdColor.cpp
@@ -71,7 +71,7 @@ int CmdColor::execute(std::string& output) {
 
       Table view;
       view.width(Context::getContext().getWidth());
-      if (Context::getContext().config.getBoolean("color")) view.forceColor();
+      view.withColor(Context::getContext().config.getBoolean("color"));
       view.add("Color");
       view.add("Definition");
 

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -96,7 +96,7 @@ int CmdInfo::execute(std::string& output) {
     Table view;
     view.width(Context::getContext().getWidth());
     if (Context::getContext().config.getBoolean("obfuscate")) view.obfuscate();
-    if (Context::getContext().color()) view.forceColor();
+    view.withColor(Context::getContext().color());
     view.add("Name");
     view.add("Value");
     setHeaderUnderline(view);
@@ -411,7 +411,7 @@ int CmdInfo::execute(std::string& output) {
       }
 
       if (Context::getContext().config.getBoolean("obfuscate")) urgencyDetails.obfuscate();
-      if (Context::getContext().config.getBoolean("color")) view.forceColor();
+      urgencyDetails.withColor(Context::getContext().config.getBoolean("color"));
 
       urgencyDetails.width(Context::getContext().getWidth());
       urgencyDetails.add("");  // Attribute
@@ -500,7 +500,7 @@ int CmdInfo::execute(std::string& output) {
     setHeaderUnderline(journal);
 
     if (Context::getContext().config.getBoolean("obfuscate")) journal.obfuscate();
-    if (Context::getContext().config.getBoolean("color")) journal.forceColor();
+    journal.withColor(Context::getContext().config.getBoolean("color"));
 
     journal.width(Context::getContext().getWidth());
     journal.add("Date");

--- a/src/commands/CmdProjects.cpp
+++ b/src/commands/CmdProjects.cpp
@@ -101,6 +101,7 @@ int CmdProjects::execute(std::string& output) {
     view.width(Context::getContext().getWidth());
     view.add("Project");
     view.add("Tasks", false);
+    view.withColor(Context::getContext().color());
     setHeaderUnderline(view);
 
     // create sorted list of table entries

--- a/src/commands/CmdStats.cpp
+++ b/src/commands/CmdStats.cpp
@@ -144,6 +144,7 @@ int CmdStats::execute(std::string& output) {
   // Create a table for output.
   Table view;
   view.width(Context::getContext().getWidth());
+  view.withColor(Context::getContext().color());
   view.intraPadding(2);
   view.add("Category");
   view.add("Data");

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -130,6 +130,8 @@ int CmdSummary::execute(std::string& output) {
 
   Color bar_color;
   Color bg_color;
+  view.withColor(Context::getContext().color());
+
   if (Context::getContext().color()) {
     bar_color = Color(Context::getContext().config.get("color.summary.bar"));
     bg_color = Color(Context::getContext().config.get("color.summary.background"));

--- a/test/calendar.test.py
+++ b/test/calendar.test.py
@@ -95,7 +95,7 @@ class TestCalendarCommandLine(TestCase):
         self.assertIn("Date Holiday", out)
 
     def test_basic_command_single_holiday(self):
-        """Verify 'calendar rc.holiday.test.name:donkeyday rc.holiday.test.date:[tomorrws date] rc.calendar.holidays:full' does not fail"""
+        """Verify 'calendar rc.holiday.test.name:donkeyday rc.holiday.test.date:[tomorrow's date] rc.calendar.holidays:full' does not fail"""
         code, out, err = self.t(
             "calendar rc.holiday.test.name:donkeyday rc.holliday.test.date:{0} rc.calendar.holidays:full".format(
                 self.tomorrow

--- a/test/commands.test.py
+++ b/test/commands.test.py
@@ -51,11 +51,61 @@ class TestCommands(TestCase):
     def test_command_dna_color(self):
         """Verify 'add', 'modify', 'list' dna"""
         code, out, err = self.t("commands rc._forcecolor:on")
-        self.assertRegex(out, r"add\s+operation\s+RW\s+Ctxt\s+Mods\s+Adds a new task")
-        self.assertRegex(
-            out, r"list\s+report\s+RO\s+ID\s+GC\s+Recur\s+Ctxt\s+Filt\s+Most details of"
+
+        columns = [
+            "add",
+            "operation",
+            "RW",
+            "",
+            "",
+            "",
+            "Ctxt",
+            "",
+            "Mods",
+            "",
+            "Adds a new task",
+        ]
+        col_regex = r"\s*\x1b\[0m\x1b\[48;5;234m \x1b\[0m\x1b\[48;5;234m\s*".join(
+            columns
         )
-        self.assertRegex(out, r"modify\s+operation\s+RW\s+Filt\s+Mods\s+Modifies the")
+        expected_regex = r"\x1b\[48;5;234m" + col_regex + r"\s*\x1b\[0m"
+        self.assertRegex(out, expected_regex)
+
+        columns = [
+            "list",
+            "report",
+            "RO",
+            "ID",
+            "GC",
+            "Recur",
+            "Ctxt",
+            "Filt",
+            "Most details of",
+        ]
+        col_regex = r"\s*(\x1b\[0m\x1b\[48;5;234m)? (\x1b\[0m\x1b\[48;5;234m)?\s*".join(
+            columns
+        )
+        expected_regex = r"(\x1b\[48;5;234m)?" + col_regex + r"\s*(\x1b\[0m)?"
+        self.assertRegex(out, expected_regex)
+
+        columns = [
+            "modify",
+            "operation",
+            "RW",
+            "",
+            "",
+            "",
+            "",
+            "Filt",
+            "Mods",
+            "",
+            "Modifies the",
+        ]
+        col_regex = r"\s*(\x1b\[0m\x1b\[48;5;234m)? (\x1b\[0m\x1b\[48;5;234m)?\s*".join(
+            columns
+        )
+        expected_regex = r"(\x1b\[48;5;234m)?" + col_regex + r"\s*(\x1b\[0m)?"
+        self.assertRegex(out, expected_regex)
 
 
 if __name__ == "__main__":

--- a/test/stats.test.py
+++ b/test/stats.test.py
@@ -54,7 +54,10 @@ class TestStatisticsCommand(TestCase):
         self.assertRegex(out, "Total\\s+3\n")
 
         code, out, err = self.t("stats rc._forcecolor:on")
-        self.assertRegex(out, "Pending\\s+1\n")
+        self.assertRegex(
+            out,
+            r"\x1b\[48;5;234mPending\s+\x1b\[0m\x1b\[48;5;234m  \x1b\[0m\x1b\[48;5;234m1\s+\x1b\[0m",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The TTY check has been removed from libshared's `Table` component in [3da15345](https://github.com/GothenburgBitFactory/libshared/commit/3da15345b1bdd2bc69de7231e578bd5d530fc92c).
Instead, the color settings from the main application are passed to it.