### PR TITLE
feat: add annotation.info setting

### DIFF
--- a/doc/man/taskrc.5.in
+++ b/doc/man/taskrc.5.in
@@ -362,6 +362,11 @@ Setting this to '0' means that it is an error to use a write command with no
 filter.
 
 .TP
+.B annotation.info=1
+Determines whether annotations are displayed below the description field by the
+'info' command. The default value is "1".
+
+.TP
 .B indent.annotation=2
 Controls the number of spaces to indent annotations when shown beneath the
 description field. The default value is "2".

--- a/scripts/vim/syntax/taskrc.vim
+++ b/scripts/vim/syntax/taskrc.vim
@@ -39,6 +39,7 @@ syn match taskrcGoodKey '^\s*\Vabbreviation.minimum='he=e-1
 syn match taskrcGoodKey '^\s*\Vactive.indicator='he=e-1
 syn match taskrcGoodKey '^\s*\Valias.\S\{-}='he=e-1
 syn match taskrcGoodKey '^\s*\Vallow.empty.filter='he=e-1
+syn match taskrcGoodKey '^\s*\Vannotation.info='he=e-1
 syn match taskrcGoodKey '^\s*\Vavoidlastcolumn='he=e-1
 syn match taskrcGoodKey '^\s*\Vbulk='he=e-1
 syn match taskrcGoodKey '^\s*\Vburndown.cumulative='he=e-1

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -115,6 +115,8 @@ std::string configurationDefaults =
     "recurring tasks (yes/no/prompt)\n"
     "allow.empty.filter=1                           # An empty filter gets a warning and requires "
     "confirmation\n"
+    "annotation.info=1                              # Display annotations below the description "
+    "with info\n"
     "indent.annotation=2                            # Indent spaces for annotations\n"
     "indent.report=0                                # Indent spaces for whole report\n"
     "row.padding=0                                  # Left and right padding for each row of "

--- a/src/commands/CmdInfo.cpp
+++ b/src/commands/CmdInfo.cpp
@@ -114,11 +114,13 @@ int CmdInfo::execute(std::string& output) {
     Color c;
     autoColorize(task, c);
     auto description = task.get("description");
-    auto indent = Context::getContext().config.getInteger("indent.annotation");
+    if (Context::getContext().config.getBoolean("annotation.info")) {
+      auto indent = Context::getContext().config.getInteger("indent.annotation");
 
-    for (auto& anno : task.getAnnotations())
-      description += '\n' + std::string(indent, ' ') +
-                     Datetime(anno.first.substr(11)).toString(dateformatanno) + ' ' + anno.second;
+      for (auto& anno : task.getAnnotations())
+        description += '\n' + std::string(indent, ' ') +
+                       Datetime(anno.first.substr(11)).toString(dateformatanno) + ' ' + anno.second;
+    }
 
     if (task.has("description")) {
       row = view.addRow();

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -81,6 +81,7 @@ int CmdShow::execute(std::string& output) {
       " abbreviation.minimum"
       " active.indicator"
       " allow.empty.filter"
+      " annotation.info"
       " avoidlastcolumn"
       " bulk"
       " calendar.details"

--- a/test/info.test.py
+++ b/test/info.test.py
@@ -115,6 +115,16 @@ class TestInfoCommand(TestCase):
         self.assertRegex(out, r"U_ONE\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
         self.assertRegex(out, r"U_TWO\s+P1D")
 
+    def test_info_without_annotations(self):
+        """Verify annotation.info hides annotations below the description"""
+        self.t("add foo")
+        self.t("1 annotate bar")
+
+        code, out, err = self.t("rc.annotation.info:off 1 info")
+
+        self.assertEqual(1, out.count("bar"))
+        self.assertIn("Annotation of 'bar' added.", out)
+
     def test_tags_without_tags_attribute(self):
         """Verify info command shows tags, even if the `tags` property is not present"""
         # Create a task directly with TC, avoiding TaskWarrior's creation of the deprecated


### PR DESCRIPTION
## Summary

- add an `annotation.info` setting that controls whether annotations appear below the Description field in `task info`
- keep the existing output by default and leave the journal table independently controlled by `journal.info`
- document the setting and recognize it in `task show` and the Vim taskrc syntax

## Tests

- `cmake --build build-4158 --target task_executable test_runner -j 6`
- `ctest --test-dir build-4158 -R '^(info|annotate|show)\.test\.py$' --output-on-failure` (3/3 passed)
- `ctest --test-dir build-4158 -j 6 --output-on-failure` (178/178 passed)

Closes #4158

## AI assistance

Developed with assistance from OpenAI Codex. I reviewed and tested the resulting changes.
