### PR TITLE
fix: don't round urgency in _urgency command

### DIFF
--- a/src/commands/CmdUrgency.cpp
+++ b/src/commands/CmdUrgency.cpp
@@ -66,9 +66,7 @@ int CmdUrgency::execute(std::string& output) {
   // Display urgency for the selected tasks.
   std::stringstream out;
   for (auto& task : filtered) {
-    out << format("task {1} urgency {2}", task.identifier(),
-                  Lexer::trim(format(task.urgency(), 6, 3)))
-        << '\n';
+    out << format("task {1} urgency {2}", task.identifier(), task.urgency()) << '\n';
   }
 
   output = out.str();


### PR DESCRIPTION
Rounding causes sorting output of _urgency to not match the sorting of any reports.