### PR TITLE
scripts: install bash completion just like fish

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -3,16 +3,24 @@ cmake_minimum_required (VERSION 3.22...4.0)
 find_package(PkgConfig)
 if(PkgConfig_FOUND)
 	pkg_get_variable(FISH_COMPLETIONSDIR fish completionsdir)
+	pkg_get_variable(BASH_COMPLETIONSDIR bash-completion completionsdir)
 endif()
 if(NOT FISH_COMPLETIONSDIR)
 	set(FISH_COMPLETIONSDIR share/fish/vendor_completions.d)
 	message(STATUS "fish pkgconfig module missing, assumed completions in ${FISH_COMPLETIONSDIR}")
 endif()
+if(NOT BASH_COMPLETIONSDIR)
+	set(BASH_COMPLETIONSDIR share/bash-completion/completions)
+	message(STATUS "bash-completion pkgconfig module missing, assumed completions in ${BASH_COMPLETIONSDIR}")
+endif()
 
-install (DIRECTORY bash vim hooks
+install (DIRECTORY vim hooks
          DESTINATION ${TASK_DOCDIR}/scripts)
 install (FILES fish/task.fish
          DESTINATION ${FISH_COMPLETIONSDIR})
+install (FILES bash/task.sh
+         DESTINATION ${BASH_COMPLETIONSDIR}
+         RENAME task)
 install (FILES zsh/_task
          DESTINATION share/zsh/site-functions)
 install (DIRECTORY add-ons


### PR DESCRIPTION
Noticed you finally started installing fish completion properly, so I thought it would make sense to install the Bash completion properly too.
