### PR TITLE
Install ca-certificates in debiantesting

### DIFF
--- a/test/docker/debiantesting
+++ b/test/docker/debiantesting
@@ -1,8 +1,6 @@
 FROM debian:testing
 
-RUN apt-get update
-RUN apt-get install -y build-essential cmake git uuid-dev faketime
-RUN apt-get install -y python3 curl
+RUN apt-get update && apt-get install -y build-essential cmake git uuid-dev faketime ca-certificates python3 curl
 
 # Setup language environment
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
This should fix the failing debiantesting checks in CI.