### PR TITLE
Fix initialization of Taskwarrior on Dockerfile

### DIFF
--- a/docker/task.dockerfile
+++ b/docker/task.dockerfile
@@ -36,7 +36,8 @@ RUN git clean -dfx && \
 FROM base AS runner
 
 # Install Taskwarrior
-COPY --from=builder /root/code/build/src/task /usr/local/bin
+COPY --from=builder /root/code/build/src/task        /usr/local/bin
+COPY --from=builder /root/code/doc/rc/default.theme  /usr/local/share/doc/task/rc/
 
 # Initialize Taskwarrior
-RUN ( echo "yes" | task ) || true
+RUN :> /root/.taskrc


### PR DESCRIPTION
Add the 'default.theme' to the test Docker file and create empty '.taskrc'.
Those two files are the minimum requirements for Taskwarrior to run.

This fixes the e2e tests for the [task-timewarrior-hook] which require an image with running Taskwarrior and Timewarrior.
Without the two files, Taskwarrior [exits with error message](https://github.com/GothenburgBitFactory/task-timewarrior-hook/actions/runs/28827309966/job/85493301382#step:6:803),

```
Could not find file in CWD, directory of config file or search paths 'default.theme'.
```

causing the e2e tests to fail.