### PR TITLE
Fix scheduled date handling in recurring tasks

### DIFF
--- a/src/recur.cpp
+++ b/src/recur.cpp
@@ -122,7 +122,11 @@ void handleRecurrence() {
             Datetime old_scheduled(t.get_date("scheduled"));
             Datetime old_due(t.get_date("due"));
             Datetime due(d);
-            rec.set("scheduled", format((due + (old_scheduled - old_due)).toEpoch()));
+            auto scheduled = checked_add_datetime(due, old_scheduled - old_due);
+            if (scheduled)
+              rec.set("scheduled", format(scheduled->toEpoch()));
+            else
+              rec.remove("scheduled");
           }
 
           rec.set("imask", i);

--- a/src/recur.cpp
+++ b/src/recur.cpp
@@ -118,6 +118,13 @@ void handleRecurrence() {
             rec.setStatus(Task::pending);
           }
 
+          if (t.has("scheduled")) {
+            Datetime old_scheduled(t.get_date("scheduled"));
+            Datetime old_due(t.get_date("due"));
+            Datetime due(d);
+            rec.set("scheduled", format((due + (old_scheduled - old_due)).toEpoch()));
+          }
+
           rec.set("imask", i);
           rec.remove("mask");  // Remove the mask of the parent.
 


### PR DESCRIPTION
Subset from PR #3006 without the changes to `until`. 

Closes #2414, #97, #3823, part of #1534. 

#1983 is mostly covered by `until` by using `until:now+someperiod` or `until:date`, the main thing missing there would be `until:some-task-count`. I could probably implement that behaviour, but I think it might be better to wait for iterative tasks to land?