### PR TITLE
UDADuration: add `age` and `countdown` format styles

### DIFF
--- a/src/columns/ColTypeDate.cpp
+++ b/src/columns/ColTypeDate.cpp
@@ -75,7 +75,7 @@ void ColumnTypeDate::measure(Task& task, unsigned int& minimum, unsigned int& ma
       minimum = maximum = Datetime::length(format);
     } else if (_style == "countdown") {
       Datetime now;
-      minimum = maximum = Duration(date - now).formatVague(true).length();
+      if (date > now) minimum = maximum = Duration(date - now).format().length();
     } else if (_style == "julian") {
       minimum = maximum = format(date.toJulian(), 13, 12).length();
     } else if (_style == "epoch") {
@@ -120,7 +120,7 @@ void ColumnTypeDate::render(std::vector<std::string>& lines, Task& task, int wid
       renderStringLeft(lines, width, color, date.toString(format));
     } else if (_style == "countdown") {
       Datetime now;
-      renderStringRight(lines, width, color, Duration(date - now).formatVague(true));
+      if (date > now) renderStringRight(lines, width, color, Duration(date - now).format());
     } else if (_style == "julian")
       renderStringRight(lines, width, color, format(date.toJulian(), 13, 12));
 

--- a/src/columns/ColUDA.cpp
+++ b/src/columns/ColUDA.cpp
@@ -243,8 +243,8 @@ ColumnUDADuration::ColumnUDADuration() {
   _style = "default";
   _label = "";
   _uda = true;
-  _styles = {_style, "indicator", "age", "iso"};
-  _examples = {"P30D", "U", "4w", "P30D"};
+  _styles = {_style, "indicator", "age", "countdown", "iso"};
+  _examples = {"P30D", "U", "4w", "30d 0:00:00", "P30D"};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -272,6 +272,9 @@ void ColumnUDADuration::measure(Task& task, unsigned int& minimum, unsigned int&
     } else if (_style == "age") {
       auto value = task.get(_name);
       if (value != "") minimum = maximum = Duration(value).formatVague(true).length();
+    } else if (_style == "countdown") {
+      auto value = task.get(_name);
+      if (value != "") minimum = maximum = Duration(value).format().length();
     } else if (_style == "indicator") {
       if (task.has(_name)) {
         auto indicator = Context::getContext().config.get("uda." + _name + ".indicator");
@@ -294,6 +297,9 @@ void ColumnUDADuration::render(std::vector<std::string>& lines, Task& task, int 
     } else if (_style == "age") {
       auto value = task.get(_name);
       renderStringRight(lines, width, color, Duration(value).formatVague(true));
+    } else if (_style == "countdown") {
+      auto value = task.get(_name);
+      renderStringRight(lines, width, color, Duration(value).format());
     } else if (_style == "indicator") {
       auto indicator = Context::getContext().config.get("uda." + _name + ".indicator");
       if (indicator == "") indicator = "U";

--- a/src/columns/ColUDA.cpp
+++ b/src/columns/ColUDA.cpp
@@ -243,7 +243,8 @@ ColumnUDADuration::ColumnUDADuration() {
   _style = "default";
   _label = "";
   _uda = true;
-  _styles = {_style, "indicator"};
+  _styles = {_style, "indicator", "iso"};
+  _examples = {"P30D", "U", "P30D"};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -265,7 +266,7 @@ bool ColumnUDADuration::validate(const std::string& value) const {
 void ColumnUDADuration::measure(Task& task, unsigned int& minimum, unsigned int& maximum) {
   minimum = maximum = 0;
   if (task.has(_name)) {
-    if (_style == "default") {
+    if (_style == "default" || _style == "iso") {
       auto value = task.get(_name);
       if (value != "") minimum = maximum = Duration(value).formatISO().length();
     } else if (_style == "indicator") {
@@ -284,7 +285,7 @@ void ColumnUDADuration::measure(Task& task, unsigned int& minimum, unsigned int&
 void ColumnUDADuration::render(std::vector<std::string>& lines, Task& task, int width,
                                Color& color) {
   if (task.has(_name)) {
-    if (_style == "default") {
+    if (_style == "default" || _style == "iso") {
       auto value = task.get(_name);
       renderStringRight(lines, width, color, Duration(value).formatISO());
     } else if (_style == "indicator") {

--- a/src/columns/ColUDA.cpp
+++ b/src/columns/ColUDA.cpp
@@ -243,8 +243,8 @@ ColumnUDADuration::ColumnUDADuration() {
   _style = "default";
   _label = "";
   _uda = true;
-  _styles = {_style, "indicator", "iso"};
-  _examples = {"P30D", "U", "P30D"};
+  _styles = {_style, "indicator", "age", "iso"};
+  _examples = {"P30D", "U", "4w", "P30D"};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -269,6 +269,9 @@ void ColumnUDADuration::measure(Task& task, unsigned int& minimum, unsigned int&
     if (_style == "default" || _style == "iso") {
       auto value = task.get(_name);
       if (value != "") minimum = maximum = Duration(value).formatISO().length();
+    } else if (_style == "age") {
+      auto value = task.get(_name);
+      if (value != "") minimum = maximum = Duration(value).formatVague(true).length();
     } else if (_style == "indicator") {
       if (task.has(_name)) {
         auto indicator = Context::getContext().config.get("uda." + _name + ".indicator");
@@ -288,6 +291,9 @@ void ColumnUDADuration::render(std::vector<std::string>& lines, Task& task, int 
     if (_style == "default" || _style == "iso") {
       auto value = task.get(_name);
       renderStringRight(lines, width, color, Duration(value).formatISO());
+    } else if (_style == "age") {
+      auto value = task.get(_name);
+      renderStringRight(lines, width, color, Duration(value).formatVague(true));
     } else if (_style == "indicator") {
       auto indicator = Context::getContext().config.get("uda." + _name + ".indicator");
       if (indicator == "") indicator = "U";

--- a/test/columns.test.py
+++ b/test/columns.test.py
@@ -543,6 +543,46 @@ class TestUDAUUIDReconfiguredFromString(TestCase):
         self.assertEqual(self.expected_str[:8], out.strip())
 
 
+class TestUDADurationFormats(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Executed once before any test in the class"""
+        cls.t = Task()
+        cls.t.config("verbose", "nothing")
+        cls.t.config("uda.uda_duration.label", "uda_duration")
+        cls.t.config("uda.uda_duration.type", "duration")
+        cls.t.config("report.xxx.columns", "id,uda_duration")
+
+        # Test only nonnegative durations, since negative ones are not handled
+        # well. See https://github.com/GothenburgBitFactory/libshared/pull/110
+        cls.t("add one uda_duration:0min")
+        cls.t("add two uda_duration:1min")
+        cls.t("add thr uda_duration:60d")
+        cls.t("add four uda_duration:'30d + 10h + 3min + 2s'")
+
+    def test_uda_duration_format_indicator(self):
+        """Verify uda_duration.indicator formatting"""
+        code, out, err = self.t(f"xxx rc.report.xxx.columns:id,uda_duration.indicator")
+        # The indicator for UDAs is always U.
+        self.assertRegex(out, r"1\s+U")
+        self.assertRegex(out, r"2\s+U")
+        self.assertRegex(out, r"3\s+U")
+        self.assertRegex(out, r"4\s+U")
+
+    def test_uda_duration_format_iso(self):
+        """Verify uda_duration.iso formatting"""
+        for style in ["iso", "default"]:
+            code, out, err = self.t(
+                f"xxx rc.report.xxx.columns:id,uda_duration.{style}"
+            )
+            # The ISO format shouldn't change at all, so do exact matches rather than
+            # more flexible regexes.
+            self.assertRegex(out, r"1\s+PT0S")
+            self.assertRegex(out, r"2\s+PT1M")
+            self.assertRegex(out, r"3\s+P60D")
+            self.assertRegex(out, r"4\s+P30DT10H3M2S")
+
+
 class TestFeature1061(TestCase):
     def setUp(self):
         """Executed before each test in the class"""

--- a/test/columns.test.py
+++ b/test/columns.test.py
@@ -417,7 +417,7 @@ class TestDateFormats(TestCase):
         """Verify due.countdown formatting"""
         code, out, err = self.t("xxx rc.report.xxx.columns:id,due.countdown")
         self.assertRegex(out, r"1\s+")
-        self.assertRegex(out, r"2\s+[0-9.]+[hmin]+")
+        self.assertRegex(out, r"2\s+(\d+d )?\d+:\d{2}:\d{2}")
 
     def test_date_format_unrecognized(self):
         """Verify due.donkey formatting fails"""

--- a/test/columns.test.py
+++ b/test/columns.test.py
@@ -582,6 +582,14 @@ class TestUDADurationFormats(TestCase):
             self.assertRegex(out, r"3\s+P60D")
             self.assertRegex(out, r"4\s+P30DT10H3M2S")
 
+    def test_uda_duration_format_age(self):
+        """Verify uda_duration.age formatting"""
+        code, out, err = self.t("xxx rc.report.xxx.columns:id,uda_duration.age")
+        self.assertRegex(out, r"1\s+")
+        self.assertRegex(out, r"2\s+[0-9]+[wmin]+")
+        self.assertRegex(out, r"3\s+[0-9]+[wmin]+")
+        self.assertRegex(out, r"4\s+[0-9]+[wmin]+")
+
 
 class TestFeature1061(TestCase):
     def setUp(self):

--- a/test/columns.test.py
+++ b/test/columns.test.py
@@ -417,7 +417,7 @@ class TestDateFormats(TestCase):
         """Verify due.countdown formatting"""
         code, out, err = self.t("xxx rc.report.xxx.columns:id,due.countdown")
         self.assertRegex(out, r"1\s+")
-        self.assertRegex(out, r"2\s+\d+\S+")
+        self.assertRegex(out, r"2\s+[0-9.]+[hmin]+")
 
     def test_date_format_unrecognized(self):
         """Verify due.donkey formatting fails"""

--- a/test/columns.test.py
+++ b/test/columns.test.py
@@ -590,6 +590,14 @@ class TestUDADurationFormats(TestCase):
         self.assertRegex(out, r"3\s+[0-9]+[wmin]+")
         self.assertRegex(out, r"4\s+[0-9]+[wmin]+")
 
+    def test_uda_duration_format_countdown(self):
+        """Verify uda_duration.countdown formatting"""
+        code, out, err = self.t("xxx rc.report.xxx.columns:id,uda_duration.countdown")
+        self.assertRegex(out, r"1\s+")
+        self.assertRegex(out, r"2\s+(\d+d )?\d+:\d{2}:\d{2}")
+        self.assertRegex(out, r"3\s+(\d+d )?\d+:\d{2}:\d{2}")
+        self.assertRegex(out, r"4\s+(\d+d )?\d+:\d{2}:\d{2}")
+
 
 class TestFeature1061(TestCase):
     def setUp(self):


### PR DESCRIPTION
As we do for datetimes, allow duration UDAs in reports to be formatted in the "vague" human-readable format or as a second-resolution countdown, instead of only the ISO format. I also added tests for the UDA duration output.

Along the way I attempted to support negative durations but was not able to -- see https://github.com/GothenburgBitFactory/libshared/pull/110 for more information. I will open a followup if that PR (or its sister PR 111) gets into libshared.

Because the countdown format for datetime seemed wrong, I fixed it before implementing the same format for duration. Maybe I should have done this in a separate PR? Let me know and I will split it up.

Fixes #3738

Fixes #4013 