### PR TITLE
Fix: add obfuscation handling for dependencies in ColumnDepends

### DIFF
--- a/src/ViewTask.cpp
+++ b/src/ViewTask.cpp
@@ -322,9 +322,9 @@ std::string ViewTask::render(std::vector<Task>& data, std::vector<int>& sequence
 
       if (cells[c].size() > max_lines) max_lines = cells[c].size();
 
-      if (obfuscate)
-        if (_columns[c]->type() == "string")
-          for (auto& line : cells[c]) line = obfuscateText(line);
+        if (obfuscate)
+          if (_columns[c]->type() == "string" && _columns[c]->name() != "depends")
+           for (auto& line : cells[c]) line = obfuscateText(line);
     }
 
     // Listing breaks are simply blank lines inserted when a column value

--- a/src/ViewTask.cpp
+++ b/src/ViewTask.cpp
@@ -322,9 +322,9 @@ std::string ViewTask::render(std::vector<Task>& data, std::vector<int>& sequence
 
       if (cells[c].size() > max_lines) max_lines = cells[c].size();
 
-        if (obfuscate)
-          if (_columns[c]->type() == "string" && _columns[c]->name() != "depends")
-           for (auto& line : cells[c]) line = obfuscateText(line);
+      if (obfuscate)
+        if (_columns[c]->type() == "string" && _columns[c]->name() != "depends")
+          for (auto& line : cells[c]) line = obfuscateText(line);
     }
 
     // Listing breaks are simply blank lines inserted when a column value


### PR DESCRIPTION
## **Description**

Prevent `rc.obfuscate=1` from hiding dependency IDs.
All string columns are obfuscated except depends.



Changes

Updated `ViewTask::render() `to skip obfuscation for depends. 


**Fixes #4049**

**After test by adding tasks which depend of each other this will be the result :**

<img width="1104" height="206" alt="Screenshot from 2026-03-10 00-00-00" src="https://github.com/user-attachments/assets/0dd7039b-4957-48f0-af3b-33e7d31544ab" />
