### PR TITLE
Enable timers in the Tokio runtime

### DIFF
--- a/src/taskchampion-cpp/src/lib.rs
+++ b/src/taskchampion-cpp/src/lib.rs
@@ -309,6 +309,7 @@ impl From<tc::Error> for CppError {
 
 fn rt() -> tokio::runtime::Handle {
     tokio::runtime::Builder::new_current_thread()
+        .enable_time()
         .build()
         .unwrap()
         .handle()


### PR DESCRIPTION
Fixes #4040.