### PR TITLE
fix: use static tokio runtime to prevent shutdown during sync

### DIFF
--- a/src/taskchampion-cpp/src/lib.rs
+++ b/src/taskchampion-cpp/src/lib.rs
@@ -307,12 +307,17 @@ impl From<tc::Error> for CppError {
     }
 }
 
-fn rt() -> tokio::runtime::Handle {
-    tokio::runtime::Builder::new_current_thread()
-        .build()
-        .unwrap()
-        .handle()
-        .clone()
+use std::sync::OnceLock;
+
+static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+fn rt() -> &'static tokio::runtime::Runtime {
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    })
 }
 
 impl std::fmt::Display for CppError {


### PR DESCRIPTION
Fixes #4040.

## Problem

The `rt()` function creates a new Tokio runtime on each call, returns its `Handle`, and immediately drops the runtime. This causes panics during sync operations:

```
thread panicked at: A Tokio 1.x context was found, but it is being shutdown.
```

## Solution

Use `OnceLock` to create a single static runtime that lives for the program's lifetime. Also use `enable_all()` to enable both time and IO features needed for sync operations.

## Changes

```rust
// Before: runtime dropped immediately after getting handle
fn rt() -> tokio::runtime::Handle {
    tokio::runtime::Builder::new_current_thread()
        .build()
        .unwrap()
        .handle()
        .clone()
}

// After: static runtime lives for program lifetime
use std::sync::OnceLock;

static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();

fn rt() -> &'static tokio::runtime::Runtime {
    RUNTIME.get_or_init(|| {
        tokio::runtime::Builder::new_current_thread()
            .enable_all()
            .build()
            .unwrap()
    })
}
```

Note: PR #4042 adds `.enable_time()` which addresses the "timers are disabled" error but doesn't fix the underlying runtime lifetime issue.