### PR TITLE
Use the pending tasks cache in the circular dependency check.

### DIFF
--- a/src/TDB2.cpp
+++ b/src/TDB2.cpp
@@ -400,6 +400,7 @@ const std::unordered_map<std::string, size_t>& TDB2::pending_index() {
 // Finds the UUID in the index. Returns nullptr if the task is not in the pending
 // set.
 Task* TDB2::find_pending(const std::string& uuid) {
+  pending_tasks();
   auto& idx = pending_index();
   auto it = idx.find(uuid);
   if (it != idx.end()) return &(*_pending_tasks)[it->second];

--- a/src/dependency.cpp
+++ b/src/dependency.cpp
@@ -33,48 +33,44 @@
 #include <shared.h>
 
 #include <iostream>
-#include <stack>
+#include <vector>
 
 #define STRING_DEPEND_BLOCKED "Task {1} is blocked by:"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Returns true if the supplied task adds a cycle to the dependency chain.
+// Only dependencies within the pending task cache are traversed.
 bool dependencyIsCircular(const Task& task) {
   // A new task has no UUID assigned yet, and therefore cannot be part of any
   // dependency chain.
-  if (task.has("uuid")) {
-    auto task_uuid = task.get("uuid");
+  if (!task.has("uuid")) return false;
 
-    std::stack<Task> s;
-    s.push(task);
+  const auto& task_uuid = task.get_ref("uuid");
+  auto& tdb2 = Context::getContext().tdb2;
 
-    std::unordered_set<std::string> visited;
-    visited.insert(task_uuid);
+  std::unordered_set<std::string> visited{task_uuid};
+  std::vector<std::string> stack;
 
-    while (!s.empty()) {
-      Task& current = s.top();
-      auto deps_current = current.getDependencyUUIDs();
+  // We start with the current task, as it may contain changes which are not
+  // cached.
+  for (const auto& dep : task.getDependencyUUIDs()) {
+    if (dep == task_uuid) return true;
+    if (visited.insert(dep).second) stack.push_back(dep);
+  }
 
-      // This is a basic depth first search that always terminates given the
-      // fact that we do not visit any task twice
-      for (const auto& dep : deps_current) {
-        if (Context::getContext().tdb2.get(dep, current)) {
-          auto current_uuid = current.get("uuid");
+  while (!stack.empty()) {
+    std::string dep_uuid = std::move(stack.back());
+    stack.pop_back();
 
-          if (task_uuid == current_uuid) {
-            // Cycle found, initial task reached for the second time!
-            return true;
-          }
+    // Dependencies outside the pending task cache terminate the traversal.
+    // We do not load the full database.
+    auto* dep_task = tdb2.find_pending(dep_uuid);
+    if (!dep_task) continue;
 
-          if (visited.find(current_uuid) == visited.end()) {
-            // Push the task to the stack, if it has not been processed yet
-            s.push(current);
-            visited.insert(current_uuid);
-          }
-        }
-      }
-
-      s.pop();
+    // Marks UUIDs so each dependency is only checked once.
+    for (const auto& dep : dep_task->getDependencyUUIDs()) {
+      if (dep == task_uuid) return true;
+      if (visited.insert(dep).second) stack.push_back(dep);
     }
   }
 

--- a/test/dependencies.test.py
+++ b/test/dependencies.test.py
@@ -96,6 +96,38 @@ class TestDependencies(TestCase):
         code, out, err = self.t("1 modify dep:2")
         self.assertNotIn("Circular dependency detected and disallowed.", err)
 
+    def test_completed_not_circular(self):
+        """Checks that completed tasks do not contribute to circularity check"""
+        self.t("2 modify dep:1")
+        completed_uuid = self.t.export_one(2)["uuid"]
+        self.t("2 done")
+        self.t("next")
+
+        self.t("1 modify dep:%s" % completed_uuid)
+        self.assertEqual([completed_uuid], self.t.export_one(1)["depends"])
+
+    def test_circular_with_visited_sibling(self):
+        """Checks that the branching logic in the check still catches after
+        visited siblings"""
+        self.t("add three")
+        self.t("add four")
+        a, b, x, root = sorted(task["uuid"] for task in self.t.export())
+        self.t("%s modify dep:%s" % (a, root))
+        self.t("%s modify dep:%s,%s" % (x, a, b))
+
+        code, out, err = self.t.runError("%s modify dep:%s,%s" % (root, b, x))
+        self.assertIn("Circular dependency detected and disallowed.", err)
+
+    def test_dependency_modify_with_cold_pending_cache(self):
+        """Checks the pending cache is initialized on dependency modifications"""
+        missing_uuid = "90000000-0000-0000-0000-000000000000"
+        self.t(
+            "rc.allow.empty.filter=1 rc.bulk=0 modify depends:%s" % missing_uuid,
+            input="yes\n",
+        )
+        for task in self.t.export():
+            self.assertEqual([missing_uuid], task["depends"])
+
     def test_blocked_blocking(self):
         """Check blocked/blocking status of two tasks"""
         self.t("2 modify dep:1")


### PR DESCRIPTION
Introduced ahead of the other work to address #4178 . 

Main changes:
1. the dependency graph is traversed using a stack of UUIDs.
2. The traversal first looks to the modified task, so that modified dependencies are included. 
3. Other dependencies are all checked against the cache with `find_pending()`.
4. Traversal stops at completed, deleted, or missing dependencies.
5. Visited UUIDs are marked, so each dependency is only visited once.
6. The cache is initialized where necessary.

Three tests are introduced:
- `test_completed_not_circular()` checks that completed tasks do not cause a positive circularity check.
- `test_circular_with_visited_sibling()` makes sure that visited siblings do not get overwritten when the unvisited sibling is popped. 
- `test_dependency_modify_with_cold_pending_cache()` checks that the pending cache is initialized during modifications. It uses an empty filter because most modify commands warm the cache, but this one doesn't. 

There are still remaining issues with empty filters, bulk modifications of completed tasks, and bulk modifications of dependencies in other regards, I plan to address these in a future PR.  

Also, this won't bring broader performance improvement on its own, because it doesn't touch the stuff relevant for eg. `task ready`. 