### PR TITLE
Fix description truncation for emoji and wide characters

### DIFF
--- a/src/columns/ColDescription.cpp
+++ b/src/columns/ColDescription.cpp
@@ -178,7 +178,7 @@ void ColumnDescription::render(std::vector<std::string>& lines, Task& task, int 
   else if (_style == "truncated") {
     int len = utf8_width(description);
     if (len > width)
-      renderStringLeft(lines, width, color, description.substr(0, width - 3) + "...");
+      renderStringLeft(lines, width, color, utf8_truncate_to_width(description, width - 3) + "...");
     else
       renderStringLeft(lines, width, color, description);
   }
@@ -207,7 +207,7 @@ void ColumnDescription::render(std::vector<std::string>& lines, Task& task, int 
 
     if (len > width)
       renderStringLeft(lines, width, color,
-                       description.substr(0, width - len_annos - 3) + "..." + annos_count);
+                       utf8_truncate_to_width(description, width - len_annos - 3) + "..." + annos_count);
     else
       renderStringLeft(lines, width, color, description + annos_count);
   }


### PR DESCRIPTION
## Summary
Replace byte-based `substr()` with `utf8_truncate_to_width()` in ColDescription truncated/truncated_count render styles.

Fixes #2333

Depends on GothenburgBitFactory/libshared#114

## Problem
Truncating descriptions containing emoji or other multi-byte UTF-8 characters produces garbled output because `substr()` cuts at byte boundaries, not character boundaries. This affects all platforms.

## Screenshot
<img width="542" height="135" alt="emoji-demo" src="https://github.com/user-attachments/assets/647e46b1-bb95-4e6f-836e-2e6025e26ea5" />

## Changes
- `ColDescription.cpp`: 2 lines changed — `description.substr()` → `utf8_truncate_to_width(description, ...)`

## Test plan
- `task add "📄 Emoji renders correctly"` displays properly
- Long descriptions with emoji truncate with clean `...` suffix
- ZWJ sequences (👨‍💻) and symbols (★⚡→●) render correctly
- No corrupted bytes in truncated output