### PR TITLE
Add support for --help

### DIFF
--- a/doc/man/task.1.in
+++ b/doc/man/task.1.in
@@ -6,6 +6,8 @@ task \- A command line todo manager.
 .SH SYNOPSIS
 .B task <filter> <command> [ <mods> | <args> ]
 .br
+.B task --help
+.br
 .B task --version
 
 .SH DESCRIPTION
@@ -127,10 +129,14 @@ the configuration file. See also the man page taskrc(5).  There are also other
 read subcommands that are not reports.
 
 .TP
+.B task --help
+Displays the same usage and command documentation as the 'task help' command.
+
+.TP
 .B task --version
-This is the only conventional command line argument that Taskwarrior supports,
-and is intended for add-on scripts to verify the version number of an installed
-Taskwarrior without invoking the mechanisms that create default files.
+This command line argument is intended for add-on scripts to verify the version
+number of an installed Taskwarrior without invoking the mechanisms that create
+default files.
 
 .TP
 .B task <filter>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,8 +47,10 @@ int main(int argc, const char** argv) {
   Context globalContext;
   Context::setContext(&globalContext);
 
-  // Support the conventional help option through the existing help command.
-  if (argc == 2 && !strcmp(argv[1], "--help")) argv[1] = "help";
+  // Reuse the existing help command instead of maintaining separate output.
+  if (argc == 2 && !strcmp(argv[1], "--help")) {
+    argv[1] = "help";
+  }
 
   // Lightweight version checking that doesn't require initialization or any I/O.
   if (argc == 2 && !strcmp(argv[1], "--version")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,9 @@ int main(int argc, const char** argv) {
   Context globalContext;
   Context::setContext(&globalContext);
 
+  // Support the conventional help option through the existing help command.
+  if (argc == 2 && !strcmp(argv[1], "--help")) argv[1] = "help";
+
   // Lightweight version checking that doesn't require initialization or any I/O.
   if (argc == 2 && !strcmp(argv[1], "--version")) {
     std::cout << VERSION << "\n";

--- a/test/commands.test.py
+++ b/test/commands.test.py
@@ -39,6 +39,14 @@ class TestCommands(TestCase):
     def setUp(self):
         self.t = Task()
 
+    def test_help_option(self):
+        """Verify '--help' is equivalent to the help command"""
+        code, help_out, help_err = self.t("help")
+        code, option_out, option_err = self.t("--help")
+
+        self.assertEqual(option_out, help_out)
+        self.assertEqual(option_err, help_err)
+
     def test_command_dna(self):
         """Verify 'add', 'modify', 'list' dna"""
         code, out, err = self.t("commands")

--- a/test/commands.test.py
+++ b/test/commands.test.py
@@ -41,9 +41,10 @@ class TestCommands(TestCase):
 
     def test_help_option(self):
         """Verify '--help' is equivalent to the help command"""
-        code, help_out, help_err = self.t("help")
-        code, option_out, option_err = self.t("--help")
+        _, help_out, help_err = self.t("help")
+        _, option_out, option_err = self.t("--help")
 
+        self.assertIn("Usage:", option_out)
         self.assertEqual(option_out, help_out)
         self.assertEqual(option_err, help_err)
 


### PR DESCRIPTION
Closes #4119.

## Summary
- route the exact `task --help` form through the existing help command
- verify that `--help` and `help` produce the same stdout and stderr
- assert that the help output contains the expected usage text
- document `--help` in the task man page

## Verification
- `uvx pre-commit run --all-files`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target test_runner task_executable --parallel 8`
- `ctest --test-dir build -R '^commands\\.test\\.py$' --output-on-failure` (1/1 passed)
- `ctest --test-dir build --parallel 8 --output-on-failure` (178/178 passed)
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --all-features --locked -- -D warnings`
- `cargo test --locked` (10/10 passed)
- `.github/workflows/metadata-check.sh`
- source package generated, extracted into a clean temporary directory, configured, and rebuilt through `task_executable`
- `git diff --check origin/develop`
