### PR TITLE
Caching foundation for a dependencyGraph which maps dependency relations.

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -122,7 +122,7 @@ void TDB2::modify(Task& task) {
 
   // invoke the hook and allow it to modify the task before updating
   Task original;
-  get(uuid, original);
+  bool found_original = get(uuid, original);
   Context::getContext().hooks.onModify(original, task);
 
   tc::Uuid tcuuid = tc::uuid_from_string(uuid);
@@ -170,7 +170,24 @@ void TDB2::modify(Task& task) {
 
   replica()->commit_operations(std::move(ops));
 
-  invalidate_cached_info();
+  // If the task entered or left the pending set, we must invalidate the cache.
+  bool was_pending = found_original && (original.getStatus() == Task::pending);
+  bool now_pending = task.getStatus() == Task::pending;
+  if (was_pending != now_pending) {
+    invalidate_cached_info();
+    return;
+  }
+
+  // If the task stayed in the set, we can edit the vector in-place.
+  if (_pending_tasks) {
+    auto idx = pending_index_of(uuid);
+    if (idx != SIZE_MAX)
+      (*_pending_tasks)[idx] = task;
+  }
+  // We have to drop the dependency map, in case modifications were made to those.
+  _dependency_graph = std::nullopt;
+  // We also have to drop _completed_tasks.
+  _completed_tasks = std::nullopt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -182,13 +182,22 @@ void TDB2::modify(Task& task) {
 
   // If the task stayed in the set, we can edit the vector in-place.
   // This speeds up modifications a lot relative to reloading and parsing from rust.
+  bool deps_changed = false;
   if (_pending_tasks) {
     auto* pt = find_pending(uuid);
-    if (pt)
+    if (pt) {
+      auto old_deps = pt->getDependencyUUIDs();
       *pt = task;
+      auto new_deps = task.getDependencyUUIDs();
+      if (old_deps != new_deps) {
+        deps_changed = true;
+        dependency_scan(*_pending_tasks, pending_index());
+      }
+    }
   }
   // We have to drop the dependency map, in case modifications were made to those.
-  _dependency_graph = std::nullopt;
+  // We only drop it if they actually changed.
+  if (deps_changed) _dependency_graph = std::nullopt;
   // We also have to drop _completed_tasks. This probably isn't strictly necessary
   // but it seems sensible for correctness reasons.
   _completed_tasks = std::nullopt;
@@ -510,6 +519,16 @@ int TDB2::num_reverts_possible() { return (int)replica()->num_undo_points(); }
 // Set Task::is_blocked / Task::is_blocking flags using the pre-built UUID map
 static void dependency_scan(std::vector<Task>& tasks,
                             const std::unordered_map<std::string, size_t>& uuid_index) {
+  // Reset all flags first. This is for safety reasons - if we don't do this
+  // dependency_scan() only sets them to true, so it can stay true (within the cache)
+  // even after we have changed a task's dependencies after a modify when
+  // dependency_scan() runs the second time - the flag will still be set to true!
+  // In many cases, this isn't user-visible - it's only visible in reports
+  // or filters that explicitly filter for +BLOCKING.
+  for (auto& task : tasks) {
+    task.is_blocking = false;
+    task.is_blocked = false;
+  }
   for (size_t i = 0; i < tasks.size(); ++i) {
     auto lstatus = tasks[i].getStatus();
     for (const auto& dep : tasks[i].getDependencyUUIDs()) {

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -64,7 +64,7 @@ void TDB2::add(Task& task) {
   rust::Vec<tc::Operation> ops;
   maybe_add_undo_point(ops);
 
-  auto uuid = task.get("uuid");
+  auto uuid = task.get_ref("uuid");
   changes[uuid] = task;
   tc::Uuid tcuuid = tc::uuid_from_string(uuid);
 
@@ -113,7 +113,7 @@ void TDB2::modify(Task& task) {
   // changes the user or hooks tried to apply to the "modified" attribute.
   task.setAsNow("modified");
   task.validate(false);
-  auto uuid = task.get("uuid");
+  auto uuid = task.get_ref("uuid");
 
   rust::Vec<tc::Operation> ops;
   maybe_add_undo_point(ops);
@@ -192,7 +192,7 @@ void TDB2::modify(Task& task) {
 
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::purge(Task& task) {
-  auto uuid = tc::uuid_from_string(task.get("uuid"));
+  auto uuid = tc::uuid_from_string(task.get_ref("uuid"));
   rust::Vec<tc::Operation> ops;
   auto maybe_tctask = replica()->get_task_data(uuid);
   if (maybe_tctask.is_some()) {

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -253,12 +253,15 @@ const std::vector<Task> TDB2::all_tasks() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::vector<Task> TDB2::pending_tasks() {
+const std::vector<Task>& TDB2::pending_tasks() {
   if (!_pending_tasks) {
     Timer timer;
 
     auto pending_tctasks = replica()->pending_task_data();
     std::vector<Task> result;
+
+    result.reserve(pending_tctasks.size());
+
     for (auto& maybe_tctask : pending_tctasks) {
       auto tctask = maybe_tctask.take();
       result.push_back(Task(std::move(tctask)));
@@ -267,19 +270,22 @@ const std::vector<Task> TDB2::pending_tasks() {
     dependency_scan(result);
 
     Context::getContext().time_load_us += timer.total_us();
-    _pending_tasks = result;
+    _pending_tasks = std::move(result);
   }
 
   return *_pending_tasks;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::vector<Task> TDB2::completed_tasks() {
+const std::vector<Task>& TDB2::completed_tasks() {
   if (!_completed_tasks) {
     auto all_tctasks = replica()->all_task_data();
     auto& ws = working_set();
 
     std::vector<Task> result;
+
+    result.reserve(all_tctasks.size());
+
     for (auto& maybe_tctask : all_tctasks) {
       auto tctask = maybe_tctask.take();
       // if this task is _not_ in the working set, return it.
@@ -287,7 +293,7 @@ const std::vector<Task> TDB2::completed_tasks() {
         result.push_back(Task(std::move(tctask)));
       }
     }
-    _completed_tasks = result;
+    _completed_tasks = std::move(result);
   }
   return *_completed_tasks;
 }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -38,6 +38,7 @@
 #include <util.h>
 
 #include <algorithm>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -267,6 +268,13 @@ const std::vector<Task>& TDB2::pending_tasks() {
       result.push_back(Task(std::move(tctask)));
     }
 
+    // Build a UUID map for use with get()/modify() and dependency_scan()
+    // while the pending vector is already in memory.
+    _pending_index.emplace();
+    _pending_index->reserve(result.size());
+    for (size_t i = 0, n = result.size(); i < n; ++i)
+      _pending_index->emplace(result[i].get_ref("uuid"), i);
+
     dependency_scan(result);
 
     Context::getContext().time_load_us += timer.total_us();
@@ -303,6 +311,27 @@ void TDB2::invalidate_cached_info() {
   _pending_tasks = std::nullopt;
   _completed_tasks = std::nullopt;
   _working_set = std::nullopt;
+  _pending_index = std::nullopt;
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+// This builds and returns the UUID map if it is missing.
+const std::unordered_map<std::string, size_t>& TDB2::pending_index() {
+  if (!_pending_index) {
+    _pending_index.emplace();
+    _pending_index->reserve(_pending_tasks->size());
+    for (size_t i = 0, n = _pending_tasks->size(); i < n; ++i)
+      _pending_index->emplace((*_pending_tasks)[i].get_ref("uuid"), i);
+  }
+
+  return *_pending_index;
+}
+
+// Finds the UUID in the index. Returns SIZE_MAX if it isn't present.
+size_t TDB2::pending_index_of(const std::string& uuid) {
+  auto& idx = pending_index();
+  auto it = idx.find(uuid);
+  return it != idx.end() ? it->second : SIZE_MAX;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -312,14 +341,13 @@ bool TDB2::get(int id, Task& task) {
   const auto tcuuid = ws->by_index(id);
   if (!tcuuid.is_nil()) {
     std::string uuid = static_cast<std::string>(tcuuid.to_string());
-    // Load all pending tasks in order to get dependency data, and in particular
-    // `task.is_blocking` and `task.is_blocked`, set correctly.
-    std::vector<Task> pending = pending_tasks();
-    for (auto& pending_task : pending) {
-      if (pending_task.get("uuid") == uuid) {
-        task = pending_task;
-        return true;
-      }
+    // Load index of pending tasks.
+    pending_tasks();
+    // Lookup the UUID in the index instead of scanning the vector.
+    auto idx = pending_index_of(uuid);
+    if (idx != SIZE_MAX) {
+      task = (*_pending_tasks)[idx];
+      return true;
     }
   }
 
@@ -329,15 +357,22 @@ bool TDB2::get(int id, Task& task) {
 ////////////////////////////////////////////////////////////////////////////////
 // Locate task by UUID, including by partial ID, wherever it is.
 bool TDB2::get(const std::string& uuid, Task& task) {
-  // Load all pending tasks in order to get dependency data, and in particular
-  // `task.is_blocking` and `task.is_blocked`, set correctly.
-  std::vector<Task> pending = pending_tasks();
+  pending_tasks();
 
-  // try by raw uuid, if the length is right
-  for (auto& pending_task : pending) {
-    if (closeEnough(pending_task.get("uuid"), uuid, uuid.length())) {
-      task = pending_task;
-      return true;
+  // Try to match exact UUID within the index.
+  auto idx = pending_index_of(uuid);
+  if (idx != SIZE_MAX) {
+    task = (*_pending_tasks)[idx];
+    return true;
+  }
+
+  // try a partial match
+  if (uuid.length() < 36) {
+    for (const auto& pending_task : *_pending_tasks) {
+      if (closeEnough(pending_task.get_ref("uuid"), uuid, uuid.length())) {
+        task = pending_task;
+        return true;
+      }
     }
   }
 

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -183,8 +183,9 @@ void TDB2::modify(Task& task) {
   // If the task stayed in the set, we can edit the vector in-place.
   // This speeds up modifications a lot relative to reloading and parsing from rust.
   if (_pending_tasks) {
-    auto idx = pending_index_of(uuid);
-    if (idx != SIZE_MAX) (*_pending_tasks)[idx] = task;
+    auto* pt = find_pending(uuid);
+    if (pt)
+      *pt = task;
   }
   // We have to drop the dependency map, in case modifications were made to those.
   _dependency_graph = std::nullopt;
@@ -367,11 +368,13 @@ const std::unordered_map<std::string, size_t>& TDB2::pending_index() {
   return *_pending_index;
 }
 
-// Finds the UUID in the index. Returns SIZE_MAX if it isn't present.
-size_t TDB2::pending_index_of(const std::string& uuid) {
+// Finds the UUID in the index. Returns nullptr if the task is not in the pending
+// set.
+Task* TDB2::find_pending(const std::string& uuid) {
   auto& idx = pending_index();
   auto it = idx.find(uuid);
-  return it != idx.end() ? it->second : SIZE_MAX;
+  if (it != idx.end()) return &(*_pending_tasks)[it->second];
+  return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -393,9 +396,9 @@ bool TDB2::get(int id, Task& task) {
     // Load index of pending tasks.
     pending_tasks();
     // Lookup the UUID in the index instead of scanning the vector.
-    auto idx = pending_index_of(uuid);
-    if (idx != SIZE_MAX) {
-      task = (*_pending_tasks)[idx];
+    auto* pt = find_pending(uuid);
+    if (pt) {
+      task = *pt;
       return true;
     }
   }
@@ -409,9 +412,9 @@ bool TDB2::get(const std::string& uuid, Task& task) {
   pending_tasks();
 
   // Try to match exact UUID within the index.
-  auto idx = pending_index_of(uuid);
-  if (idx != SIZE_MAX) {
-    task = (*_pending_tasks)[idx];
+  auto* pt = find_pending(uuid);
+  if (pt) {
+    task = *pt;
     return true;
   }
 

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -47,7 +47,8 @@ bool TDB2::debug_mode = false;
 static void dependency_scan(std::vector<Task>&, const std::unordered_map<std::string, size_t>&);
 
 // Build maps for dependency queries.
-static DependencyGraph build_dependency_graph(const std::vector<Task>&, const std::unordered_map<std::string, size_t>&);
+static DependencyGraph build_dependency_graph(const std::vector<Task>&,
+                                              const std::unordered_map<std::string, size_t>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::open_replica(const std::string& location, bool create_if_missing, bool read_write) {
@@ -183,8 +184,7 @@ void TDB2::modify(Task& task) {
   // This speeds up modifications a lot relative to reloading and parsing from rust.
   if (_pending_tasks) {
     auto idx = pending_index_of(uuid);
-    if (idx != SIZE_MAX)
-      (*_pending_tasks)[idx] = task;
+    if (idx != SIZE_MAX) (*_pending_tasks)[idx] = task;
   }
   // We have to drop the dependency map, in case modifications were made to those.
   _dependency_graph = std::nullopt;
@@ -275,8 +275,7 @@ const std::vector<Task> TDB2::all_tasks() {
   // inside all_tasks.
   std::unordered_map<std::string, size_t> all_index;
   all_index.reserve(all.size());
-  for (size_t i = 0; i < all.size(); ++i)
-    all_index[all[i].get_ref("uuid")] = i;
+  for (size_t i = 0; i < all.size(); ++i) all_index[all[i].get_ref("uuid")] = i;
 
   dependency_scan(all, all_index);
 
@@ -530,18 +529,18 @@ int TDB2::num_reverts_possible() { return (int)replica()->num_undo_points(); }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Set Task::is_blocked / Task::is_blocking flags using the pre-built UUID map
-static void dependency_scan(std::vector<Task>& tasks, const std::unordered_map<std::string, size_t>& uuid_index) {
-  for (size_t i = 0; i< tasks.size(); ++i) {
+static void dependency_scan(std::vector<Task>& tasks,
+                            const std::unordered_map<std::string, size_t>& uuid_index) {
+  for (size_t i = 0; i < tasks.size(); ++i) {
     auto lstatus = tasks[i].getStatus();
     for (const auto& dep : tasks[i].getDependencyUUIDs()) {
       auto it = uuid_index.find(dep);
-      if (it == uuid_index.end())
-        continue;
+      if (it == uuid_index.end()) continue;
 
       size_t j = it->second;
       auto rstatus = tasks[j].getStatus();
-      if (lstatus != Task::completed && lstatus != Task::deleted &&
-          rstatus != Task::completed && rstatus != Task::deleted) {
+      if (lstatus != Task::completed && lstatus != Task::deleted && rstatus != Task::completed &&
+          rstatus != Task::deleted) {
         tasks[i].is_blocked = true;
         tasks[j].is_blocking = true;
       }
@@ -551,21 +550,19 @@ static void dependency_scan(std::vector<Task>& tasks, const std::unordered_map<s
 
 /////////////////////////////////////////////////////////////////////////////////
 // Build the full dependency map from the task vector.
-static DependencyGraph build_dependency_graph(const std::vector<Task>& tasks,
-                                              const std::unordered_map<std::string, size_t>& uuid_index) {
+static DependencyGraph build_dependency_graph(
+    const std::vector<Task>& tasks, const std::unordered_map<std::string, size_t>& uuid_index) {
   DependencyGraph graph;
 
   for (size_t i = 0; i < tasks.size(); ++i) {
     const auto& deps = tasks[i].getDependencyUUIDs();
-    if (deps.empty())
-      continue;
+    if (deps.empty()) continue;
 
     const auto& uuid = tasks[i].get_ref("uuid");
 
     for (const auto& dep : deps) {
       auto it = uuid_index.find(dep);
-      if (it == uuid_index.end())
-        continue;
+      if (it == uuid_index.end()) continue;
 
       graph.dependencies[uuid].push_back(it->second);
       graph.dependents[dep].push_back(i);

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -175,7 +175,7 @@ void TDB2::modify(Task& task) {
   // If the task entered or left the pending set, we must invalidate the cache.
   bool was_pending = found_original && (original.getStatus() == Task::pending);
   bool now_pending = task.getStatus() == Task::pending;
-  if (was_pending != now_pending) {
+  if (was_pending != now_pending || !found_original) {
     invalidate_cached_info();
     return;
   }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -43,6 +43,7 @@
 #include <vector>
 
 bool TDB2::debug_mode = false;
+// This functions main job is to set Task::is_blocked / Task::is_blocking flags.
 static void dependency_scan(std::vector<Task>&, const std::unordered_map<std::string, size_t>&);
 
 // Build maps for dependency queries.
@@ -179,6 +180,7 @@ void TDB2::modify(Task& task) {
   }
 
   // If the task stayed in the set, we can edit the vector in-place.
+  // This speeds up modifications a lot relative to reloading and parsing from rust.
   if (_pending_tasks) {
     auto idx = pending_index_of(uuid);
     if (idx != SIZE_MAX)
@@ -186,7 +188,8 @@ void TDB2::modify(Task& task) {
   }
   // We have to drop the dependency map, in case modifications were made to those.
   _dependency_graph = std::nullopt;
-  // We also have to drop _completed_tasks.
+  // We also have to drop _completed_tasks. This probably isn't strictly necessary
+  // but it seems sensible for correctness reasons.
   _completed_tasks = std::nullopt;
 }
 
@@ -258,6 +261,7 @@ int TDB2::latest_id() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Not cached: callers read this once per process, and it can be very large.
 const std::vector<Task> TDB2::all_tasks() {
   Timer timer;
   auto all_tctasks = replica()->all_task_data();
@@ -281,6 +285,8 @@ const std::vector<Task> TDB2::all_tasks() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Load and cache pending tasks. The first call will build the UUID index,
+// after which it is reused.
 const std::vector<Task>& TDB2::pending_tasks() {
   if (!_pending_tasks) {
     Timer timer;
@@ -312,6 +318,9 @@ const std::vector<Task>& TDB2::pending_tasks() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Load and cache all completed tests by scanning all tasks,
+// and excluding those in the working set. We cache it to speed up those reports
+// which involve completed tasks.
 const std::vector<Task>& TDB2::completed_tasks() {
   if (!_completed_tasks) {
     auto all_tctasks = replica()->all_task_data();
@@ -335,6 +344,7 @@ const std::vector<Task>& TDB2::completed_tasks() {
 
 /////////////////////////////////////////////////////////////////////////////////
 // Build and return the dependency map for pending tasks.
+// We invalidate it whenever pending_tasks may have changed.
 const DependencyGraph& TDB2::dependency_graph() {
   if (!_dependency_graph) {
     pending_tasks();
@@ -343,15 +353,6 @@ const DependencyGraph& TDB2::dependency_graph() {
   }
 
   return *_dependency_graph;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void TDB2::invalidate_cached_info() {
-  _pending_tasks = std::nullopt;
-  _completed_tasks = std::nullopt;
-  _working_set = std::nullopt;
-  _dependency_graph = std::nullopt;
-  _pending_index = std::nullopt;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -372,6 +373,15 @@ size_t TDB2::pending_index_of(const std::string& uuid) {
   auto& idx = pending_index();
   auto it = idx.find(uuid);
   return it != idx.end() ? it->second : SIZE_MAX;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TDB2::invalidate_cached_info() {
+  _pending_tasks = std::nullopt;
+  _completed_tasks = std::nullopt;
+  _working_set = std::nullopt;
+  _dependency_graph = std::nullopt;
+  _pending_index = std::nullopt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -448,15 +448,15 @@ bool TDB2::has(const std::string& uuid) {
 const std::vector<Task> TDB2::siblings(Task& task) {
   std::vector<Task> results;
   if (task.has("parent")) {
-    std::string parent = task.get("parent");
+    const auto& parent = task.get_ref("parent");
 
-    for (auto& i : this->pending_tasks()) {
+    for (const auto& i : pending_tasks()) {
       // Do not include self in results.
       if (i.id != task.id) {
         // Do not include completed or deleted tasks.
         if (i.getStatus() != Task::completed && i.getStatus() != Task::deleted) {
           // If task has the same parent, it is a sibling.
-          if (i.has("parent") && i.get("parent") == parent) {
+          if (i.has("parent") && i.get_ref("parent") == parent) {
             results.push_back(i);
           }
         }
@@ -468,39 +468,15 @@ const std::vector<Task> TDB2::siblings(Task& task) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Return the child tasks of a parent. Uses the _pending_tasks cache, to avoid
+// having to fetch this info from the Rust replica.
 const std::vector<Task> TDB2::children(Task& parent) {
-  // scan _pending_ tasks for those with `parent` equal to this task
   std::vector<Task> results;
-  std::string this_uuid = parent.get("uuid");
+  const auto& this_uuid = parent.get_ref("uuid");
 
-  auto& ws = working_set();
-  size_t end_idx = ws->largest_index();
-
-  for (size_t i = 0; i <= end_idx; i++) {
-    auto uuid = ws->by_index(i);
-    if (uuid.is_nil()) {
-      continue;
-    }
-
-    // skip self-references
-    if (uuid.to_string() == this_uuid) {
-      continue;
-    }
-
-    auto task_opt = replica()->get_task_data(uuid);
-    if (task_opt.is_none()) {
-      continue;
-    }
-    auto task = task_opt.take();
-
-    std::string parent_uuid;
-    if (!task->get("parent", parent_uuid)) {
-      continue;
-    }
-
-    if (parent_uuid == this_uuid) {
-      results.push_back(Task(std::move(task)));
-    }
+  for (const auto& i : pending_tasks()) {
+    if (i.get_ref("uuid") == this_uuid) continue;
+    if (i.has("parent") && i.get_ref("parent") == this_uuid) results.push_back(i);
   }
   return results;
 }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -448,9 +448,9 @@ bool TDB2::has(const std::string& uuid) {
 const std::vector<Task> TDB2::siblings(Task& task) {
   std::vector<Task> results;
   if (task.has("parent")) {
-    std::string parent = task.get("parent");
+    const auto& parent = task.get_ref("parent");
 
-    for (auto& i : this->pending_tasks()) {
+    for (const auto& i : pending_tasks()) {
       // Do not include self in results.
       if (i.id != task.id) {
         // Do not include completed or deleted tasks.
@@ -468,39 +468,15 @@ const std::vector<Task> TDB2::siblings(Task& task) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Return the child tasks of a parent. Uses the _pending_tasks cache, to avoid
+// having to fetch this info from the Rust replica.
 const std::vector<Task> TDB2::children(Task& parent) {
-  // scan _pending_ tasks for those with `parent` equal to this task
   std::vector<Task> results;
-  std::string this_uuid = parent.get("uuid");
+  const auto& this_uuid = parent.get_ref("uuid");
 
-  auto& ws = working_set();
-  size_t end_idx = ws->largest_index();
-
-  for (size_t i = 0; i <= end_idx; i++) {
-    auto uuid = ws->by_index(i);
-    if (uuid.is_nil()) {
-      continue;
-    }
-
-    // skip self-references
-    if (uuid.to_string() == this_uuid) {
-      continue;
-    }
-
-    auto task_opt = replica()->get_task_data(uuid);
-    if (task_opt.is_none()) {
-      continue;
-    }
-    auto task = task_opt.take();
-
-    std::string parent_uuid;
-    if (!task->get("parent", parent_uuid)) {
-      continue;
-    }
-
-    if (parent_uuid == this_uuid) {
-      results.push_back(Task(std::move(task)));
-    }
+  for (const auto& i : pending_tasks()) {
+    if (i.get_ref("uuid") == this_uuid) continue;
+    if (i.has("parent") && i.get("parent") == this_uuid) results.push_back(i);
   }
   return results;
 }

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -43,7 +43,10 @@
 #include <vector>
 
 bool TDB2::debug_mode = false;
-static void dependency_scan(std::vector<Task>&);
+static void dependency_scan(std::vector<Task>&, const std::unordered_map<std::string, size_t>&);
+
+// Build maps for dependency queries.
+static DependencyGraph build_dependency_graph(const std::vector<Task>&, const std::unordered_map<std::string, size_t>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::open_replica(const std::string& location, bool create_if_missing, bool read_write) {
@@ -247,7 +250,14 @@ const std::vector<Task> TDB2::all_tasks() {
     all.push_back(Task(std::move(tctask)));
   }
 
-  dependency_scan(all);
+  // Build a temporary map so that dependency_scan can resolve references
+  // inside all_tasks.
+  std::unordered_map<std::string, size_t> all_index;
+  all_index.reserve(all.size());
+  for (size_t i = 0; i < all.size(); ++i)
+    all_index[all[i].get_ref("uuid")] = i;
+
+  dependency_scan(all, all_index);
 
   Context::getContext().time_load_us += timer.total_us();
   return all;
@@ -275,7 +285,7 @@ const std::vector<Task>& TDB2::pending_tasks() {
     for (size_t i = 0, n = result.size(); i < n; ++i)
       _pending_index->emplace(result[i].get_ref("uuid"), i);
 
-    dependency_scan(result);
+    dependency_scan(result, *_pending_index);
 
     Context::getContext().time_load_us += timer.total_us();
     _pending_tasks = std::move(result);
@@ -306,11 +316,24 @@ const std::vector<Task>& TDB2::completed_tasks() {
   return *_completed_tasks;
 }
 
+/////////////////////////////////////////////////////////////////////////////////
+// Build and return the dependency map for pending tasks.
+const DependencyGraph& TDB2::dependency_graph() {
+  if (!_dependency_graph) {
+    pending_tasks();
+    // reuse the UUID index
+    _dependency_graph = build_dependency_graph(*_pending_tasks, pending_index());
+  }
+
+  return *_dependency_graph;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 void TDB2::invalidate_cached_info() {
   _pending_tasks = std::nullopt;
   _completed_tasks = std::nullopt;
   _working_set = std::nullopt;
+  _dependency_graph = std::nullopt;
   _pending_index = std::nullopt;
 }
 
@@ -479,29 +502,50 @@ int TDB2::num_local_changes() { return (int)replica()->num_local_operations(); }
 int TDB2::num_reverts_possible() { return (int)replica()->num_undo_points(); }
 
 ////////////////////////////////////////////////////////////////////////////////
-// For any task that has depenencies, follow the chain of dependencies until the
-// end.  Along the way, update the Task::is_blocked and Task::is_blocking data
-// cache.
-static void dependency_scan(std::vector<Task>& tasks) {
-  for (auto& left : tasks) {
-    for (auto& dep : left.getDependencyUUIDs()) {
-      for (auto& right : tasks) {
-        if (right.get("uuid") == dep) {
-          // GC hasn't run yet, check both tasks for their current status
-          Task::status lstatus = left.getStatus();
-          Task::status rstatus = right.getStatus();
-          if (lstatus != Task::completed && lstatus != Task::deleted &&
-              rstatus != Task::completed && rstatus != Task::deleted) {
-            left.is_blocked = true;
-            right.is_blocking = true;
-          }
+// Set Task::is_blocked / Task::is_blocking flags using the pre-built UUID map
+static void dependency_scan(std::vector<Task>& tasks, const std::unordered_map<std::string, size_t>& uuid_index) {
+  for (size_t i = 0; i< tasks.size(); ++i) {
+    auto lstatus = tasks[i].getStatus();
+    for (const auto& dep : tasks[i].getDependencyUUIDs()) {
+      auto it = uuid_index.find(dep);
+      if (it == uuid_index.end())
+        continue;
 
-          // Only want to break out of the "right" loop.
-          break;
-        }
+      size_t j = it->second;
+      auto rstatus = tasks[j].getStatus();
+      if (lstatus != Task::completed && lstatus != Task::deleted &&
+          rstatus != Task::completed && rstatus != Task::deleted) {
+        tasks[i].is_blocked = true;
+        tasks[j].is_blocking = true;
       }
     }
   }
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+// Build the full dependency map from the task vector.
+static DependencyGraph build_dependency_graph(const std::vector<Task>& tasks,
+                                              const std::unordered_map<std::string, size_t>& uuid_index) {
+  DependencyGraph graph;
+
+  for (size_t i = 0; i < tasks.size(); ++i) {
+    const auto& deps = tasks[i].getDependencyUUIDs();
+    if (deps.empty())
+      continue;
+
+    const auto& uuid = tasks[i].get_ref("uuid");
+
+    for (const auto& dep : deps) {
+      auto it = uuid_index.find(dep);
+      if (it == uuid_index.end())
+        continue;
+
+      graph.dependencies[uuid].push_back(it->second);
+      graph.dependents[dep].push_back(i);
+    }
+  }
+
+  return graph;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -182,13 +182,22 @@ void TDB2::modify(Task& task) {
 
   // If the task stayed in the set, we can edit the vector in-place.
   // This speeds up modifications a lot relative to reloading and parsing from rust.
+  bool deps_changed = false;
   if (_pending_tasks) {
     auto* pt = find_pending(uuid);
-    if (pt)
+    if (pt) {
+      auto old_deps = pt->getDependencyUUIDs();
       *pt = task;
+      auto new_deps = task.getDependencyUUIDs();
+      if (old_deps != new_deps) {
+        deps_changed = true;
+        dependency_scan(*_pending_tasks, pending_index());
+      }
+    }
   }
   // We have to drop the dependency map, in case modifications were made to those.
-  _dependency_graph = std::nullopt;
+  // We only drop it if they actually changed.
+  if (deps_changed) _dependency_graph = std::nullopt;
   // We also have to drop _completed_tasks. This probably isn't strictly necessary
   // but it seems sensible for correctness reasons.
   _completed_tasks = std::nullopt;
@@ -479,7 +488,7 @@ const std::vector<Task> TDB2::children(Task& parent) {
 
   for (const auto& i : pending_tasks()) {
     if (i.get_ref("uuid") == this_uuid) continue;
-    if (i.has("parent") && i.get("parent") == this_uuid) results.push_back(i);
+    if (i.has("parent") && i.get_ref("parent") == this_uuid) results.push_back(i);
   }
   return results;
 }
@@ -510,6 +519,16 @@ int TDB2::num_reverts_possible() { return (int)replica()->num_undo_points(); }
 // Set Task::is_blocked / Task::is_blocking flags using the pre-built UUID map
 static void dependency_scan(std::vector<Task>& tasks,
                             const std::unordered_map<std::string, size_t>& uuid_index) {
+  // Reset all flags first. This is for safety reasons - if we don't do this
+  // dependency_scan() only sets them to true, so it can stay true (within the cache)
+  // even after we have changed a task's dependencies after a modify when
+  // dependency_scan() runs the second time - the flag will still be set to true!
+  // In many cases, this isn't user-visible - it's only visible in reports
+  // or filters that explicitly filter for +BLOCKING.
+  for (auto& task : tasks) {
+    task.is_blocking = false;
+    task.is_blocked = false;
+  }
   for (size_t i = 0; i < tasks.size(); ++i) {
     auto lstatus = tasks[i].getStatus();
     for (const auto& dep : tasks[i].getDependencyUUIDs()) {

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -54,9 +54,11 @@ class TDB2 {
   int latest_id();
 
   // Generalized task accessors.
+  // We don't cache the all_tasks vector because no command accesses it more than once.
+  // Caching it would cause higher memory use and would require additional rewrites to make tests pass.
   const std::vector<Task> all_tasks();
-  const std::vector<Task> pending_tasks();
-  const std::vector<Task> completed_tasks();
+  const std::vector<Task>& pending_tasks();
+  const std::vector<Task>& completed_tasks();
   bool get(int, Task&);
   bool get(const std::string&, Task&);
   bool has(const std::string&);

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -40,14 +40,13 @@
 // Adjacency maps for the dependency graph.
 // Index refers to the pending_tasks() vector.
 struct DependencyGraph {
- std::unordered_map<std::string, std::vector<size_t>> dependents;
- std::unordered_map<std::string, std::vector<size_t>> dependencies;
+  std::unordered_map<std::string, std::vector<size_t>> dependents;
+  std::unordered_map<std::string, std::vector<size_t>> dependencies;
 };
 // We adopt a caching strategy which lazily builds _pending_tasks,
 // _completed_tasks, _working_set, _dependency_graph from the Rust
 // replica whwnever its state may have changed. Callers receive const
 // refs to avoid silent copies of the whole vectors.
-
 
 // TDB2 Class represents all the files in the task database.
 class TDB2 {
@@ -67,7 +66,8 @@ class TDB2 {
 
   // Generalized task accessors.
   // We don't cache the all_tasks vector because no command accesses it more than once.
-  // Caching it would cause higher memory use and would require additional rewrites to make tests pass.
+  // Caching it would cause higher memory use and would require additional rewrites to make tests
+  // pass.
   const std::vector<Task> all_tasks();
   // pending and completed tasks are cached after first use.
   const std::vector<Task>& pending_tasks();

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -59,6 +59,8 @@ class TDB2 {
   const std::vector<Task> all_tasks();
   const std::vector<Task>& pending_tasks();
   const std::vector<Task>& completed_tasks();
+  // Index of pending tasks by UUID.
+  size_t pending_index_of(const std::string& uuid);
   bool get(int, Task&);
   bool get(const std::string&, Task&);
   bool has(const std::string&);
@@ -81,7 +83,12 @@ class TDB2 {
   std::optional<rust::Box<tc::WorkingSet>> _working_set;
   std::optional<std::vector<Task>> _pending_tasks;
   std::optional<std::vector<Task>> _completed_tasks;
+  // Lazily cache UUIDs within the pending set.
+  std::optional<std::unordered_map<std::string, size_t>> _pending_index;
   void invalidate_cached_info();
+
+  // Return the full pending UUID map.
+  const std::unordered_map<std::string, size_t>& pending_index();
 
   // UUID -> Task containing all tasks modified in this invocation.
   std::map<std::string, Task> changes;

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -43,6 +43,11 @@ struct DependencyGraph {
  std::unordered_map<std::string, std::vector<size_t>> dependents;
  std::unordered_map<std::string, std::vector<size_t>> dependencies;
 };
+// We adopt a caching strategy which lazily builds _pending_tasks,
+// _completed_tasks, _working_set, _dependency_graph from the Rust
+// replica whwnever its state may have changed. Callers receive const
+// refs to avoid silent copies of the whole vectors.
+
 
 // TDB2 Class represents all the files in the task database.
 class TDB2 {
@@ -64,12 +69,14 @@ class TDB2 {
   // We don't cache the all_tasks vector because no command accesses it more than once.
   // Caching it would cause higher memory use and would require additional rewrites to make tests pass.
   const std::vector<Task> all_tasks();
+  // pending and completed tasks are cached after first use.
   const std::vector<Task>& pending_tasks();
   const std::vector<Task>& completed_tasks();
   // dependency_graph is built on first use from pending_tasks() and reused.
+  // functions that use it are Task::getDependencyTasks(), getBlockedTasks()
+  // and urgency_inherit().
   const DependencyGraph& dependency_graph();
-  // Index of pending tasks by UUID.
-  size_t pending_index_of(const std::string& uuid);
+
   bool get(int, Task&);
   bool get(const std::string&, Task&);
   bool has(const std::string&);
@@ -80,6 +87,10 @@ class TDB2 {
   std::string uuid(int);
   int id(const std::string&);
 
+  // Index of pending tasks by UUID.
+  // Used by get() and modify().
+  size_t pending_index_of(const std::string& uuid);
+
   int num_local_changes();
   int num_reverts_possible();
 
@@ -89,12 +100,15 @@ class TDB2 {
   std::optional<rust::Box<tc::Replica>> _replica;
 
   // Cached information from the replica
+  // All caches are invalidated when state may have changed
+  // in the replica.
   std::optional<rust::Box<tc::WorkingSet>> _working_set;
   std::optional<std::vector<Task>> _pending_tasks;
   std::optional<std::vector<Task>> _completed_tasks;
   // Dependency cache.
   std::optional<DependencyGraph> _dependency_graph;
   // Lazily cache UUIDs within the pending set.
+  // Avoids scans of the vectors with get/modify..
   std::optional<std::unordered_map<std::string, size_t>> _pending_index;
   void invalidate_cached_info();
 

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -37,6 +37,13 @@
 #include <unordered_set>
 #include <vector>
 
+// Adjacency maps for the dependency graph.
+// Index refers to the pending_tasks() vector.
+struct DependencyGraph {
+ std::unordered_map<std::string, std::vector<size_t>> dependents;
+ std::unordered_map<std::string, std::vector<size_t>> dependencies;
+};
+
 // TDB2 Class represents all the files in the task database.
 class TDB2 {
  public:
@@ -59,6 +66,8 @@ class TDB2 {
   const std::vector<Task> all_tasks();
   const std::vector<Task>& pending_tasks();
   const std::vector<Task>& completed_tasks();
+  // dependency_graph is built on first use from pending_tasks() and reused.
+  const DependencyGraph& dependency_graph();
   // Index of pending tasks by UUID.
   size_t pending_index_of(const std::string& uuid);
   bool get(int, Task&);
@@ -83,6 +92,8 @@ class TDB2 {
   std::optional<rust::Box<tc::WorkingSet>> _working_set;
   std::optional<std::vector<Task>> _pending_tasks;
   std::optional<std::vector<Task>> _completed_tasks;
+  // Dependency cache.
+  std::optional<DependencyGraph> _dependency_graph;
   // Lazily cache UUIDs within the pending set.
   std::optional<std::unordered_map<std::string, size_t>> _pending_index;
   void invalidate_cached_info();

--- a/src/TDB2.h
+++ b/src/TDB2.h
@@ -87,9 +87,10 @@ class TDB2 {
   std::string uuid(int);
   int id(const std::string&);
 
-  // Index of pending tasks by UUID.
+  // Index of pending tasks by UUID. The ptr is stable until the
+  // cache is invalidated.
   // Used by get() and modify().
-  size_t pending_index_of(const std::string& uuid);
+  Task* find_pending(const std::string& uuid);
 
   int num_local_changes();
   int num_reverts_possible();


### PR DESCRIPTION
This is an initial PR which lays the groundwork for one that will shortly follow. It introduces lazy caching of pending/completed tasks, a UUID index for pending tasks, the construction of a dependency map, and adds in-place mutation of pending tasks. This roughly halves the instruction count for many reports (though the speed gain from this PR is minor to the one that I will make if it is accepted, about 1.3x for many reports. I gave up waiting for the performance tests in ./performance/ to complete, and instead constructed a smaller, 300 task test database.)

## Changes

- `pending_tasks()` and `completed_tasks()` return `const std::vector<Task>&` instead of copying. `all_tasks()` is deliberately not cached, as it can be very large and is only read once per invocation.
- an index of pending task UUIDs, `_pending_index` is lazily built with `pending_tasks()`. `get()` and `modify()` use this instead of scanning the vectors.
- A `DependencyGraph` hashmap is introduced and built from the pending cache. (A temporary map is created for `all_tasks()`, in the event that `dependency_scan()` must refer to things in all_tasks.) This is not yet consumed by `Task` in this PR - that will be the PR to follow.
- `modify()` makes updates in-place within the vector by leveraging the `_pending_tasks` index. This cache is invalidated in any case where there may be a change of state between the Rust replica and the cached index.
- some minor changes relating to memory management for `pending_tasks` and `completed_tasks`.
- use the new cache in `siblings()`/`children()`, as well as `get_ref()` to avoid copying. This also fixes a non-user-visible bug where `children()` would return different `is_blocked()`/`is_blocking()` flags to what you would expect. 

## Endnotes

This PR doesn't necessarily bring much by itself, but it's needed to lay the groundwork for DependencyGraph to be used by `getDependencyTasks()` and `getBlockedTasks()`. Adding in in-place modifications is a somewhat opportunistic addition for the PR, as it's not strictly necessary for core functionality, but it _does_ improve modification performance when running big batch modifications. 

All tests pass and I am _pretty sure_ this doesn't break anything, but there's a _small chance_ bugs have slipped by me. 

This would be my first major contribution to a C++ codebase, and I am not a professional software engineer, so feedback on pretty much everything here is accepted gratefully. 