### PR TITLE
Move fish completion to vendor's directory

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required (VERSION 3.22...4.0)
-install (DIRECTORY bash fish vim hooks
+
+set(FISH_COMPLETIONSDIR share/fish/vendor_completions.d)
+
+install (DIRECTORY bash vim hooks
          DESTINATION ${TASK_DOCDIR}/scripts)
+install (FILES fish/task.fish
+         DESTINATION ${FISH_COMPLETIONSDIR})
 install (FILES zsh/_task
          DESTINATION share/zsh/site-functions)
 install (DIRECTORY add-ons

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required (VERSION 3.22...4.0)
 
-set(FISH_COMPLETIONSDIR share/fish/vendor_completions.d)
+find_package(PkgConfig)
+if(PkgConfig_FOUND)
+	pkg_get_variable(FISH_COMPLETIONSDIR fish completionsdir)
+endif()
+if(NOT FISH_COMPLETIONSDIR)
+	set(FISH_COMPLETIONSDIR share/fish/vendor_completions.d)
+	message(STATUS "fish pkgconfig module missing, assumed completions in ${FISH_COMPLETIONSDIR}")
+endif()
 
 install (DIRECTORY bash vim hooks
          DESTINATION ${TASK_DOCDIR}/scripts)


### PR DESCRIPTION
I noticed that task completions won't work recently but it can be "fixed" by symlinking the completions scripts from vendor_completions.d directory as described by fish docs [1].
Use this directory by default.

Fixes #3023

Notice: ~Not tested~ CI tested, I'm open to adjustments if this is out of conventional style.

[1] https://fishshell.com/docs/current/completions.html