### PR TITLE
Increase timeout in delete test

### DIFF
--- a/test/delete.test.py
+++ b/test/delete.test.py
@@ -126,7 +126,7 @@ class TestDelete(TestCase):
     def _validate_prompt_loop(self, input=""):
         """Helper method to check if task flooded stream on closed STDIN"""
         try:
-            code, out, err = self.t("/foo[1-3]/ delete", input=input, timeout=0.3)
+            code, out, err = self.t("/foo[1-3]/ delete", input=input, timeout=3)
         except CommandError as e:
             # If delete fails with a timeout, don't fail the test immediately
             code, out, err = e.code, e.out, e.err


### PR DESCRIPTION
On a busy CI worker, 300ms is barely time to execute an instruction, so this test often fails with SIGABRT (`-6 != 1`). A longer timeout should make this far less likely.